### PR TITLE
[diff-intake] use three-dot diff for PR/branch comparison (DMT-450)

### DIFF
--- a/plugins/amplitude/skills/diff-intake/SKILL.md
+++ b/plugins/amplitude/skills/diff-intake/SKILL.md
@@ -23,13 +23,27 @@ precise — no prose around the YAML block.
 Fetch the list of changed files from the source, then categorize each one.
 
 ### Fetching changes
-- **PR URL**
+- **PR URL** (preferred — authoritative; doesn't depend on the local sandbox's refs)
 `gh pr view <number-or-url>`
 `gh pr view <pr-number> --json files --jq '.files[] | "\(.path)\t+\(.additions) -\(.deletions)\t"'`
-- **Branch comparison**
-`git log <main|master>..<branch>`
-`git diff --stat <main|master>..<branch>`
+- **Branch comparison** — **use three-dot (`...`), not two-dot (`..`)**:
+`git log <main|master>...<branch>`
+`git diff --stat <main|master>...<branch>`
 - **Ambiguous mention** (PR number, branch name): infer the right form and fetch without asking unless auth fails.
+
+> **Why three-dot.** `git diff A..B` returns the symmetric difference between
+> the two refs — every file that differs in either direction. When the branch
+> is behind master (stale rebase, never rebased, master moved forward after
+> the branch was created), the two-dot diff includes files master added that
+> the branch never touched, and the agent reads them as "branch removed
+> these" and proposes instrumenting them. `git diff A...B` returns only the
+> changes B added since its merge-base with A — that is, "what this PR
+> contributed." Always use three-dot when a PR or branch is the unit of
+> work. Real incident: amplitude/javascript#113318 (a 1-file test-only PR)
+> ended up with a prepare PR proposing instrumentation for an unrelated
+> GitHub-settings page because master had added tracking there after the
+> branch was created — the two-dot diff exposed it as a phantom "removal."
+> (Linear: DMT-450.)
 
 ### Categorize files
 Assign each file to a category based on its path:
@@ -47,12 +61,12 @@ Read every single **Core Logic** file and create the file summary map.
 Only process and include **Core Logic** files.
 
 ### Fetching detailed diffs
-- **PR**
+- **PR** (preferred — `baseRefOid` pins the merge-base explicitly so the diff doesn't drift if the sandbox's local `main` is stale)
 `gh pr view <number-or-url> --json baseRefOid,headRefOid`
-Using the response, get a detailed diff
+Using the response, get a detailed diff:
 `git diff <baseRefOid>...<headRefOid> -- <file1> <file2> <file_n>`
-- **Branch comparison**
-`git diff main..feature/foo  -- <file1> <file2> <file_n>`
+- **Branch comparison** — **three-dot, not two-dot** (see "Why three-dot" above):
+`git diff main...feature/foo -- <file1> <file2> <file_n>`
 
 ### For each file, record
 - `summary` — 2-line summary of what changed


### PR DESCRIPTION
## What

`plugins/amplitude/skills/diff-intake/SKILL.md` now prescribes **three-dot** diff (`master...branch`) for every branch-comparison invocation, instead of the **two-dot** (`master..branch`) form it had. Adds a "Why three-dot" callout citing the real incident so this doesn't regress.

## Why

[DMT-450](https://linear.app/amplitude/issue/DMT-450/diff-intake-skill-uses-two-dot-diff-against-a-stale-branch-proposes). When a branch is behind master (stale rebase / never rebased), `git diff master..branch` returns the symmetric difference between the two refs — including files that master added but the branch never touched. The agent reads those as "the branch removed this tracking" and dutifully "reintroduces" instrumentation for code completely unrelated to the actual PR.

Real incident on amplitude/javascript: PR [#113318](https://github.com/amplitude/javascript/pull/113318) was a 1-file test-only change in `packages/session-replay-ui/`. The bot's prepare PR [#114174](https://github.com/amplitude/javascript/pull/114174) proposed two events on `packages/lightning/src/components/GithubSettings/GithubSettingsPage.tsx` — a completely unrelated package — because master had added tracking to that file after the branch was created. The agent's own transcript used the word **"reintroduced"** when proposing the instrumentation, which was the smoking gun. Trace: session `26328a6a-95a1-4057-8aa8-f176cfdbe81a`, handoff `5bd200b8-bfca-42cf-86c0-60eb71880e9f`.

## Validation

Reproduced the bug and verified the fix on a synthetic repo with the same topology (branch behind master + master added tracking + master had unrelated work):

| Command | Files returned |
|---|---|
| `git diff master..SR-4158 --name-only` (old) | `GithubSettingsPage.tsx`, `admin-config.ts`, `session-replay-override.test.ts` (3 — wrong, includes master's adds) |
| `git diff master...SR-4158 --name-only` (new) | `session-replay-override.test.ts` (1 — correct, only what the branch added) |

The new commands match what `gh pr view --json files` returns (which is the authoritative source we now also recommend when a PR URL is available).

## Belt-and-suspenders

Cover-commit landed on `coding-agent/init-mode-skills` (working branch) as `7be8a21` so live agent runs benefit immediately — they don't have to wait for this PR to merge into `main`.

## Linked

- Linear: [DMT-450](https://linear.app/amplitude/issue/DMT-450/diff-intake-skill-uses-two-dot-diff-against-a-stale-branch-proposes)
- Originating Slack: https://amplitude.slack.com/archives/C0AQP1DBYJU/p1778716223236319
- Source PR: amplitude/javascript#113318
- Bot's bad prepare PR: amplitude/javascript#114174