### PR TITLE
Add Codex marketplace and plugin manifest

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "amplitude",
+  "interface": {
+    "displayName": "Amplitude"
+  },
+  "plugins": [
+    {
+      "name": "amplitude",
+      "source": {
+        "source": "local",
+        "path": "./plugins/amplitude"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -99,11 +99,13 @@ jobs:
             exit 0
           fi
 
-          # Bump each plugin's version in both marketplace manifests.
+          # Bump each plugin's version in both marketplace manifests and the
+          # Codex plugin manifest when present.
           # Per Claude Code docs, for relative-path plugins version should be set in
           # the marketplace entry, not plugin.json: https://code.claude.com/docs/en/plugin-marketplaces#version-resolution-and-release-channels
           # Cursor reads .cursor-plugin/marketplace.json; Claude Code reads .claude-plugin/marketplace.json.
-          # Keep both in sync so the two marketplaces don't drift.
+          # Codex stores version in .codex-plugin/plugin.json, so keep that in
+          # sync with the marketplace versions for the same plugin.
           declare -a bump_summaries=()
           declare -a bump_details=()
           marketplaces=(".claude-plugin/marketplace.json" ".cursor-plugin/marketplace.json")
@@ -126,6 +128,13 @@ jobs:
                 '(.plugins[] | select(.name == $name) | .version) = $v' \
                 "$marketplace" > tmp.json && mv tmp.json "$marketplace"
             done
+
+            codex_manifest="plugins/$plugin_name/.codex-plugin/plugin.json"
+            if [ -f "$codex_manifest" ]; then
+              jq --arg v "$new_version" \
+                '.version = $v' \
+                "$codex_manifest" > tmp.json && mv tmp.json "$codex_manifest"
+            fi
 
             echo "Bumped $plugin_name: $current_version -> $new_version ($bump_type bump)"
             bump_summaries+=("$plugin_name to $new_version")
@@ -170,6 +179,7 @@ jobs:
           fi
 
           git add '.claude-plugin/marketplace.json' '.cursor-plugin/marketplace.json'
+          find plugins -path '*/.codex-plugin/plugin.json' -print0 | xargs -0 -r git add
           git commit -m "${{ steps.bump.outputs.commit_msg }}"
           git push
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,21 @@
 
 Official Amplitude plugin for AI coding tools. Turn your AI assistant into a product analyst — instrument analytics, analyze charts, run experiments, and understand users directly from your editor.
 
-Works with **Claude Code**, **Cursor**, and **Claude**.
+Works with **Codex**, **Claude Code**, **Cursor**, and **Claude**.
 
 ---
 
 ## Installation
+
+### Codex
+
+Use the repo-scoped marketplace file in this repository:
+
+```bash
+codex plugin marketplace add .
+```
+
+Then install the plugin from the `Amplitude` marketplace in Codex's plugin directory.
 
 ### Claude Code
 
@@ -108,16 +118,21 @@ A typical flow: `diff-intake` → `discover-event-surfaces` → `instrument-even
 ## Repository Structure
 
 ```text
+.agents/plugins/
+  marketplace.json            # Marketplace catalog (Codex)
 .claude-plugin/
   marketplace.json            # Marketplace catalog (Claude Code)
 .cursor-plugin/
   marketplace.json            # Marketplace catalog (Cursor) — kept in sync with .claude-plugin
 plugins/
   amplitude/
+    .codex-plugin/
+      plugin.json             # Plugin manifest (Codex)
     .claude-plugin/
       plugin.json             # Plugin manifest (Claude Code)
     .cursor-plugin/
       plugin.json             # Plugin manifest (Cursor) — kept in sync with .claude-plugin
+    .mcp.json                 # MCP server config shared by Codex and other clients
     skills/
       add-analytics-instrumentation/
       analyze-account-health/

--- a/plugins/amplitude/.codex-plugin/plugin.json
+++ b/plugins/amplitude/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amplitude",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Use Amplitude as an expert analyst and instrumentation partner inside Codex.",
   "author": {
     "name": "Amplitude",

--- a/plugins/amplitude/.codex-plugin/plugin.json
+++ b/plugins/amplitude/.codex-plugin/plugin.json
@@ -1,0 +1,50 @@
+{
+  "name": "amplitude",
+  "version": "1.2.0",
+  "description": "Use Amplitude as an expert analyst and instrumentation partner inside Codex.",
+  "author": {
+    "name": "Amplitude",
+    "email": "support@amplitude.com",
+    "url": "https://amplitude.com"
+  },
+  "homepage": "https://github.com/amplitude/mcp-marketplace",
+  "repository": "https://github.com/amplitude/mcp-marketplace",
+  "license": "MIT",
+  "keywords": [
+    "analytics",
+    "amplitude",
+    "charts",
+    "dashboards",
+    "feedback",
+    "analysis",
+    "instrumentation",
+    "tracking",
+    "account-health",
+    "customer-success",
+    "daily-brief",
+    "weekly-brief",
+    "monitor-experiments",
+    "discover-opportunities"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Amplitude",
+    "shortDescription": "Analytics, experimentation, and instrumentation workflows for Codex.",
+    "longDescription": "Bundle Amplitude analysis, experimentation, session replay, and instrumentation skills with the Amplitude MCP server configuration for use in Codex.",
+    "developerName": "Amplitude",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://amplitude.com",
+    "privacyPolicyURL": "https://amplitude.com/privacy",
+    "termsOfServiceURL": "https://amplitude.com/terms",
+    "defaultPrompt": [
+      "Use Amplitude to analyze this chart and explain the drivers behind the change.",
+      "Use Amplitude to plan analytics instrumentation for this feature."
+    ],
+    "brandColor": "#005AF0"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Codex plugin manifest for the existing Amplitude plugin
- add a repo-scoped Codex marketplace entry under .agents/plugins/marketplace.json
- document Codex installation and repository structure in the README

## Validation
- validated the new JSON files with python3 -m json.tool
- confirmed the existing Claude/Cursor auto-version-bump workflow still picks up changes under plugins/amplitude/**, including the new Codex manifest
- confirmed the existing Claude/Cursor manifest sync check remains unaffected