### PR TITLE
chore: add repository governance files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Default maintainers for marketplace manifests, plugin metadata, skills, and agents.
+* @amplitude/mcp @amplitude/amplitude-mcp
+
+# Changes to automation and marketplace entrypoints should get explicit maintainer review.
+.github/workflows/* @amplitude/mcp @amplitude/amplitude-mcp
+.agents/** @amplitude/mcp @amplitude/amplitude-mcp
+.claude-plugin/** @amplitude/mcp @amplitude/amplitude-mcp
+.cursor-plugin/** @amplitude/mcp @amplitude/amplitude-mcp
+
+# Published and experimental plugin content.
+plugins/amplitude/** @amplitude/mcp @amplitude/amplitude-mcp
+plugins/amplitude-experimental/** @amplitude/mcp @amplitude/amplitude-mcp

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Amplitude, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+Report potential vulnerabilities through Amplitude's security disclosure process:
+
+- Email: security@amplitude.com
+- Security page: https://amplitude.com/security
+
+Include as much detail as possible, including the affected plugin, skill, manifest, or MCP server configuration, reproduction steps, and any known impact.
+
+We will review reports promptly and coordinate fixes or disclosures as appropriate.


### PR DESCRIPTION
## Summary
- Add CODEOWNERS coverage for marketplace manifests, workflows, plugins, skills, and agents.
- Add MIT license file to match the README's stated license.
- Add a security policy with private vulnerability reporting guidance.

## Test plan
- Not run; documentation and repository metadata only.