### PR TITLE
[coding-agent] Skill fixes: scope contract + PII guardrails

### DIFF
--- a/plugins/amplitude/skills/full-repo-instrumentation/SKILL.md
+++ b/plugins/amplitude/skills/full-repo-instrumentation/SKILL.md
@@ -27,6 +27,43 @@ description quality requirements that apply throughout.
 
 ---
 
+## Scope contract (READ FIRST)
+
+If the runner's instructions named a subdirectory (e.g., *"Analyze the
+`sites/marketplace` subdirectory"*), treat that subdirectory as **your
+repository** for this run. You may ONLY read, write, or stage files
+under that subdirectory. Other subdirectories of the same git repo are
+**out of scope** — they will be instrumented by their own separate
+agent runs.
+
+Do not extend the workspace beyond the named subdirectory. Do not
+import scope from a `git ls-files` walk of the repo root. Do not write
+`.amplitude/events.json`, `.amplitude/tracking-plan.md`, source code,
+or any other file outside the named subdirectory under any
+circumstance. The PR commit captures every changed file in the working
+tree, so out-of-scope writes ship to other sites' source code AND
+register events from those sites into the Amplitude project — a known
+monorepo failure mode that registers customer events the reviewer
+never approved.
+
+Where this skill (or any sub-skill it calls) says **"scan the full
+repository"** or **"the full repo"**, read it as **"the full
+subdirectory"** when a subdirectory was named. Phase 1's instruction
+to *"scan the full repository"* applies to the named subdirectory's
+tree only, not the monorepo root.
+
+If no subdirectory was named — i.e., the runner says *"Analyze the
+{owner}/{repo} repository"* with no subdirectory clause — the working
+directory IS the whole repo and you may walk it freely. The scope
+contract is only meaningful when a subdirectory is in play.
+
+Verification step before any artifact write: every path you are about
+to create or modify must start with the named subdirectory's prefix.
+If a path doesn't, the write is out of scope — drop it, don't expand
+the workspace to "fix" the path.
+
+---
+
 ## Phase 0: Check for prior state
 
 Check if `.amplitude/manifest.json` exists:

--- a/plugins/amplitude/skills/user-property-best-practices/SKILL.md
+++ b/plugins/amplitude/skills/user-property-best-practices/SKILL.md
@@ -91,14 +91,41 @@ Only suggest properties whose value is **straightforward to set** — pulling da
 source and setting it directly. If a property requires aggregating events, running queries,
 or deriving a value from multiple data points, it is NOT a good user property.
 
-- Good: `email` (read directly from user record)
+- Good: `email domain` (extracted from email at the call site, e.g., `email.split("@")[1]`)
 - Good: `authentication source` (known at login time)
 - Bad: `Most Viewed Product` (requires aggregating event history)
 - Bad: `Preferred Category` (requires ranking logic over event data)
 - Bad: `Purchase Frequency Bracket` (requires counting purchases over a time window)
 - Bad: `Preferred Department` (requires analyzing which department the user buys from most)
 
-## 7. Named Clearly Using Lower Case
+## 7. PII Guardrails (always)
+
+**Never propose raw PII as a user property.** That includes raw email, phone number, full
+name, street address, SSN, credit card, or any free-form identifier the user typed. Even
+when the property is trivially available in the codebase (`user.email`, `signup_form.phone`,
+etc.), wrap it before storing:
+
+- **`email`** → propose `email domain` (`email.split("@")[1]`) — enough for cohort
+  segmentation by domain. Do NOT also set raw `email` alongside `email domain`. If per-user
+  identification is needed, that goes through `setUserId(<id>)` (Amplitude hashes server-side),
+  not as a property.
+- **`phone` / `ssn` / `credit_card`** → prefer a boolean flag (`has phone: true`) or a coarse
+  derived value (`card brand: visa`) over the raw value.
+- **`full_name`** → prefer `display name initials` or omit entirely. A full name as a user
+  property leaks PII into every event the user triggers.
+- **Free-form text** the user typed (search query, support message body, etc.) → never a
+  user property. If you need to segment by intent, propose a derived classification
+  (`search category`, `support topic`) instead.
+
+If the existing codebase passes raw PII to a tracking call, do **not** extend the call by
+adding the raw value as a new user property. Propose deriving the safe form at the call site
+instead, even if that requires touching the tracking surface code.
+
+This rule overrides §6's "Does Not Require Excessive Computation" — a 1-line
+`email.split("@")[1]` at the call site is a worthwhile cost to keep PII out of the
+user-properties store.
+
+## 8. Named Clearly Using Lower Case
 
 Use concise, descriptive names in lower case with spaces. Avoid abbreviations that aren't universally understood.
 


### PR DESCRIPTION
Two pure-markdown skill edits from tonight's eval testing against `tjtorres/coding-agent-test-sites`. Full incident detail in [EVAL_FINDINGS.md](https://github.com/tjtorres/coding-agent-test-sites/blob/main/EVAL_FINDINGS.md) (F-014, F-015).

## F-014 — `full-repo-instrumentation/SKILL.md` scope contract

The skill currently says "scan the full repository" with no qualifier when a subdirectory is named in the runner's brief. On a monorepo (the test-sites repo has 35 subdirs under `web/`, `mobile/`, `sites/`, etc.), the agent interpreted "full repository" as the whole monorepo and walked across sibling subdirs, then committed those writes into the active PR.

**Observed in the 33-site bulk init:** 7 of 32 PRs committed files outside their target subdir.
- `mobile/ios-swiftui-clean` files appeared in 4 unrelated PRs
- `edge/a11y-keyboard-interactions` files appeared in 4 unrelated PRs (also explains why a11y "didn't get its own PR" — its instrumentation shipped in other sites' commits)

Fix: new "Scope contract (READ FIRST)" section at the top of the skill that:
- Reframes "scan the full repository" as "scan the named subdirectory" when one is given
- Explicitly forbids reads/writes outside the subdirectory
- Requires verification that every artifact path starts with the subdirectory prefix before writing
- Notes the case where no subdirectory is named (whole-repo runs are unaffected)

## F-015 — `user-property-best-practices/SKILL.md` PII guardrails

The skill's §6 ("Does Not Require Excessive Computation") used `email` as a "Good" example user property because it can be read directly from the user record. The agent took that literally on `web/next-existing-segment-browser` PR #115 and set BOTH raw `email` AND `email_domain` as user properties via `identify()` — the raw email is a `G1_pii_in_properties` anti-pattern hit per the test-sites `GAP_CATALOG.md`.

Fix:
- Replace the `email` example in §6 with `email domain` (extracted via `email.split("@")[1]`)
- Add new §7 "PII Guardrails (always)" forbidding raw email, phone, SSN, credit card, full name, and free-form user-typed text as user properties — with the safe derived alternative for each
- Renumber the old §7 "Named Clearly Using Lower Case" to §8

## Verification plan

Re-fire the bulk init after this lands:
- F-014 verified: 0 of N PRs touch files outside their target subdir
- F-015 verified: 0 of N PRs add raw `email` to user properties (only `email_domain` or omitted)

Both fixes are markdown-only — no code, no tests, no schema. Targeting the `coding-agent/init-mode-skills` branch since `full-repo-instrumentation/SKILL.md` and `user-property-best-practices/SKILL.md` only exist there (not yet on main).

<details>
<summary>AI Prompt</summary>

After running the eval-testing loop tonight against `tjtorres/coding-agent-test-sites`, two skill-prompt issues surfaced from the agent's behavior on real PRs (F-014, F-015 in `EVAL_FINDINGS.md`). TJ asked me to focus on skill-prompt edits over langley plumbing, so this PR lands the two pure-markdown fixes.

</details>