### PR TITLE
skill: tighten add-analytics-instrumentation Phase 0 product-surface gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "amplitude",
       "source": "./plugins/amplitude",
       "description": "Use Amplitude as an expert analyst - instrument Amplitude, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "author": {
         "name": "Amplitude",
         "email": "support@amplitude.com",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "amplitude",
       "source": "./plugins/amplitude",
       "description": "Use Amplitude as an expert analyst - instrument Amplitude, discover product opportunities, analyze charts, create dashboards, manage experiments, and understand users and accounts",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "author": {
         "name": "Amplitude",
         "email": "support@amplitude.com",

--- a/plugins/amplitude/.codex-plugin/plugin.json
+++ b/plugins/amplitude/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amplitude",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Use Amplitude as an expert analyst and instrumentation partner inside Codex.",
   "author": {
     "name": "Amplitude",

--- a/plugins/amplitude/skills/add-analytics-instrumentation/SKILL.md
+++ b/plugins/amplitude/skills/add-analytics-instrumentation/SKILL.md
@@ -19,121 +19,182 @@ description: >
 
 You are the orchestrator for the analytics instrumentation pipeline. Your job is
 to figure out what the user wants to instrument, gather the relevant code, and
-run the pipeline to produce a tracking plan — **or cleanly skip** if the change
-has no user-facing product surfaces worth instrumenting.
+run the pipeline to produce a tracking plan.
 
 ## Pipeline
 
-### Phase 0: Product-surface gate (stop-early)
+### Phase 0: Product-surface gate (PR / Branch mode only)
 
-Before running the pipeline, decide whether this diff is a product change.
-The agent should not propose events for work that never reaches a user —
-tooling, harness code, infrastructure, pure data transformations — because
-that produces taxonomy rows that will never fire and noise in PR review.
+Before doing any other work in PR or branch mode, decide a single question:
 
-**The judgment to make**
+> Does this diff add a **new user-reachable execution path** that produces a
+> surface, response, or feedback a user perceives?
 
-For this specific diff, ask: *does a user directly cause any of the changed
-code to run, and does that code produce a surface, response, or feedback
-the user perceives?*
+If the answer is **no** for every changed file, write the marker file
+`.amplitude/no-trackable-surfaces.md` and **STOP**. Do not proceed to Step 0.
+The orchestrator reads the marker and posts a "no trackable surfaces" comment
+on the original PR instead of opening a prepare PR with events that would
+never fire.
 
-That's the entire question. Don't enumerate path patterns — conventions
-vary wildly across customer codebases. A Rails app's tests live in
-`spec/`. A Go service's user-facing handlers live in `cmd/`. A CLI tool's
-product IS the command-line interface. A Next.js `pages/api/` file is
-backend *and* product because users hit it with every click. Path names
-are a weak hint at best; the file's contents and how it's reached are
-what matter.
+This gate exists because publishing a prepare PR for a refactor-only diff
+wastes reviewer time, pollutes the project's PR list, and erodes trust in the
+agent. A prepare PR the reviewer closes is **not** cheaper than a quiet skip —
+it is more expensive, because every false positive trains reviewers to ignore
+the agent's output.
 
-**How to read a file**
+**Apply the gate to PR / Branch input only.** File / Directory and Feature
+inputs (Step 1a / Step 1b) are explicit user requests to instrument specific
+code; Phase 0 does not apply there.
 
-For each changed file (or the small set of files most representative of
-the change, when a diff touches many), read it and ask:
+#### Decision rule
 
-1. **Is this code on a user-reachable path?** Follow the imports and call
-   chain as far as it takes to answer. If a utility function is only
-   called by a CI script that produces a JSON report, it's not
-   user-reachable. If the same utility is called by a route handler that
-   returns HTML, it is.
+Read the **contents** of every changed file (not just paths). For each file,
+ask: does the change introduce or expose a new user-reachable execution path?
+A user-reachable execution path is code a user **directly causes to run** by
+interacting with the product (clicking, typing, navigating, submitting,
+viewing, calling an exposed API), and which produces something the user
+perceives.
 
-2. **Does it produce a user-perceptible effect?** UI renders, HTTP
-   responses to browsers/mobile/API consumers, CLI output when the CLI
-   is the product, state changes that drive subsequent UI behavior, and
-   modifications to existing analytics call sites all count. Internal
-   data crunching with no user-visible outcome (a training pipeline, a
-   data migration, an eval harness that writes to a log) does not.
+- If **every** changed file is refactor-only (see patterns below) → write
+  `.amplitude/no-trackable-surfaces.md` and STOP.
+- If **any** changed file introduces a new user-reachable execution path →
+  proceed to Step 0.
+- If you cannot tell from the diff whether a change is user-reachable, read
+  the surrounding code (callers, route definitions, exported symbols). Do not
+  guess. **Do not default to proceeding** — the right tiebreaker is "is there
+  evidence of a new user-reachable path?" If there is no such evidence, the
+  answer is no.
 
-3. **Would an analyst at this company reasonably want to know when this
-   code runs?** If the answer is "no, this is behind-the-scenes
-   machinery," it's probably not worth instrumenting even if it *does*
-   technically sit on a user-reachable path.
+#### Refactor patterns that route to no-trackable-surfaces
 
-**Strong positive signals** (any ONE is enough for the pipeline to proceed):
+These changes do **not** add new user-reachable execution paths and MUST route
+to the marker file when they are the only kind of change in the diff:
 
-- UI component definitions (JSX/TSX render trees, Vue `<template>`,
-  Svelte markup, SwiftUI `View` bodies, Jetpack Compose `@Composable`
-  functions, Android layouts / Activities, UIKit view controllers) — the
-  file renders pixels a user sees.
-- Event handlers attached to interactive elements — `onClick`,
-  `onSubmit`, `@click`, `addEventListener`, gesture recognizers,
-  keyboard/touch handlers. The file describes something a user can
-  directly invoke.
-- Route / endpoint definitions that serve user requests — any framework,
-  any language, including CLI command registrations when the CLI is
-  the product.
-- Existing analytics / tracking call sites being modified — if the diff
-  changes code that already fires events, instrumenting is by definition
-  in scope.
-- A clear, reader-level description that says "this is the product
-  surface" — e.g., a component module, a page file, an API controller.
+1. **Constant or literal relocations** — moving a string/number/object
+   literal from one scope to another (e.g. function-local → module-level,
+   inline → named export). Behaviour is unchanged; only the binding site
+   moves.
 
-**Strong negative signals** (push toward stopping, but don't trigger by
-themselves — a single ambiguous file with positive signal still proceeds):
+   *Example (the #37008 shape):*
+   ```diff
+   -function format(x) {
+   -  const PREFIX = "user_";
+   -  return PREFIX + x;
+   -}
+   +const PREFIX = "user_";
+   +function format(x) {
+   +  return PREFIX + x;
+   +}
+   ```
+   No new surface. Skip.
 
-- The file is a test, verified by its own imports (`pytest`, `unittest`,
-  `vitest`, `jest`, `rspec`, `go test` helpers, etc.) rather than by its
-  directory name.
-- The file is a developer utility whose only callers are other developer
-  utilities or CI pipelines.
-- The change is a pure configuration / manifest edit (lockfile bump,
-  `tsconfig` tweak, dependency pin).
-- The change is a schema migration with no accompanying code touching a
-  user surface.
-- The change is documentation / markdown only.
+2. **Renames** — variable, function, parameter, type, or file renames where
+   call sites are updated mechanically and behaviour is preserved.
 
-**Decision rule**
+   *Example:*
+   ```diff
+   -export function getUserId(req) { return req.session.user.id; }
+   +export function resolveUserId(req) { return req.session.user.id; }
+   ```
+   No new surface. Skip. (If the rename touches a tracking call name, that's
+   a separate concern handled downstream — never rename event names in
+   `events.json`.)
 
-- If ANY changed file is user-reachable AND produces a user-perceptible
-  effect (positive signal and no overwhelming reason to think otherwise)
-  → **proceed** with the full pipeline.
-- If EVERY changed file you read lacks a user-reachable path and a
-  user-perceptible effect → **stop** and write the marker file below.
-- If you genuinely cannot tell — the diff is small, the context is
-  ambiguous, the imports are unfamiliar — **default to proceeding**. The
-  cost of a false positive (a prepare PR the reviewer closes with one
-  click) is much lower than the cost of a false negative (missing real
-  user surfaces the team relies on). The gate exists to filter *clear*
-  non-product work, not to second-guess every PR.
+3. **Type-only changes** — adding/refining TypeScript types, Python type
+   hints, generic parameters, or interface declarations without altering
+   runtime behaviour.
 
-**When stopping**, write a single marker file:
+   *Example:*
+   ```diff
+   -function load(id) { ... }
+   +function load(id: UserId): Promise<User> { ... }
+   ```
+   No new surface. Skip.
 
+4. **Formatting and whitespace** — prettier/black/gofmt reflows, import
+   reordering, trailing-comma changes, line-length wraps.
+
+5. **Code reorganization** — splitting a file into modules, extracting a
+   helper, inlining a one-off function, reordering exports — when call sites
+   resolve to the same behaviour. The execution graph is unchanged; only the
+   file layout differs.
+
+6. **Comment / docstring / JSDoc edits** — including TODO removals and
+   typo fixes inside comments.
+
+7. **Dead-code deletion** — removing unused exports, unreachable branches,
+   or commented-out blocks.
+
+8. **Dependency / lockfile bumps** — `package-lock.json`, `yarn.lock`,
+   `uv.lock`, `Pipfile.lock`, `go.sum`, `Gemfile.lock`. Same applies to
+   version-only `package.json` / `pyproject.toml` bumps with no new
+   imported call sites in source files.
+
+9. **Build / config / tooling** — CI YAML, `.eslintrc`, `tsconfig.json`,
+   `Makefile`, dockerfiles, `.gitignore`. These don't reach users at
+   runtime.
+
+10. **Test-only diffs** — changes confined to test files (`*.test.*`,
+    `*_test.py`, `spec/`, `__tests__/`). Tests don't run in production and
+    don't fire tracking calls a user perceives. (Caveat: if the test file is
+    actually the product — e.g. an exported test fixture imported by user
+    code — read the contents to verify before applying this rule.)
+
+11. **Generated code** — files marked auto-generated, vendored bundles,
+    minified output. The source generator is what a reviewer would
+    instrument; the artifact is not.
+
+If the diff mixes refactor-only files with files that DO introduce new
+user-reachable paths, the gate **opens** — proceed to Step 0. The
+downstream pipeline will scope its analysis to the user-reachable files.
+
+#### Heuristics that strongly suggest a new user-reachable path (gate opens)
+
+Any of these in a changed file is sufficient evidence to proceed:
+
+- A new exported handler, route, controller, or page component
+- A new `onClick`, `onSubmit`, `onChange`, or other event-handler binding in
+  a user-visible component
+- A new `fetch` / `axios` / RPC call from client code, or a new endpoint
+  registration on the server
+- A new branch in user-reachable control flow that produces user-visible
+  output (toast, modal, redirect, response body, render output)
+- A new feature-flag check that gates user-visible behaviour
+- A new form field, button, link, or navigation entry
+- A new SDK call site (`.track(`, `.identify(`, `.setUserId(`,
+  `.setGroup(`, `.groupIdentify(`) — if the diff is already adding these,
+  the gate is moot, but their presence confirms the path is user-reachable
+
+#### Marker file template
+
+When the gate closes, write `.amplitude/no-trackable-surfaces.md` with this
+shape:
+
+```markdown
+---
+reason: <one-line summary of why no surfaces were found>
+changed_paths:
+  - <path/to/file.ts>
+  - <path/to/other.py>
+classification: refactor-only | tooling-only | tests-only | docs-only | mixed-non-product
+---
+
+# No trackable surfaces
+
+This diff was reviewed against the Phase 0 product-surface gate. No changed
+file introduces a new user-reachable execution path that would warrant
+instrumentation.
+
+## What we looked at
+
+<bulleted summary, one line per file, naming the refactor pattern that
+applied — e.g. "src/utils/format.ts: constant relocation (PREFIX moved to
+module scope, no behaviour change)">
 ```
-# .amplitude/no-trackable-surfaces.md
-reason: "<one-sentence explanation tied to what you actually read in the
-  diff — cite specific files / behaviors, not just path patterns>"
-files_reviewed:
-  - path: <path 1>
-    signal: <what you saw when you read it — "unit test", "CLI utility
-      called only from CI", "Dockerfile", etc.>
-  - path: <path 2>
-    signal: <...>
-```
 
-Then STOP. Do not proceed to diff-intake or any downstream skill. Do not
-write `.amplitude/events.json`. The orchestrator flow (pr_agent.yaml /
-init_agent.yaml) reads this marker file and posts a short comment on the
-original PR explaining that no instrumentation is proposed, instead of
-opening a prepare PR with events that would never fire.
+Then STOP. Do not write `.amplitude/events.json`. Do not run Step 0 onward.
+The orchestrator inspects the marker and posts the "no trackable surfaces"
+comment on the original PR.
 
 ### Step 0: Capture intent
 

--- a/plugins/amplitude/skills/taxonomy/SKILL.md
+++ b/plugins/amplitude/skills/taxonomy/SKILL.md
@@ -594,80 +594,87 @@ Default lookback: **180 days**.
 
 # Available Tools
 
-## Event Discovery & Metadata
+These are the actual Amplitude MCP server tools available for taxonomy work. Tool names must match exactly.
 
-### list_events
-Lightweight listing of all events ordered by importance descending. Supports pagination with `offset` and `limit`. Best for broad taxonomy scans and governance audits.
+## Context
 
-**Tool reference**: `langley.tools.taxonomy.combined_metadata.CombinedMetadataTool.list_events`
+### `get_context`
+Get information about the current user, organization, and accessible projects. Call this first to discover project IDs.
 
-### get_relevant_events
-Semantic + text hybrid search for events matching a description. Use multiple phrasings in parallel to disambiguate.
+### `get_project_context`
+Get project-specific settings: time zone, currency, session definition, AI context. Use to understand project configuration before making changes.
 
-**Parameters:**
-- `query`: Natural language description
-- `categories`: Metadata categories (e.g., `['basic', 'ai_descriptions', 'metrics']` — up to 100 events)
+### `search`
+Search for charts, dashboards, notebooks, experiments, events, properties, cohorts, and other Amplitude content. Use this before `get_events` to find the event you're looking for.
 
-**Tool reference**: `langley.tools.taxonomy.combined_metadata.CombinedMetadataTool.get_relevant_events`
+### `get_workspace_settings`
+Get workspace settings including approval workflow status. Check before writing to the default branch — when `approvalWF` is "Required", the user must create a non-default branch first.
 
-### get_event_metadata
-Deep metadata for specific events: properties, usage, relationships, importance, content associations.
+## Event Discovery
 
-**Parameters:**
-- `event_names`: List of events to analyze
-- `categories`: e.g., `['basic', 'ai_descriptions', 'metrics', 'importance', 'content_usage', 'properties', 'relationships']` — up to 25 events with heavy categories
+### `get_events`
+Retrieve events from a project with filtering by event types, limit, and cursor pagination. Returns full event objects including category and active status.
 
-**Tool reference**: `langley.tools.taxonomy.combined_metadata.CombinedMetadataTool.get_event_metadata`
+- Use `search` first to find the event you're looking for.
+- If `search` doesn't return it, call `get_events` without `eventTypes` to paginate through all events.
+- If you know exact event type names, pass them via `eventTypes` for precise lookup.
 
-## Property Discovery & Metadata
+### `get_custom_or_labeled_events`
+Retrieve custom events, labeled (autotrack) events, or both from a project.
 
-### list_properties / get_relevant_properties / get_property_metadata
-Discover and analyze properties with the same semantic search pattern as events.
+- `eventKind: "_all"` — both custom and labeled events (default).
+- `eventKind: "custom"` — non-autotrack custom events only.
+- `eventKind: "labeled"` — labeled/autotrack events only.
+- Returns `isAutotrack` flag, definition, and `flattenedDefinition` (source event lists).
 
-**Tool references**:
-- `langley.tools.taxonomy.combined_metadata.CombinedMetadataTool.list_properties`
-- `langley.tools.taxonomy.combined_metadata.CombinedMetadataTool.get_relevant_properties`
-- `langley.tools.taxonomy.combined_metadata.CombinedMetadataTool.get_property_metadata`
+### `get_transformations`
+Retrieve data transformations (merge events, merge properties, map property values) from a project. Use to audit data cleaning rules.
 
-### get_property_stats
-Live property statistics from the metrics API. Verify volume and recent usage before recommending.
+## Property Discovery
 
-**Tool reference**: `langley.tools.taxonomy.combined_metadata.CombinedMetadataTool.get_property_stats`
+### `get_properties`
+Retrieve properties from a project's taxonomy. Use `propertyType` to select which kind:
 
-### get_property_values
-Retrieve enumerable values for a property. Validate cardinality and value consistency.
+| `propertyType` | What it returns | Key params |
+|---|---|---|
+| `event` | Properties for a specific event type | `eventType` (required) |
+| `user` | User-level properties | `sources`, `name` |
+| `derived` | Computed/formula properties | `derivedPropertyType`, `names` |
+| `group` | Group properties (e.g., company_name, plan_tier) | `groupTypes` |
+| `lookup` | CSV lookup table properties | `configurationFilter`, `lookupTableName` |
+| `channel` | Traffic source channel properties | `names` |
+| `persisted` | Event-to-user persisted properties | `names` |
 
-**Tool reference**: `langley.tools.taxonomy.combined_metadata.CombinedMetadataTool.get_property_values`
+All property types except `event` support limit/cursor pagination.
 
-## Context & Validation
+## Metadata Updates
 
-### search_knowledge_base
-Search organization-specific knowledge base for business context, tracking plans, data dictionaries, and naming conventions.
+### `update_event`
+Update event metadata: descriptions, display names, categories, official status, and event names. Operates on the tracking plan.
 
-**Tool reference**: `langley.tools.knowledge.bedrock_kb_tool.BedrockKnowledgeBaseTool.search_knowledge_base`
+- Event type keys must match the event `name` exactly (case-sensitive) — not the `displayName`. Resolve via `get_events` first if needed.
+- Supports `branchId` or `branchName` to target non-default branches.
+- Do not overwrite existing descriptions — append additional context instead.
+- Never update bracket-prefixed or vendor-prefixed events (`[Amplitude]`, `[Experiment]`, etc.) unless explicitly requested.
+- Requires "Update Tracking Plan" permission.
 
-### documentation_question
-Answer Amplitude product questions. Use before telling a user something is not feasible.
+### `update_properties`
+Update property metadata (description, official status, category, and/or name). Use `propertyType` to select which kind:
 
-**Tool reference**: Amplitude MCP tool `documentation_question`
+| `propertyType` | What it updates | Key params |
+|---|---|---|
+| `event` | Event property metadata (global or event-scoped) | `metadataScope`, `eventType` (when scope is `"event"`) |
+| `user` | User property metadata | `descriptions`, `isOfficial`, `categories`, `newNames` |
 
-### get_context
-Get user/org/project context. Discover all projects the user has access to.
+- Use `get_properties` first to verify property names and status before updating.
+- Requires "Update Tracking Plan" permission.
 
-**Tool reference**: Amplitude MCP tool `get_context`
+### `update_custom_or_labeled_events`
+Update descriptions, categories, names, official status, and/or definitions on custom or labeled events.
 
-## Safe Metadata Write Operations
-
-| Tool | Purpose |
-|------|---------|
-| `set_event_description` | Add/update event description |
-| `set_event_display_name` | Update event display name |
-| `set_event_category` | Assign event to a category |
-| `add_event_tags` | Add tags to an event |
-| `set_event_deprecated` | Mark event as deprecated |
-| `hide_event` | Hide from taxonomy (does not delete) |
-| `set_property_description` | Add/update property description |
-| `set_property_display_name` | Update property display name |
+- Only use when the user explicitly asks to update a "custom event" or "labeled event." For regular events, use `update_event`.
+- Definitions are **replaced in full**, not merged — pass the complete new source-event list.
+- Renaming will break chart references — always warn the user.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds an explicit **Phase 0 product-surface gate** to `plugins/amplitude/skills/add-analytics-instrumentation/SKILL.md`. The gate runs first for PR/Branch input and decides whether the diff adds a new user-reachable execution path. If not, the agent writes `.amplitude/no-trackable-surfaces.md` and stops — no prepare PR.

This replaces the prior _\"default to PROCEEDING when ambiguous\"_ bias (which currently lives in the langley `pr_agent.yaml` prompt) with a concrete heuristic: **\"is there evidence of a new user-reachable execution path? if not, the answer is no.\"**

### What's enumerated

Eleven refactor patterns explicitly route to `no-trackable-surfaces`, each with an example diff:

1. Constant / literal relocations *(includes the #37008-shape example: a constant moved from function-local to module scope)*
2. Renames (variable / function / type / file)
3. Type-only changes (TS types, Python hints, generics)
4. Formatting / whitespace
5. Code reorganization (file splits, helper extraction)
6. Comment / docstring / JSDoc edits
7. Dead-code deletion
8. Dependency / lockfile bumps
9. Build / config / tooling
10. Test-only diffs
11. Generated code

A complementary list of \"new user-reachable path\" signals (new exported handlers, new event-handler bindings, new fetch/RPC, new SDK call sites, etc.) tells the gate when to **open** so reviewers don't lose real surfaces.

### Why

[amplitude/amplitude#37008](https://github.com/amplitude/amplitude/pull/37008) shipped a phantom prepare PR because the agent moved a constant to module scope and Phase 0's bias-toward-proceeding waved it through. Reviewers closed the prepare PR; the agent learned nothing because Phase 0 thought it had done the right thing.

### Defense in depth

This is the prompt-layer fix. A separate change in langley adds a **post-hoc SDK-call-site detector** in `commit_and_push` that scans the agent's added/modified lines for `\\.track\\(`, `\\.identify\\(`, `\\.setUserId\\(`, `\\.setGroup\\(`, `\\.groupIdentify\\(` — and skips opening the prepare PR if zero are found. Either layer alone catches the #37008 case; both layers catch future regressions in one or the other.

## Test plan

- [x] `grep` SKILL.md for the new section: `Phase 0: Product-surface gate`, `Refactor patterns that route to no-trackable-surfaces`, all eleven enumerated patterns present, marker-file template included.
- [x] Verify the #37008-shape example diff is in the \"Constant or literal relocations\" example.
- [x] Verify the bias-toward-proceeding language is gone — replaced with \"Do not default to proceeding\".
- [ ] (downstream) End-to-end: pair with the langley post-hoc detector against a refactor-only PR; confirm the agent posts the \"no surfaces\" comment and does not open a prepare PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)