### PR TITLE
feat: [BA-49] Align instrumentation skills with quickstart's 10–30 event target

### DIFF
--- a/plugins/amplitude/skills/add-analytics-instrumentation/SKILL.md
+++ b/plugins/amplitude/skills/add-analytics-instrumentation/SKILL.md
@@ -122,7 +122,9 @@ Invoke the `instrument-events` skill, passing the `event_candidates` YAML from
 step 2.
 
 It produces a `trackingPlan` JSON with exact file locations, tracking code, and
-property definitions for every critical (priority 3) event.
+property definitions for every critical (priority 3) and useful (priority 2)
+event — together targeting the 10–30 events recommended by the
+`amplitude-quickstart-taxonomy-agent` skill's starter-kit guidance.
 
 ## Presenting the result
 

--- a/plugins/amplitude/skills/discover-event-surfaces/SKILL.md
+++ b/plugins/amplitude/skills/discover-event-surfaces/SKILL.md
@@ -196,9 +196,25 @@ Now, with that context fresh, assign a **priority**:
 
 | Priority         | Meaning                                                                                                            | Guidance                                                                                                                         |
 | ---------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| **3** (critical) | You would block a release if this event were missing. It answers a question the team *will* ask in the first week. | Reserve for events that directly measure whether the feature succeeded or failed. Most changes produce only 1-2 critical events. |
+| **3** (critical) | You would block a release if this event were missing. It answers a question the team *will* ask in the first week. | Reserve for events that directly measure whether the feature succeeded or failed.                                                |
 | **2** (useful)   | Adds real analytical value but the feature can ship without it. Worth adding if instrumentation cost is low.       | Segmentation dimensions, secondary workflows, configuration choices.                                                             |
 | **1** (optional) | Nice-to-have. Only instrument if the team has bandwidth and a specific hypothesis to test.                         | Edge-case failures, exploratory engagement signals, discoverability metrics.                                                     |
+
+### Target candidate count
+
+Aim for a **starter-kit-sized** candidate list, aligned with the
+`amplitude-quickstart-taxonomy-agent` skill's guidance: **10–30 total events**
+across priorities 2 and 3 combined (priority 1 is unbounded — include freely if
+useful, since downstream skills won't instrument them by default).
+
+- ~10–15 candidates for a small change (1–2 user-facing flows)
+- ~15–25 for a medium change (3–4 flows, multiple components)
+- Up to ~25–30 for a large change (multiple features, full user journeys)
+
+If you find yourself producing fewer than ~10 priority-2-or-3 candidates on a
+non-trivial change, you've likely under-scoped — re-read the user flow and look
+for segmentation dimensions, alternate paths, configuration events, and
+friction points you skipped.
 
 **Funnel events deserve special attention.** When a change introduces or modifies a multi-step process (checkout flow, onboarding wizard, data import pipeline), the PM's first question will be "where are users dropping off?" A gap between funnel start and funnel end with no visibility in between is a blind spot that can hide serious product problems — if engagement craters at step 2 of 5, the team needs to know, not guess.
 
@@ -210,9 +226,9 @@ To decide how many *intermediate* funnel events to mark critical, gauge the leng
 - **Medium process (3-5 steps, possibly spanning pages):** Add one intermediate event at the most likely drop-off point — typically where the user commits effort (fills a form, makes a key selection, uploads a file).
 - **Long process (5+ steps, multi-page or wizard-style):** 2-3 intermediate events at natural phase boundaries. Think "started → configured → submitted → confirmed" rather than tracking every field interaction.
 
-Be selective with intermediate events. Every funnel event you mark critical is one more thing an engineer must implement and a PM must monitor. If you're unsure whether an intermediate step is worth tracking, it probably isn't — the start and end events will reveal whether there's a problem, and the team can always add granularity later once they see where drop-off is high.
+Be selective when marking intermediate funnel events as **critical (priority 3)** — every priority-3 event is one a PM monitors closely from day one. But intermediate steps that don't make priority 3 should still appear as priority 2 if they'd inform a useful analysis later. Don't drop them entirely.
 
-Less is more. A focused set of critical events that actually get dashboarded beats a sprawling list nobody looks at. When in doubt, downgrade — it's easier to add an event later than to remove one that's already in dashboards.
+Aim for a focused set of priority-3 events plus a complementary set of priority-2 events that together hit the 10–30 target above. Critical events anchor the dashboard; useful events fill out the segmentation and secondary-flow story so the team isn't blind to anything that matters.
 
 ## 9. Emit YAML output
 

--- a/plugins/amplitude/skills/instrument-events/SKILL.md
+++ b/plugins/amplitude/skills/instrument-events/SKILL.md
@@ -2,7 +2,7 @@
 name: instrument-events
 description: >
   Given event_candidates YAML (output from discover-event-surfaces), generates a
-  concrete instrumentation plan for priority-3 (critical) events. Acts as a
+  concrete instrumentation plan for priority-3 (critical) and priority-2 (useful) events. Acts as a
   Software Architect: discovers existing analytics patterns in the codebase, reads
   the hinted files to determine what variables are in scope, designs minimal
   chart-useful properties, and identifies the exact insertion point for each
@@ -28,19 +28,27 @@ Read the `taxonomy` skill at `../taxonomy/SKILL.md` to understand the core philo
 
 ---
 
-## 1. Filter to critical events
+## 1. Filter to critical and useful events
 
-Parse the `event_candidates` YAML. Extract only candidates where `priority: 3`.
-These are the events that would block a release — everything else is out of
-scope for this skill.
+Parse the `event_candidates` YAML. Include candidates where `priority: 3`
+(critical) or `priority: 2` (useful) — both make it into the tracking plan by
+default. Drop `priority: 1` (optional) unless the user explicitly asks to
+include them.
 
-If there are zero priority-3 events, tell the user and stop.
+This default scope aligns with the `amplitude-quickstart-taxonomy-agent`
+skill's "10–30 events" starter-kit target: critical events anchor the
+dashboard and useful events fill out segmentation and secondary flows. A
+plan that covers only priority-3 events systematically under-instruments the
+feature.
 
-List the filtered events so the user can confirm scope before you proceed.
+If there are zero priority-3 *and* priority-2 events, tell the user and stop.
 
-## 2. For each critical event, build the instrumentation plan
+List the filtered events so the user can confirm scope before you proceed,
+grouped by priority so the user can see the split.
 
-Work through each priority-3 event one at a time:
+## 2. For each event, build the instrumentation plan
+
+Work through each event one at a time, starting with priority 3, then priority 2:
 
 ### 2a. Read the hinted file
 
@@ -166,4 +174,4 @@ Ask if they want to adjust anything before an engineer implements it.
 - **Match, don't invent.** The codebase already has a way of sending events. Find it and follow it exactly.
 - **Properties earn their place.** Every property must answer: "what chart axis or filter does this enable?" If the answer is vague, cut it.
 - **Scope is sacred.** Only use variables available at the insertion point. Don't propose refactors to thread data through — that's a separate PR.
-- **Critical means critical.** This skill only handles priority 3. If the user wants priority 2 events, they should say so explicitly and you can include them.
+- **Default scope is priority 2 + 3.** Both critical and useful events ship in the tracking plan by default — that's what hits the 10–30 starter-kit target the quickstart taxonomy skill calls for. Priority 1 (optional) stays opt-in.


### PR DESCRIPTION
## Summary

The instrumentation pipeline (`discover-event-surfaces` → `instrument-events`) was producing only ~1–2 events per run, far below the 10–30 starter-kit target the `amplitude-quickstart-taxonomy-agent` skill recommends. Two specific bottlenecks:

1. `discover-event-surfaces/SKILL.md` told the model "most changes produce only 1-2 critical events" and instructed it to downgrade when in doubt.
2. `instrument-events/SKILL.md` hard-filtered to priority-3 only, dropping priority-2 candidates unless the user explicitly opted in.

This PR aligns both skills with the quickstart taxonomy's 10–30 event target.

## Changes

- **`discover-event-surfaces/SKILL.md`**: Removed the "1-2 critical events" line from the priority table; added a new **Target candidate count** section pinning 10–30 (across priorities 2 and 3) to the quickstart guidance; rewrote the funnel-events closer so intermediate steps that don't make priority 3 still land at priority 2 instead of being dropped.
- **`instrument-events/SKILL.md`**: Loosened the priority-3-only filter to include priority 2 (useful) by default. Priority 1 (optional) stays opt-in. Updated the frontmatter description, section heading, and closing principle to match.
- **`add-analytics-instrumentation/SKILL.md`**: Updated the orchestrator's description of what `instrument-events` produces.

## Validation

Validated end-to-end via the [`amplitude/context-hub`](https://github.com/amplitude/context-hub) consumer (which pulls these skills via `pnpm skills:refresh` and bundles them):

- ✅ `pnpm build` succeeds; new prompts ship in the bundled `discover-event-surfaces.zip`, `instrument-events.zip`, and `add-analytics-instrumentation.zip`
- ✅ `pnpm test` — 41/41 passed
- ✅ `bash scripts/scan-prompt-injection.sh dist/skills` — 58 archives clean
- ✅ Confirmed all four old phrases are absent from the bundled output: `"1-2 critical events"`, `"Extract only candidates"`, `"Critical means critical"`, `"Less is more"`.

## Test plan

- [ ] End-to-end run of `add-analytics-instrumentation` against a representative PR; confirm tracking-plan event count is meaningfully larger than ~1–2 and roughly tracks the change scope (small change → ~10–15, medium → ~15–25, large → up to ~25–30).
- [ ] Spot-check that priority-2 events appear in the final tracking plan with usable `instrumentation` hints, properties, and reasoning.
- [ ] Verify the funnel-coverage logic still emits start/end as priority 3 and intermediate as priority 2 (rather than dropping intermediate steps).

Closes [BA-49](https://linear.app/amplitude/issue/BA-49/align-instrumentation-skills-with-quickstarts-10-30-event-target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)