### PR TITLE
chore: add root .cursor-plugin symlink for Cursor marketplace indexing

### DIFF
--- a/.cursor-plugin
+++ b/.cursor-plugin
@@ -1,0 +1,1 @@
+.claude-plugin

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ A typical flow: `diff-intake` → `discover-event-surfaces` → `instrument-even
 ```text
 .claude-plugin/
   marketplace.json            # Marketplace catalog
+.cursor-plugin/               # Symlink to .claude-plugin (Cursor marketplace support)
 plugins/
   amplitude/
     .claude-plugin/


### PR DESCRIPTION
## Summary

Cursor's plugin parser expects a multi-plugin repo to expose its marketplace manifest at `.cursor-plugin/marketplace.json` at the repo root ([Cursor Plugins reference](https://cursor.com/docs/reference/plugins#multi-plugin-repositories)). Today this repo only has `.claude-plugin/marketplace.json` at the root, so Cursor's indexer has nothing to crawl — even after #17 added the per-plugin `.cursor-plugin` symlinks.

This PR symlinks `.cursor-plugin -> .claude-plugin` at the repo root, mirroring the pattern already used inside each plugin folder and keeping a single source of truth (the auto-version-bump workflow continues to read/write `.claude-plugin/marketplace.json` unchanged).

## Context

From an ext-cursor-amplitude Slack thread with Rohan Shah (Cursor):

> On the re-index, seems like you all got rid of the .cursor-plugin file and the manifest. We need those to be able to read in the components.

After this merges, Cursor still needs a **manual re-index** of this repo (per Rohan, re-indexing isn't automatic yet; a partner portal is planned).

## Changes

- Add `.cursor-plugin` symlink -> `.claude-plugin` at repo root
- Document the root symlink in README's Repository Structure section

## Verification

- `.cursor-plugin/marketplace.json` resolves via symlink ✅
- Each plugin already has `.cursor-plugin/plugin.json` via the symlinks from #17 ✅
- `auto-version-bump.yml` still targets `.claude-plugin/marketplace.json` — no workflow changes needed ✅

## Test plan

- [ ] Merge to main
- [ ] Ping Rohan / Cursor team to trigger a manual re-index of `amplitude/mcp-marketplace`
- [ ] Verify the amplitude plugin and its skills show up correctly on [cursor.com/marketplace](https://cursor.com/marketplace)

Made with [Cursor](https://cursor.com)