### PR TITLE
chore: remove version from plugin.json manifests

### DIFF
--- a/plugins/amplitude-experimental/.claude-plugin/plugin.json
+++ b/plugins/amplitude-experimental/.claude-plugin/plugin.json
@@ -1,5 +1,4 @@
 {
   "name": "amplitude-experimental",
-  "description": "Experimental skills from Amplitude.",
-  "version": "1.0.0"
+  "description": "Experimental skills from Amplitude."
 }

--- a/plugins/amplitude-experimental/.cursor-plugin/plugin.json
+++ b/plugins/amplitude-experimental/.cursor-plugin/plugin.json
@@ -1,5 +1,4 @@
 {
   "name": "amplitude-experimental",
-  "description": "Experimental skills from Amplitude.",
-  "version": "1.0.0"
+  "description": "Experimental skills from Amplitude."
 }

--- a/plugins/amplitude/.claude-plugin/plugin.json
+++ b/plugins/amplitude/.claude-plugin/plugin.json
@@ -1,5 +1,4 @@
 {
   "name": "amplitude",
-  "description": "Use Amplitude like an expert - instrument analytics, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts",
-  "version": "1.0.0"
+  "description": "Use Amplitude like an expert - instrument analytics, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts"
 }

--- a/plugins/amplitude/.cursor-plugin/plugin.json
+++ b/plugins/amplitude/.cursor-plugin/plugin.json
@@ -1,5 +1,4 @@
 {
   "name": "amplitude",
-  "description": "Use Amplitude like an expert - instrument analytics, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts",
-  "version": "1.0.0"
+  "description": "Use Amplitude like an expert - instrument analytics, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts"
 }


### PR DESCRIPTION
## Summary

- Removes `version` field from all four `plugin.json` files (`.claude-plugin` and `.cursor-plugin` for both plugins)
- Per Claude Code docs, for relative-path plugins the version should live in `marketplace.json` only — if both are set, `plugin.json` silently wins and the marketplace version gets ignored
- Version is already correctly tracked and auto-bumped in both `.claude-plugin/marketplace.json` and `.cursor-plugin/marketplace.json`

## Test plan
- [ ] `manifest-sync-check` CI passes (`.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json` still match)
- [ ] Auto-version-bump still fires on merge and updates marketplace.json files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)