### PR TITLE
Update installation instructions for official Claude marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,23 @@ Works with **Claude Code**, **Cursor**, and **Claude**.
 
 ### Claude Code
 
-From the terminal:
+Amplitude is listed in the [official Claude plugin marketplace](https://claude.com/plugins). Install directly from inside Claude Code:
 
-```bash
-claude plugin marketplace add amplitude/mcp-marketplace
-claude plugin install amplitude@amplitude
+```
+/plugin install amplitude@claude-plugins-official
+/reload-plugins
 ```
 
-Or from inside Claude Code:
+Or from the terminal:
+
+```bash
+claude plugin install amplitude@claude-plugins-official
+```
+
+Then authenticate when prompted.
+
+<details>
+<summary>Install from the GitHub marketplace instead</summary>
 
 ```
 /plugin marketplace add amplitude/mcp-marketplace
@@ -25,7 +34,7 @@ Or from inside Claude Code:
 /reload-plugins
 ```
 
-Then authenticate when prompted.
+</details>
 
 ### Cursor
 

--- a/README.md
+++ b/README.md
@@ -10,31 +10,18 @@ Works with **Claude Code**, **Cursor**, and **Claude**.
 
 ### Claude Code
 
-Amplitude is listed in the [official Claude plugin marketplace](https://claude.com/plugins). Install directly from inside Claude Code:
+```
+claude plugin install amplitude
+```
+
+Or from inside Claude Code:
 
 ```
-/plugin install amplitude@claude-plugins-official
+/plugin install amplitude
 /reload-plugins
-```
-
-Or from the terminal:
-
-```bash
-claude plugin install amplitude@claude-plugins-official
 ```
 
 Then authenticate when prompted.
-
-<details>
-<summary>Install from the GitHub marketplace instead</summary>
-
-```
-/plugin marketplace add amplitude/mcp-marketplace
-/plugin install amplitude@amplitude
-/reload-plugins
-```
-
-</details>
 
 ### Cursor
 


### PR DESCRIPTION
## Summary

- Amplitude is now in the official Claude plugin marketplace, so installation is now a single command — no marketplace setup required
- Dropped the two-step `marketplace add` + `plugin install amplitude@amplitude` flow entirely

## Before
```
/plugin marketplace add amplitude/mcp-marketplace
/plugin install amplitude@amplitude
/reload-plugins
```

## After
```
claude plugin install amplitude
```

The official Claude marketplace (`claude-plugins-official`) is auto-available in Claude Code, so the plugin name resolves without any qualifier. This matches how other official plugins (e.g. PostHog) document their install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)