### PR TITLE
chore: replace .cursor-plugin symlinks with real manifests

### DIFF
--- a/.cursor-plugin
+++ b/.cursor-plugin
@@ -1,1 +1,0 @@
-.claude-plugin

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,43 @@
+{
+  "name": "amplitude",
+  "owner": {
+    "name": "Amplitude",
+    "email": "support@amplitude.com"
+  },
+  "metadata": {
+    "description": "Amplitude analytics plugins for AI coding agents",
+    "version": "0.0.1"
+  },
+  "plugins": [
+    {
+      "name": "amplitude",
+      "source": "./plugins/amplitude",
+      "strict": false,
+      "description": "Use Amplitude as an expert analyst - instrument Amplitude, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts",
+      "version": "1.1.0",
+      "author": {
+        "name": "Amplitude"
+      },
+      "homepage": "https://github.com/amplitude/mcp-marketplace",
+      "repository": "https://github.com/amplitude/mcp-marketplace",
+      "license": "MIT",
+      "keywords": [
+        "analytics",
+        "amplitude",
+        "charts",
+        "dashboards",
+        "feedback",
+        "analysis",
+        "instrumentation",
+        "tracking",
+        "account-health",
+        "customer-success",
+        "daily-brief",
+        "weekly-brief",
+        "monitor-experiments",
+        "discover-opportunities"
+      ],
+      "category": "analytics"
+    }
+  ]
+}

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -99,16 +99,19 @@ jobs:
             exit 0
           fi
 
-          # Bump each plugin's version in marketplace.json
+          # Bump each plugin's version in both marketplace manifests.
           # Per Claude Code docs, for relative-path plugins version should be set in
           # the marketplace entry, not plugin.json: https://code.claude.com/docs/en/plugin-marketplaces#version-resolution-and-release-channels
+          # Cursor reads .cursor-plugin/marketplace.json; Claude Code reads .claude-plugin/marketplace.json.
+          # Keep both in sync so the two marketplaces don't drift.
           declare -a bump_summaries=()
           declare -a bump_details=()
-          marketplace=".claude-plugin/marketplace.json"
+          marketplaces=(".claude-plugin/marketplace.json" ".cursor-plugin/marketplace.json")
+          primary_marketplace="${marketplaces[0]}"
 
           for plugin_name in "${!plugins_to_bump[@]}"; do
             bump_type="${plugins_to_bump[$plugin_name]}"
-            current_version=$(jq -r --arg name "$plugin_name" '.plugins[] | select(.name == $name) | .version // "0.0.0"' "$marketplace")
+            current_version=$(jq -r --arg name "$plugin_name" '.plugins[] | select(.name == $name) | .version // "0.0.0"' "$primary_marketplace")
             IFS='.' read -r major minor patch <<< "$current_version"
 
             if [ "$bump_type" = "minor" ]; then
@@ -117,9 +120,12 @@ jobs:
               new_version="$major.$minor.$((patch + 1))"
             fi
 
-            jq --arg name "$plugin_name" --arg v "$new_version" \
-              '(.plugins[] | select(.name == $name) | .version) = $v' \
-              "$marketplace" > tmp.json && mv tmp.json "$marketplace"
+            for marketplace in "${marketplaces[@]}"; do
+              [ -f "$marketplace" ] || continue
+              jq --arg name "$plugin_name" --arg v "$new_version" \
+                '(.plugins[] | select(.name == $name) | .version) = $v' \
+                "$marketplace" > tmp.json && mv tmp.json "$marketplace"
+            done
 
             echo "Bumped $plugin_name: $current_version -> $new_version ($bump_type bump)"
             bump_summaries+=("$plugin_name to $new_version")
@@ -163,7 +169,7 @@ jobs:
             exit 0
           fi
 
-          git add '.claude-plugin/marketplace.json'
+          git add '.claude-plugin/marketplace.json' '.cursor-plugin/marketplace.json'
           git commit -m "${{ steps.bump.outputs.commit_msg }}"
           git push
 

--- a/.github/workflows/manifest-sync-check.yml
+++ b/.github/workflows/manifest-sync-check.yml
@@ -1,0 +1,61 @@
+name: Manifest Sync Check
+
+on:
+  pull_request:
+    paths:
+      - '.claude-plugin/**'
+      - '.cursor-plugin/**'
+      - 'plugins/*/.claude-plugin/**'
+      - 'plugins/*/.cursor-plugin/**'
+
+jobs:
+  check-manifests-in-sync:
+    name: Claude / Cursor manifests in sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Verify .claude-plugin and .cursor-plugin manifests match
+        run: |
+          set -eo pipefail
+
+          fail=0
+
+          check_pair() {
+            local claude="$1"
+            local cursor="$2"
+
+            if [ ! -f "$claude" ] && [ ! -f "$cursor" ]; then
+              return 0
+            fi
+
+            if [ ! -f "$claude" ]; then
+              echo "::error file=$cursor::$cursor exists but $claude does not — both must be present and in sync."
+              fail=1
+              return
+            fi
+
+            if [ ! -f "$cursor" ]; then
+              echo "::error file=$claude::$claude exists but $cursor does not — both must be present and in sync."
+              fail=1
+              return
+            fi
+
+            # Normalize JSON (jq -S sorts keys) and compare.
+            if ! diff -u <(jq -S . "$claude") <(jq -S . "$cursor"); then
+              echo "::error file=$cursor::$claude and $cursor are out of sync. Update both manifests together."
+              fail=1
+            fi
+          }
+
+          check_pair ".claude-plugin/marketplace.json" ".cursor-plugin/marketplace.json"
+
+          for plugin_dir in plugins/*/; do
+            plugin_name=$(basename "$plugin_dir")
+            check_pair \
+              "${plugin_dir}.claude-plugin/plugin.json" \
+              "${plugin_dir}.cursor-plugin/plugin.json"
+          done
+
+          exit $fail

--- a/README.md
+++ b/README.md
@@ -109,13 +109,15 @@ A typical flow: `diff-intake` → `discover-event-surfaces` → `instrument-even
 
 ```text
 .claude-plugin/
-  marketplace.json            # Marketplace catalog
-.cursor-plugin/               # Symlink to .claude-plugin (Cursor marketplace support)
+  marketplace.json            # Marketplace catalog (Claude Code)
+.cursor-plugin/
+  marketplace.json            # Marketplace catalog (Cursor) — kept in sync with .claude-plugin
 plugins/
   amplitude/
     .claude-plugin/
-      plugin.json             # Plugin manifest
-    .cursor-plugin/           # Symlink to .claude-plugin (Cursor support)
+      plugin.json             # Plugin manifest (Claude Code)
+    .cursor-plugin/
+      plugin.json             # Plugin manifest (Cursor) — kept in sync with .claude-plugin
     skills/
       add-analytics-instrumentation/
       analyze-account-health/

--- a/plugins/amplitude-experimental/.cursor-plugin
+++ b/plugins/amplitude-experimental/.cursor-plugin
@@ -1,1 +1,0 @@
-.claude-plugin

--- a/plugins/amplitude-experimental/.cursor-plugin/plugin.json
+++ b/plugins/amplitude-experimental/.cursor-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "amplitude-experimental",
+  "description": "Experimental skills from Amplitude.",
+  "version": "1.0.0"
+}

--- a/plugins/amplitude/.cursor-plugin
+++ b/plugins/amplitude/.cursor-plugin
@@ -1,1 +1,0 @@
-.claude-plugin

--- a/plugins/amplitude/.cursor-plugin/plugin.json
+++ b/plugins/amplitude/.cursor-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "amplitude",
+  "description": "Use Amplitude like an expert - instrument analytics, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
## Summary

Follow-up to #20. After that merged, Rohan (Cursor) confirmed that Cursor needs **both** a root marketplace manifest (`.cursor-plugin/marketplace.json`) **and** per-plugin manifests (`.cursor-plugin/plugin.json`) in order to read a repo's components.

The previous approach used symlinks (`.cursor-plugin -> .claude-plugin`). Git stores those as mode `120000` blobs containing the target path, which may not resolve through every indexer — if Cursor's parser reads via the GitHub tree API rather than walking a cloned filesystem, the symlinks would be invisible and the manifests unreachable.

This PR replaces all `.cursor-plugin` symlinks with real directories containing real duplicated JSON manifests, and adds tooling to prevent the two sides from drifting.

## Changes

**Real manifests** (duplicated from `.claude-plugin/`):
- `.cursor-plugin/marketplace.json`
- `plugins/amplitude/.cursor-plugin/plugin.json`
- `plugins/amplitude-experimental/.cursor-plugin/plugin.json`

**Sync guarantees:**
- `auto-version-bump.yml` now writes to both marketplace manifests on every auto-bump (same logic, iterates over an array)
- New `manifest-sync-check.yml` runs on PRs that touch `.claude-plugin` or `.cursor-plugin` and fails CI if the two sides disagree (normalized `jq -S` diff)

**Docs:** README repo-structure block updated to reflect the real files.

## Why not stay on symlinks?

Rohan flagged in the ext-cursor-amplitude thread that the manifests previously "went missing" from Cursor's perspective. Given we can't easily verify what Cursor's indexer does with git symlinks, real files eliminate the ambiguity. The sync-check workflow keeps the maintenance cost ~zero.

## Test plan

- [ ] PR CI passes (in particular, `manifest-sync-check` should pass since all pairs were copied identically)
- [ ] After merge, ping Rohan to manually re-index `amplitude/mcp-marketplace` in Cursor
- [ ] Verify the amplitude plugin and its skills appear on [cursor.com/marketplace](https://cursor.com/marketplace)
- [ ] On the next PR that touches a plugin, confirm `auto-version-bump` updates both manifests in a single commit

Made with [Cursor](https://cursor.com)