### PR TITLE
chore: add author metadata so claude.com renders Amplitude with capital A

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,9 @@
       "description": "Use Amplitude as an expert analyst - instrument Amplitude, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts",
       "version": "1.3.0",
       "author": {
-        "name": "Amplitude"
+        "name": "Amplitude",
+        "email": "support@amplitude.com",
+        "url": "https://amplitude.com"
       },
       "homepage": "https://github.com/amplitude/mcp-marketplace",
       "repository": "https://github.com/amplitude/mcp-marketplace",
@@ -44,7 +46,9 @@
       "description": "Experimental skills from Amplitude",
       "version": "1.0.0",
       "author": {
-        "name": "Amplitude"
+        "name": "Amplitude",
+        "email": "support@amplitude.com",
+        "url": "https://amplitude.com"
       },
       "homepage": "https://github.com/amplitude/mcp-marketplace",
       "repository": "https://github.com/amplitude/mcp-marketplace",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -15,7 +15,9 @@
       "description": "Use Amplitude as an expert analyst - instrument Amplitude, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts",
       "version": "1.3.0",
       "author": {
-        "name": "Amplitude"
+        "name": "Amplitude",
+        "email": "support@amplitude.com",
+        "url": "https://amplitude.com"
       },
       "homepage": "https://github.com/amplitude/mcp-marketplace",
       "repository": "https://github.com/amplitude/mcp-marketplace",
@@ -44,7 +46,9 @@
       "description": "Experimental skills from Amplitude",
       "version": "1.0.0",
       "author": {
-        "name": "Amplitude"
+        "name": "Amplitude",
+        "email": "support@amplitude.com",
+        "url": "https://amplitude.com"
       },
       "homepage": "https://github.com/amplitude/mcp-marketplace",
       "repository": "https://github.com/amplitude/mcp-marketplace",

--- a/plugins/amplitude/.claude-plugin/plugin.json
+++ b/plugins/amplitude/.claude-plugin/plugin.json
@@ -1,4 +1,9 @@
 {
   "name": "amplitude",
-  "description": "Use Amplitude like an expert - instrument analytics, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts"
+  "description": "Use Amplitude like an expert - instrument analytics, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts",
+  "author": {
+    "name": "Amplitude",
+    "email": "support@amplitude.com",
+    "url": "https://amplitude.com"
+  }
 }

--- a/plugins/amplitude/.cursor-plugin/plugin.json
+++ b/plugins/amplitude/.cursor-plugin/plugin.json
@@ -1,4 +1,9 @@
 {
   "name": "amplitude",
-  "description": "Use Amplitude like an expert - instrument analytics, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts"
+  "description": "Use Amplitude like an expert - instrument analytics, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts",
+  "author": {
+    "name": "Amplitude",
+    "email": "support@amplitude.com",
+    "url": "https://amplitude.com"
+  }
 }


### PR DESCRIPTION
## Summary
Adds an `author` block to `plugins/amplitude/.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json`, and enriches the existing `author` entries in the top-level marketplace manifests with `email` and `url`.

## Why
`claude.com/plugins/amplitude` currently renders the heading as lowercase `amplitude` because our plugin manifest has no `author` field. claude.com appears to derive the heading from `author.name` in `.claude-plugin/plugin.json`; when the field is absent it falls back to the lowercase `name` identifier.

I sampled 14 plugins in the official registry to confirm this pattern:

| Plugin | `author.name` set? | claude.com heading |
|---|---|---|
| stripe / linear / sentry / posthog / atlassian / vercel / semgrep / atlan / pinecone | Yes (matches brand) | Capitalized brand name |
| firebase / code-review | Yes (parent company) | Title-cased plugin name |
| terraform | Yes (parent company) | lowercase (outlier) |
| **amplitude** | **No** | **lowercase** ❌ |

In every case where the brand name is in `author.name`, the heading capitalizes correctly. With this PR, `claude.com/plugins/amplitude` should render as **Amplitude**.

## Non-breaking
- `name` identifiers are unchanged, so install commands (`claude plugin install amplitude`), URL slugs, and existing user configs all keep working.
- `.claude-plugin/marketplace.json` and `.cursor-plugin/marketplace.json` remain byte-identical (manifest sync check passes).
- The Codex plugin manifest already has the same `author` block, so this brings the Claude/Cursor manifests to parity.

## Test plan
- [x] `python3 -m json.tool` validates all four files
- [x] `diff -u` of the marketplace pair: in sync
- [x] `diff -u` of the plugin pair: in sync
- [ ] After merge, verify `claude.com/plugins/amplitude` heading reads "Amplitude"

🤖 Generated with [Claude Code](https://claude.com/claude-code)