### PR TITLE
chore: add Cursor marketplace support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "source": "./plugins/amplitude",
       "strict": false,
       "description": "Use Amplitude as an expert analyst - instrument Amplitude, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Amplitude"
       },

--- a/plugins/amplitude-experimental/.cursor-plugin
+++ b/plugins/amplitude-experimental/.cursor-plugin
@@ -1,0 +1,1 @@
+.claude-plugin

--- a/plugins/amplitude/.cursor-plugin
+++ b/plugins/amplitude/.cursor-plugin
@@ -1,0 +1,1 @@
+.claude-plugin


### PR DESCRIPTION
## Summary

- Adds `.cursor-plugin -> .claude-plugin` symlinks to both plugin directories (`amplitude`, `amplitude-experimental`)
- Cursor reads `.cursor-plugin/plugin.json` the same way Claude Code reads `.claude-plugin/plugin.json`, so the symlink keeps a single source of truth
- Bumps `amplitude` to `1.1.0` (minor bump for newly added files)

## Test plan
- [ ] Verify Cursor picks up the plugins from the marketplace after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)