### PR TITLE
fix: add amplitude-experimental to marketplace and remove unsupported strict field

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,6 @@
     {
       "name": "amplitude",
       "source": "./plugins/amplitude",
-      "strict": false,
       "description": "Use Amplitude as an expert analyst - instrument Amplitude, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts",
       "version": "1.2.1",
       "author": {
@@ -36,6 +35,24 @@
         "weekly-brief",
         "monitor-experiments",
         "discover-opportunities"
+      ],
+      "category": "analytics"
+    },
+    {
+      "name": "amplitude-experimental",
+      "source": "./plugins/amplitude-experimental",
+      "description": "Experimental skills from Amplitude",
+      "version": "1.0.0",
+      "author": {
+        "name": "Amplitude"
+      },
+      "homepage": "https://github.com/amplitude/mcp-marketplace",
+      "repository": "https://github.com/amplitude/mcp-marketplace",
+      "license": "MIT",
+      "keywords": [
+        "analytics",
+        "amplitude",
+        "experimental"
       ],
       "category": "analytics"
     }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -12,7 +12,6 @@
     {
       "name": "amplitude",
       "source": "./plugins/amplitude",
-      "strict": false,
       "description": "Use Amplitude as an expert analyst - instrument Amplitude, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts",
       "version": "1.2.1",
       "author": {
@@ -36,6 +35,24 @@
         "weekly-brief",
         "monitor-experiments",
         "discover-opportunities"
+      ],
+      "category": "analytics"
+    },
+    {
+      "name": "amplitude-experimental",
+      "source": "./plugins/amplitude-experimental",
+      "description": "Experimental skills from Amplitude",
+      "version": "1.0.0",
+      "author": {
+        "name": "Amplitude"
+      },
+      "homepage": "https://github.com/amplitude/mcp-marketplace",
+      "repository": "https://github.com/amplitude/mcp-marketplace",
+      "license": "MIT",
+      "keywords": [
+        "analytics",
+        "amplitude",
+        "experimental"
       ],
       "category": "analytics"
     }


### PR DESCRIPTION
- Add plugins/amplitude-experimental entry to both .claude-plugin and
  .cursor-plugin marketplace.json manifests so its skills are discoverable
- Remove the "strict" field from the amplitude entry, which Cursor does not
  support and was preventing skills from rendering

https://claude.ai/code/session_01Upoy9Ee9a9gM7BGYBDJcdK