### PR TITLE
docs: add discover-analytics-patterns prerequisite to add-analytics-instrumentation

### DIFF
--- a/plugins/amplitude/skills/add-analytics-instrumentation/SKILL.md
+++ b/plugins/amplitude/skills/add-analytics-instrumentation/SKILL.md
@@ -21,6 +21,25 @@ You are the orchestrator for the analytics instrumentation pipeline. Your job is
 to figure out what the user wants to instrument, gather the relevant code, and
 run the pipeline to produce a tracking plan.
 
+## Before you start: discover existing patterns
+
+Before producing a tracking plan, invoke the `discover-analytics-patterns` skill
+to identify how analytics is already wired in this codebase — custom wrappers
+(`trackEvent()`, `useAnalytics()`, `ampli.*` typed methods), helper modules,
+and naming conventions. Two reasons:
+
+1. The downstream `instrument-events` and `discover-event-surfaces` skills both
+   depend on its `event_naming_convention` and `property_naming_convention`
+   outputs (do not redefine them).
+2. **If the codebase already has tracking calls — even via a wrapper — REUSE
+   that wrapper when you instrument new events.** Reimplementing on top of the
+   raw SDK when a wrapper exists is the most common failure mode customers
+   report; the wrapper is what their other engineers will recognize and grep
+   for.
+
+Capture the wrapper / pattern names so the final tracking plan and the setup
+report can reference them by name.
+
 ## Pipeline
 
 ### Step 0: Capture intent


### PR DESCRIPTION
## Summary

- Adds a "Before you start: discover existing patterns" pointer to the top of `add-analytics-instrumentation/SKILL.md` so the orchestrator runs pattern discovery before producing a tracking plan.
- Calls out the most common customer failure mode: reimplementing on top of the raw SDK when a `trackEvent()` / `useAnalytics()` / `ampli.*` wrapper already exists in the codebase. REUSE wins because the wrapper is what the rest of the team recognizes and greps for.
- Matches the wizard-side commandment that landed in [amplitude/wizard#585](https://github.com/amplitude/wizard/pull/585) (`src/lib/commandments.ts`) — the wizard pre-stages this skill, so without an upstream change every refresh would clobber the wizard's local edit. Landing it here gives every other consumer (Cursor, Codex, anyone running the marketplace plugin directly) the same benefit.

## Customer context

Lendi (Jamie Lim) reported that the Amplitude wizard reimplemented every event on top of `@amplitude/analytics-browser` even though their codebase already had a `trackEvent()` wrapper. Root cause: nothing in the orchestrator skill told the agent to run pattern discovery first.

## Files touched

- `plugins/amplitude/skills/add-analytics-instrumentation/SKILL.md`

## Test plan

- [ ] Skill text reads cleanly when rendered (markdown structure intact, no broken cross-references).
- [ ] Run `add-analytics-instrumentation` against a sample repo with an existing `trackEvent()` wrapper and confirm the agent loads `discover-analytics-patterns` before proposing events.
- [ ] No assertion changes needed in mcp-marketplace's own test suite — this is documentation-only.