### PR TITLE
[skill] Tighten Phase 0 product-surface gate: refactor-only diffs → no-trackable-surfaces

### DIFF
--- a/plugins/amplitude/skills/add-analytics-instrumentation/SKILL.md
+++ b/plugins/amplitude/skills/add-analytics-instrumentation/SKILL.md
@@ -100,20 +100,68 @@ themselves — a single ambiguous file with positive signal still proceeds):
 - The change is a schema migration with no accompanying code touching a
   user surface.
 - The change is documentation / markdown only.
+- **The diff is a pure refactor of code that already runs**, with no new
+  user-reachable execution path introduced. Concretely, all of these
+  patterns are "no new surface" and route to the marker file:
+  - **Constant or symbol moved to module-level scope** (or out of it)
+    without changing how / when it is read. Hoisting a literal out of a
+    function body so it can be reused is internal plumbing — a user did
+    not gain a new surface, the code that runs in response to a user is
+    unchanged. (See amplitude/amplitude#37008 — the canonical false
+    positive that motivated this rule.)
+  - **Pure rename** of a function, class, variable, file, or directory
+    when call sites are mechanically updated and behavior is unchanged.
+  - **File move / split / consolidation** that re-homes existing code
+    without touching its semantics — including extracting a helper into
+    its own module, or merging two helpers into one.
+  - **Type-only changes**: adding type annotations, narrowing a generic,
+    converting `any` to a concrete type, reshuffling a function
+    signature when no callers behave differently at runtime.
+  - **Formatting-only churn**: whitespace, import ordering, lint
+    autofix, prettier / black / gofmt runs, comment edits, doc-string
+    rewrites.
+  - **Dead-code removal**: deleting an unreachable branch, an unused
+    helper, a deprecated symbol with no remaining callers.
+
+  A refactor of already-instrumented product code is still "no new
+  surface": the existing `track(` call sites are untouched, there is no
+  new event to fire, and a tracking-plan diff would be empty.
 
 **Decision rule**
 
-- If ANY changed file is user-reachable AND produces a user-perceptible
-  effect (positive signal and no overwhelming reason to think otherwise)
-  → **proceed** with the full pipeline.
-- If EVERY changed file you read lacks a user-reachable path and a
-  user-perceptible effect → **stop** and write the marker file below.
-- If you genuinely cannot tell — the diff is small, the context is
-  ambiguous, the imports are unfamiliar — **default to proceeding**. The
-  cost of a false positive (a prepare PR the reviewer closes with one
-  click) is much lower than the cost of a false negative (missing real
-  user surfaces the team relies on). The gate exists to filter *clear*
-  non-product work, not to second-guess every PR.
+The question is not "is this code on a user-reachable path" — most files
+in a product app are. The sharper question is **"does THIS DIFF
+introduce a new user-reachable execution path that is not already
+instrumented?"** Refactors of already-running product code do not, even
+though the surrounding file is a product surface.
+
+- If the diff **introduces a new user-reachable execution path** —
+  concretely, ANY of: a new event handler attached to a user-interactive
+  element, a new route / endpoint / IPC handler / CLI subcommand, a new
+  page / view / screen / component entry point, a new async/await call
+  from a product surface into product code that was not there before, a
+  newly exported function reached from product UI, or a newly added
+  `track(` call site (or modification to an existing one) → **proceed**
+  with the full pipeline.
+- If EVERY changed file is non-product (test, CI utility, harness code,
+  infrastructure, schema-only, docs) → **stop** and write the marker
+  file below.
+- If the diff is **a pure refactor** of already-running product code —
+  any of the patterns from the "Strong negative signals" refactor list
+  above (constant relocation, rename, file move, type-only change,
+  formatting churn, dead-code removal) — there is **no new
+  user-reachable execution path**, so → **stop** and write the marker
+  file below. A refactor of a product surface still counts as no new
+  surface; the existing instrumentation is untouched and there is no
+  new behavior to track.
+- If you genuinely cannot decide between proceed and stop — the diff is
+  small, ambiguous, the imports are unfamiliar — **stop**. A reviewer
+  can always re-run the agent against the PR if they actually want
+  events; a prepare PR opened on internal plumbing wastes review time
+  and erodes trust in the gate. The earlier "default to proceeding when
+  ambiguous" rule produced exactly this failure mode in
+  amplitude/amplitude#37008 — a module-level constant relocation the
+  agent treated as instrumentable product work.
 
 **When stopping**, write a single marker file:
 


### PR DESCRIPTION
## Summary

Tighten Phase 0 of `add-analytics-instrumentation` so refactor-only diffs
(constant moves, renames, file moves, type-only changes, formatting churn,
dead-code removal) explicitly route to `.amplitude/no-trackable-surfaces.md`
and stop, instead of biasing toward proceeding when ambiguous.

## Why

The current Phase 0 prompt closes with:

> If you genuinely cannot tell — the diff is small, the context is
> ambiguous, the imports are unfamiliar — **default to proceeding**. The
> cost of a false positive (a prepare PR the reviewer closes with one
> click) is much lower than the cost of a false negative…

That bias trips false positives on internal-plumbing diffs. The canonical
example is amplitude/amplitude#37008 — the agent saw a constant moved to
module-level scope and opened a prepare PR even though **no new SDK call
sites were added**. Reviewers close those PRs by hand, which (a) wastes
review time and (b) erodes trust in the gate (the next legitimate prepare
PR gets a more skeptical read).

A post-hoc detector lands in parallel in langley as the load-bearing
safety net (it scans the prepare branch's diff for new `\.track\(` /
`\.identify\(` / `\.setUserId\(` / `\.setGroup\(` / `\.groupIdentify\(`
call sites in the agent's added/modified lines and skips
`create_pull_request` if zero are added). This PR is the prompt-side
defense: stop the agent earlier so the detector rarely has to fire.

## What changed

`plugins/amplitude/skills/add-analytics-instrumentation/SKILL.md` only.

1. **Reframed the central question** from "is this code on a
   user-reachable path" (most code in a product app is) to
   **"does THIS DIFF introduce a NEW user-reachable execution path that
   isn't already instrumented?"** — a sharper gate that distinguishes
   "this file is a product surface" from "this diff adds a product
   surface."

2. **Added concrete refactor patterns to the strong-negative signals
   list**, each with a one-line reason it's a no-surface change:
   - Constant or symbol moved to module-level scope (cites
     amplitude/amplitude#37008 inline as the canonical false positive).
   - Pure rename of function / class / variable / file / directory.
   - File move / split / consolidation.
   - Type-only changes (annotations, `any` → concrete, signature
     reshuffles with no runtime delta).
   - Formatting-only churn (whitespace, lint autofix, prettier / black /
     gofmt, comment / doc-string edits).
   - Dead-code removal.

   Plus an explicit clarification that **a refactor of
   already-instrumented product code is still "no new surface"** — the
   existing `track(` call sites are untouched, no new event to fire.

3. **Replaced the "default to proceeding when ambiguous" decision rule**
   with a four-bullet ladder:
   - Diff introduces a new user-reachable execution path → proceed.
     Concrete enumeration: new event handler, new route / endpoint /
     IPC handler / CLI subcommand, new page / view / screen / component
     entry point, new async/await call from a product surface, newly
     exported function reached from product UI, newly added / modified
     `track(` call site.
   - Every changed file is non-product (test, CI utility, harness,
     infra, schema-only, docs) → stop.
   - Diff is a pure refactor of already-running product code → stop.
   - Genuinely ambiguous → **stop**, not proceed. Reviewer can re-run
     the agent if they actually want events. (Cites #37008 as the
     concrete failure mode of the old bias.)

## Acceptance

- [x] `.agents/skills/add-analytics-instrumentation/SKILL.md` (here:
  `plugins/amplitude/skills/add-analytics-instrumentation/SKILL.md`)
  contains the tightened Phase 0 with the new "no new user-reachable
  execution path → no-trackable-surfaces" rule replacing the old
  "default to proceeding" bias.
- [x] No-surfaces examples list explicitly enumerates: constant moves,
  renames, file moves, type-only changes, formatting-only changes,
  dead-code removal.
- [x] Diff touches only `SKILL.md` — no incidental drift.

## Base branch

Targets `coding-agent/init-mode-skills` (the branch that introduced
Phase 0 — `main` does not have Phase 0 yet, so a `main`-targeted PR
would have to re-introduce the entire section). When
`coding-agent/init-mode-skills` lands on main, this tightening rolls in
with it.

## Test plan

- [x] `gh pr diff <number> --repo amplitude/mcp-marketplace` shows ONLY
  `plugins/amplitude/skills/add-analytics-instrumentation/SKILL.md`.
- [ ] Reviewer reads the new Phase 0 against an amplitude/amplitude#37008-shape
  diff (constant moved to module-level scope, no new track calls) and
  confirms the decision rule clearly routes to the marker file.
- [ ] Reviewer reads the new Phase 0 against a real instrumentation diff
  (new component + new `track('Foo Clicked', …)`) and confirms the
  decision rule still routes to **proceed**.