### PR TITLE
feat(skills): add send-first-event

### DIFF
--- a/plugins/amplitude/skills/send-first-event/SKILL.md
+++ b/plugins/amplitude/skills/send-first-event/SKILL.md
@@ -6,7 +6,8 @@ description: >
   Amplitude", "add Amplitude to this app", "add analytics to my app", "get my first event
   into Amplitude", or "instrument this app with Amplitude" and the repo has no Amplitude
   tracking yet. If tracking already exists, use discover-analytics-patterns or
-  add-analytics-instrumentation instead. Stops at one verified event.
+  add-analytics-instrumentation instead. Stops at one verified event. Requires the
+  Amplitude MCP server (key retrieval + server-side event verification).
 ---
 
 # send-first-event
@@ -24,12 +25,12 @@ Nothing more — no tracking plan, no event taxonomy, no dashboards.
 > **Conflict rule:** if the user's instructions conflict with anything this skill does —
 > in either direction — say so explicitly and let them decide. Never silently override.
 
-> **Amplitude MCP (if connected):** when an Amplitude MCP server is available in this
-> environment, prefer its tools where a step offers an **[MCP path]** — programmatic key
-> retrieval and server-side ingestion verification replace the manual asks. Every step
-> still works without it via the ask-the-user path. Use only tools the connected server
-> actually exposes — never invent tool names; if the tool a step expects isn't there,
-> take the no-MCP path.
+> **Requires the Amplitude MCP.** This skill assumes an Amplitude MCP server is connected
+> — programmatic key retrieval and server-side ingestion verification are how it works.
+> No Amplitude MCP in this environment → **stop before making any changes**: point the
+> user at the Amplitude MCP install docs (https://amplitude.com/docs → Amplitude MCP) and
+> resume once it's connected. Use only tools the connected server actually exposes —
+> never invent tool names; where a specific tool is missing, the step names its fallback.
 
 ## Step 0: Preflight — is Amplitude already here?
 
@@ -61,52 +62,38 @@ first match, top-down:
   env access — but if you cannot confidently map the client boundary or the env access,
   stop and say so instead of improvising. Never invent SDK option names.
 
-## Step 2: Get the API key, data center, and Setup page
+## Step 2: Project, data center, and key timing
 
-**[MCP path]** — with the Amplitude MCP connected, skip the questions below, with three
-guards:
+Settle three things via the MCP — each with its fallback when the context doesn't carry
+the answer:
 
 - **Project:** state the target project **by name** and get a yes — even when only one is
   selected. A silently-wrong project passes Step 7's ingestion check while the user's
-  real project stays empty.
+  real project stays empty. (No project yet → the user signs up / creates one first.)
 - **Data center:** read EU/US from the project's context. If the context doesn't clearly
-  show it, don't guess — ask the user exactly as the no-MCP path does; wrong region =
-  events silently never arrive.
+  show it, don't guess — ask the user (quick check: their logged-in URL —
+  `app.eu.amplitude.com` is EU, `app.amplitude.com` is US). Settle this **before any code
+  is generated** — it changes the init options in Step 4, and events sent to the wrong
+  endpoint never arrive.
 - **Setup page:** take the project's Setup-page URL from the MCP context if it exposes
-  one; otherwise collect the org slug and build the link as below — Step 7 uses it.
+  one; otherwise ask for the org's **URL slug** — the segment right after `/analytics/`
+  in their logged-in Amplitude URL (not the org display name; the two can differ) — and
+  build it (Step 7 uses it):
+
+  ```
+  https://app.amplitude.com/analytics/<slug>/setup      # US
+  https://app.eu.amplitude.com/analytics/<slug>/setup   # EU
+  ```
 
 **Key timing:** if the server exposes a dedicated key-retrieval tool, defer the key fetch
-to Step 4 and retrieve it just-in-time — human round-trips are expensive, so the no-MCP
-path front-loads its questions; tool calls are cheap, so fetch at the moment of use. If
-there is no dedicated key tool (or it's unclear which tool that is), do **not** defer:
-ask the user for the key now, exactly as below — and never use a generic data/query tool
-to obtain a key. Either way the key gets placed per **Key placement** at the end of this
-step. Then go to Step 3.
+to Step 4 and retrieve it just-in-time — tool calls are cheap, so fetch at the moment of
+use. If there is no dedicated key tool (or it's unclear which tool that is), ask the user
+for their **project API key** now — it's on the Setup page above — and never use a
+generic data/query tool to obtain a key. Either way the key gets placed per
+**Key placement** below. Then go to Step 3.
 
-**[No MCP — ask the user]:**
-
-Ask the user for their **project API key** — it's on their Amplitude **Setup page** (if they
-have no project yet: sign up, create one, the Setup page appears after that).
-
-Also ask which **data center** their project is on — **EU or US**. Quick check: if their
-Amplitude URL when logged in is `app.eu.amplitude.com`, it's EU; `app.amplitude.com` is US.
-Settle this **now, before any code is generated** — it changes the init options in Step 4,
-and events sent to the wrong endpoint never arrive.
-
-To point them at the Setup page directly, ask for their org's **URL slug** — the segment
-right after `/analytics/` in their Amplitude URL when logged in (not the org display name;
-the two can differ) — and build the link:
-
-```
-https://app.amplitude.com/analytics/<slug>/setup      # US
-https://app.eu.amplitude.com/analytics/<slug>/setup   # EU
-```
-
-Have the user confirm that URL loads. If they don't know the slug, have them log in at the
-data center's host URL and open Setup from there.
-
-**Key placement — BOTH paths, follow the repo's convention** (however the key was
-obtained — MCP fetch or user-provided — it lands the same way):
+**Key placement — follow the repo's convention** (however the key was obtained — MCP
+fetch or user-provided — it lands the same way):
 
 - **Repo already uses env machinery** (existing `.env*` files or framework env config) →
   put the key in the env file the repo already uses (create it if missing, keep existing
@@ -163,14 +150,14 @@ npm install @amplitude/unified@^1.1.20     # browser branches
 npm install @amplitude/analytics-node@^1   # Node backend branch
 ```
 
-**[MCP path, deferred key]** — fetch the key now with the server's dedicated
+**[Deferred key]** — fetch the key now with the server's dedicated
 key-retrieval tool and place it per Step 2's **Key placement** rules (env file +
 missing-key guard, or hardcoded constant + comment) **before** writing the init module —
 the snippets below read the key from wherever you placed it, and a fetched-but-unplaced
 key means the guard fires and analytics is silently disabled. If you wrote an env file
 while a dev server was already running, note that it must be restarted — env vars load
-at startup. If the fetch fails or returns no key, fall back to asking the user (Step 2's
-no-MCP ask) — the key must never be silently absent.
+at startup. If the fetch fails or returns no key, fall back to asking the user for the
+key (it's on their Setup page) — the key must never be silently absent.
 
 Initialize **once**, at the app entry. The file paths and placement below are an example
 integration — adapt them to this repo's conventions, and match the repo's language: the
@@ -317,7 +304,7 @@ The source of truth is **observed ingestion** — either the MCP's server-side c
 user's in-app confirmation. Never your own assumption, and never the network tab alone:
 a request that left the browser is not an event that landed.
 
-**[MCP path]** — once the app runs and the chosen event has fired (load/mount events fire
+**Primary — the ingestion check:** once the app runs and the chosen event has fired (load/mount events fire
 on start; interaction events need the action performed — ask the user to do it, or, only
 with their permission, perform it **through the running app's real flow**; never by
 calling `track()` or the HTTP API directly, which would confirm an event the app didn't
@@ -330,10 +317,11 @@ checklist flip themselves — if you have no Setup URL, the ingestion check is t
 skip the pointer. Tool shows nothing (or only autocapture) after ~a minute → fall through
 to the debug list below; do not claim success.
 
-**[No MCP]** — have the user start the app and watch the **checklist on their Amplitude
-Setup page** (the `/setup` URL built in Step 2). It flips to confirmed the moment any
-event arrives (usually seconds) — that proves *something* landed. The specific proof is
-their **chosen event name** showing up in the project's live event stream (the Setup
+**Fallback — the server exposes no ingestion-check tool** (it may be gated or not rolled
+out to this org): have the user start the app and watch the **checklist on their
+Amplitude Setup page** (the `/setup` URL from Step 2). It flips to confirmed the moment
+any event arrives (usually seconds) — that proves *something* landed. The specific proof
+is their **chosen event name** showing up in the project's live event stream (the Setup
 page's event feed). Both together = done. **Do not claim success before the user
 confirms.**
 
@@ -376,9 +364,10 @@ Audit this list before your final message — every box, honestly:
 - [ ] Region correct for their data center.
 - [ ] Key placed per the repo's convention — env file + missing-key guard, or hardcoded +
       explanatory comment — and never silently absent.
-- [ ] The landing is confirmed — by the MCP ingestion check (cite the tool result), or by
-      the user (checklist flip plus their event name in the stream). Without the MCP you
-      cannot observe this yourself; if unconfirmed either way, say so and stop.
+- [ ] The landing is confirmed — by the ingestion check (cite the tool result), or by
+      the user (checklist flip plus their event name in the stream). Without the
+      ingestion-check tool you cannot observe this yourself; if unconfirmed either way,
+      say so and stop.
 
 Anything unchecked → report it plainly. Never claim completion over an unchecked box.
 
@@ -388,9 +377,9 @@ Once the landing is confirmed (the last **Complete when** box — not before), o
 their result: **"Your `<chosen event>` landed, and autocapture is collecting real
 usage alongside it."** (Node backend: their event landed — no autocapture claim.)
 
-Then one default next step: if the Amplitude MCP is connected, offer to build a first chart
-of their chosen event over time via the create-chart skill — a modest smoke-test of their
-new data. No MCP → point them at the chart builder in the Amplitude UI.
+Then one default next step: offer to build a first chart of their chosen event over time
+via the create-chart skill — a modest smoke-test of their new data (if that skill isn't
+available here, point them at the chart builder in the Amplitude UI).
 
 If the key is hardcoded: when you set up environments or deploys, move it to an env var
 (and consider per-environment projects).

--- a/plugins/amplitude/skills/send-first-event/SKILL.md
+++ b/plugins/amplitude/skills/send-first-event/SKILL.md
@@ -63,13 +63,25 @@ first match, top-down:
 
 ## Step 2: Get the API key, data center, and Setup page
 
-**[MCP path]** — with the Amplitude MCP connected, skip the questions below: confirm
-which Amplitude **project** to target (ask only if ambiguous — e.g. the MCP context shows
-several), read the **data center** from that project's context, and **defer the key fetch
-to Step 4** — retrieve it just-in-time with the MCP's key tool when you write the init
-module. Human round-trips are expensive, so the no-MCP path front-loads its questions;
-tool calls are cheap, so the MCP path fetches at the moment of use instead. Then go to
-Step 3.
+**[MCP path]** — with the Amplitude MCP connected, skip the questions below, with three
+guards:
+
+- **Project:** state the target project **by name** and get a yes — even when only one is
+  selected. A silently-wrong project passes Step 7's ingestion check while the user's
+  real project stays empty.
+- **Data center:** read EU/US from the project's context. If the context doesn't clearly
+  show it, don't guess — ask the user exactly as the no-MCP path does; wrong region =
+  events silently never arrive.
+- **Setup page:** take the project's Setup-page URL from the MCP context if it exposes
+  one; otherwise collect the org slug and build the link as below — Step 7 uses it.
+
+**Key timing:** if the server exposes a dedicated key-retrieval tool, defer the key fetch
+to Step 4 and retrieve it just-in-time — human round-trips are expensive, so the no-MCP
+path front-loads its questions; tool calls are cheap, so fetch at the moment of use. If
+there is no dedicated key tool (or it's unclear which tool that is), do **not** defer:
+ask the user for the key now, exactly as below — and never use a generic data/query tool
+to obtain a key. Either way the key gets placed per **Key placement** at the end of this
+step. Then go to Step 3.
 
 **[No MCP — ask the user]:**
 
@@ -93,7 +105,8 @@ https://app.eu.amplitude.com/analytics/<slug>/setup   # EU
 Have the user confirm that URL loads. If they don't know the slug, have them log in at the
 data center's host URL and open Setup from there.
 
-**Key placement — follow the repo's convention:**
+**Key placement — BOTH paths, follow the repo's convention** (however the key was
+obtained — MCP fetch or user-provided — it lands the same way):
 
 - **Repo already uses env machinery** (existing `.env*` files or framework env config) →
   put the key in the env file the repo already uses (create it if missing, keep existing
@@ -149,6 +162,15 @@ major 1 (npm shown as the example):
 npm install @amplitude/unified@^1.1.20     # browser branches
 npm install @amplitude/analytics-node@^1   # Node backend branch
 ```
+
+**[MCP path, deferred key]** — fetch the key now with the server's dedicated
+key-retrieval tool and place it per Step 2's **Key placement** rules (env file +
+missing-key guard, or hardcoded constant + comment) **before** writing the init module —
+the snippets below read the key from wherever you placed it, and a fetched-but-unplaced
+key means the guard fires and analytics is silently disabled. If you wrote an env file
+while a dev server was already running, note that it must be restarted — env vars load
+at startup. If the fetch fails or returns no key, fall back to asking the user (Step 2's
+no-MCP ask) — the key must never be silently absent.
 
 Initialize **once**, at the app entry. The file paths and placement below are an example
 integration — adapt them to this repo's conventions, and match the repo's language: the
@@ -296,12 +318,17 @@ user's in-app confirmation. Never your own assumption, and never the network tab
 a request that left the browser is not an event that landed.
 
 **[MCP path]** — once the app runs and the chosen event has fired (load/mount events fire
-on start; interaction events need the action performed — ask the user to do it, or do it
-yourself only with their permission), call the MCP's ingestion-check tool for the chosen
-event name in the last few minutes. The tool confirming arrival = you have observed
-success and may say so, citing the tool result. Still point the user at their Setup page
-so they see the checklist flip themselves. Tool shows nothing after ~a minute → fall
-through to the debug list below; do not claim success.
+on start; interaction events need the action performed — ask the user to do it, or, only
+with their permission, perform it **through the running app's real flow**; never by
+calling `track()` or the HTTP API directly, which would confirm an event the app didn't
+produce), call the MCP's ingestion-check tool for the chosen event in the last few
+minutes — **against the same project confirmed in Step 2** (key and check scoped to
+different projects = false verdicts in both directions). Success = the tool's result
+naming **your chosen event** — generic autocapture arrivals are not proof it landed. With that observed you may claim success, citing the
+tool result; still point the user at their Setup page (URL from Step 2) so they see the
+checklist flip themselves — if you have no Setup URL, the ingestion check is the proof,
+skip the pointer. Tool shows nothing (or only autocapture) after ~a minute → fall through
+to the debug list below; do not claim success.
 
 **[No MCP]** — have the user start the app and watch the **checklist on their Amplitude
 Setup page** (the `/setup` URL built in Step 2). It flips to confirmed the moment any
@@ -316,8 +343,8 @@ If nothing shows within a minute:
    `serverZone: 'EU'` to the init options (Step 4).
 2. Restart the dev server — env vars load at startup.
 3. Try an incognito window / disable ad blockers — both silently drop analytics requests.
-4. Re-check the key (env file or init module) against the Setup page — no extra spaces or
-   quotes.
+4. Re-check the key (env file or init module) against the Setup page — or, on the MCP
+   path, re-fetch it with the key tool and compare — no extra spaces or quotes.
 
 ## Non-negotiables — enforce, don't ratify
 
@@ -334,7 +361,10 @@ These are exact, not suggestions. If anything deviates, fix it before moving on 
    has env machinery, hardcoded with the explanatory comment on bare repos. Either way it
    must never be silently absent.
 5. No events the user didn't choose — never invent a taxonomy.
-6. Never claim success you didn't observe.
+6. Never claim success you didn't observe. Observation means exactly two things: the MCP
+   ingestion check returning **the chosen event by name** in the confirmed project, or
+   the user confirming in their own UI. Nothing else counts — not the network tab, not
+   a passing build, not autocapture traffic.
 
 ## Complete when
 
@@ -354,7 +384,8 @@ Anything unchecked → report it plainly. Never claim completion over an uncheck
 
 ## Done
 
-Open with their result: **"Your `<chosen event>` landed, and autocapture is collecting real
+Once the landing is confirmed (the last **Complete when** box — not before), open with
+their result: **"Your `<chosen event>` landed, and autocapture is collecting real
 usage alongside it."** (Node backend: their event landed — no autocapture claim.)
 
 Then one default next step: if the Amplitude MCP is connected, offer to build a first chart

--- a/plugins/amplitude/skills/send-first-event/SKILL.md
+++ b/plugins/amplitude/skills/send-first-event/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: setup-amplitude-first-event
+name: send-first-event
 description: >
   Installs the Amplitude SDK from zero and verifies the first event reaches the user's
   project. Use when the user asks "set up Amplitude", "install Amplitude", "add Amplitude
@@ -9,7 +9,7 @@ description: >
   instead. Stops at one verified event.
 ---
 
-# setup-amplitude-first-event
+# send-first-event
 
 You are setting up Amplitude in the user's project and verifying one real event reaches their
 Amplitude project. Goal: **detect → install + init → fire one verify event → confirm.**
@@ -21,7 +21,8 @@ Nothing more — no tracking plan, no custom event design, no dashboards.
 
 ## Step 1: Detect the framework
 
-Read `package.json` and match against this table:
+Read `package.json` and match against this table. Exactly **one** row applies — take the
+first match, top-down:
 
 | Dependency | Branch | Entry point | Env var prefix | SDK |
 |---|---|---|---|---|

--- a/plugins/amplitude/skills/send-first-event/SKILL.md
+++ b/plugins/amplitude/skills/send-first-event/SKILL.md
@@ -24,6 +24,13 @@ Nothing more — no tracking plan, no event taxonomy, no dashboards.
 > **Conflict rule:** if the user's instructions conflict with anything this skill does —
 > in either direction — say so explicitly and let them decide. Never silently override.
 
+> **Amplitude MCP (if connected):** when an Amplitude MCP server is available in this
+> environment, prefer its tools where a step offers an **[MCP path]** — programmatic key
+> retrieval and server-side ingestion verification replace the manual asks. Every step
+> still works without it via the ask-the-user path. Use only tools the connected server
+> actually exposes — never invent tool names; if the tool a step expects isn't there,
+> take the no-MCP path.
+
 ## Step 0: Preflight — is Amplitude already here?
 
 Scan before touching anything: `@amplitude/*` in any `package.json`, and Amplitude
@@ -55,6 +62,16 @@ first match, top-down:
   stop and say so instead of improvising. Never invent SDK option names.
 
 ## Step 2: Get the API key, data center, and Setup page
+
+**[MCP path]** — with the Amplitude MCP connected, skip the questions below: confirm
+which Amplitude **project** to target (ask only if ambiguous — e.g. the MCP context shows
+several), read the **data center** from that project's context, and **defer the key fetch
+to Step 4** — retrieve it just-in-time with the MCP's key tool when you write the init
+module. Human round-trips are expensive, so the no-MCP path front-loads its questions;
+tool calls are cheap, so the MCP path fetches at the moment of use instead. Then go to
+Step 3.
+
+**[No MCP — ask the user]:**
 
 Ask the user for their **project API key** — it's on their Amplitude **Setup page** (if they
 have no project yet: sign up, create one, the Setup page appears after that).
@@ -247,7 +264,7 @@ Browser branches:
 
 ```ts
 amplitude.track('Viewed Home Page', {
-  skill_version: 'BA395.6', // helps improve this setup flow — safe to remove
+  skill_version: 'BA395.7', // helps improve this setup flow — safe to remove
 });
 ```
 
@@ -255,7 +272,7 @@ Node backend:
 
 ```ts
 track('Viewed Home Page', {
-  skill_version: 'BA395.6', // helps improve this setup flow — safe to remove
+  skill_version: 'BA395.7', // helps improve this setup flow — safe to remove
 }, { user_id: 'first-event-verify' });
 ```
 
@@ -274,12 +291,24 @@ of fixing unrelated code. **Never claim success on a failing build.**
 
 ## Step 7: Run and confirm
 
-Have the user start the app and watch the **checklist on their Amplitude Setup page** (the
-`/setup` URL built in Step 2). It flips to confirmed the moment any event arrives (usually
-seconds) — that proves *something* landed. The specific proof is their **chosen event
-name** showing up in the project's live event stream (the Setup page's event feed). Both
-together = done. That in-app confirmation is the source of truth: **do not claim success
-before you have it.**
+The source of truth is **observed ingestion** — either the MCP's server-side check or the
+user's in-app confirmation. Never your own assumption, and never the network tab alone:
+a request that left the browser is not an event that landed.
+
+**[MCP path]** — once the app runs and the chosen event has fired (load/mount events fire
+on start; interaction events need the action performed — ask the user to do it, or do it
+yourself only with their permission), call the MCP's ingestion-check tool for the chosen
+event name in the last few minutes. The tool confirming arrival = you have observed
+success and may say so, citing the tool result. Still point the user at their Setup page
+so they see the checklist flip themselves. Tool shows nothing after ~a minute → fall
+through to the debug list below; do not claim success.
+
+**[No MCP]** — have the user start the app and watch the **checklist on their Amplitude
+Setup page** (the `/setup` URL built in Step 2). It flips to confirmed the moment any
+event arrives (usually seconds) — that proves *something* landed. The specific proof is
+their **chosen event name** showing up in the project's live event stream (the Setup
+page's event feed). Both together = done. **Do not claim success before the user
+confirms.**
 
 If nothing shows within a minute:
 
@@ -317,8 +346,9 @@ Audit this list before your final message — every box, honestly:
 - [ ] Region correct for their data center.
 - [ ] Key placed per the repo's convention — env file + missing-key guard, or hardcoded +
       explanatory comment — and never silently absent.
-- [ ] The user confirmed the landing — checklist flip plus their event name in the stream.
-      You cannot observe this yourself; if unconfirmed, say so and stop.
+- [ ] The landing is confirmed — by the MCP ingestion check (cite the tool result), or by
+      the user (checklist flip plus their event name in the stream). Without the MCP you
+      cannot observe this yourself; if unconfirmed either way, say so and stop.
 
 Anything unchecked → report it plainly. Never claim completion over an unchecked box.
 

--- a/plugins/amplitude/skills/send-first-event/SKILL.md
+++ b/plugins/amplitude/skills/send-first-event/SKILL.md
@@ -6,8 +6,10 @@ description: >
   Amplitude", "add Amplitude to this app", "add analytics to my app", "get my first event
   into Amplitude", or "instrument this app with Amplitude" and the repo has no Amplitude
   tracking yet. If tracking already exists, use discover-analytics-patterns or
-  add-analytics-instrumentation instead. Stops at one verified event. Requires the
-  Amplitude MCP server (key retrieval + server-side event verification).
+  add-analytics-instrumentation instead. Stops at one verified event. Use on setup
+  intent whether or not an Amplitude MCP server is connected: the skill requires one
+  and begins by walking the user through connecting it if absent; key retrieval and
+  ingestion verification ride the MCP when exposed, with in-step fallbacks otherwise.
 ---
 
 # send-first-event
@@ -25,12 +27,18 @@ Nothing more — no tracking plan, no event taxonomy, no dashboards.
 > **Conflict rule:** if the user's instructions conflict with anything this skill does —
 > in either direction — say so explicitly and let them decide. Never silently override.
 
-> **Requires the Amplitude MCP.** This skill assumes an Amplitude MCP server is connected
-> — programmatic key retrieval and server-side ingestion verification are how it works.
+> **Requires the Amplitude MCP.** What the requirement actually rests on is
+> **authenticated project identity**: every step targets a project confirmed from the
+> server's context, and that has no fallback. Key retrieval and server-side ingestion
+> verification also ride the MCP and make the run stronger where exposed — but their
+> in-step fallbacks are gap-fillers, never a substitute for the connection itself.
 > No Amplitude MCP in this environment → **stop before making any changes**: point the
 > user at the Amplitude MCP install docs (https://amplitude.com/docs → Amplitude MCP) and
-> resume once it's connected. Use only tools the connected server actually exposes —
-> never invent tool names; where a specific tool is missing, the step names its fallback.
+> resume once it's connected. If the user declines the MCP even after you surface the
+> conflict, still do not run this skill — point them at the platform SDK docs or their
+> project's Setup page instead; this skill does not operate without the MCP. Use only
+> tools the connected server actually exposes — never invent tool names; where a
+> specific tool is missing, the step names its fallback.
 
 ## Step 0: Preflight — is Amplitude already here?
 
@@ -78,12 +86,15 @@ the answer:
 - **Setup page:** take the project's Setup-page URL from the MCP context if it exposes
   one; otherwise ask for the org's **URL slug** — the segment right after `/analytics/`
   in their logged-in Amplitude URL (not the org display name; the two can differ) — and
-  build it (Step 7 uses it):
+  build it (Step 7 uses it), and have the user confirm the URL loads:
 
   ```
   https://app.amplitude.com/analytics/<slug>/setup      # US
   https://app.eu.amplitude.com/analytics/<slug>/setup   # EU
   ```
+
+  If they don't know the slug, have them log in at the data center's host URL and open
+  Setup from there.
 
 **Key timing:** if the server exposes a dedicated key-retrieval tool, defer the key fetch
 to Step 4 and retrieve it just-in-time — tool calls are cheap, so fetch at the moment of
@@ -150,7 +161,9 @@ npm install @amplitude/unified@^1.1.20     # browser branches
 npm install @amplitude/analytics-node@^1   # Node backend branch
 ```
 
-**[Deferred key]** — fetch the key now with the server's dedicated
+**[Deferred key — only if Step 2 deferred it]** — if the key was already placed in
+Step 2 (no dedicated key tool → user provided it), skip this block and initialize.
+Otherwise: fetch the key now with the server's dedicated
 key-retrieval tool and place it per Step 2's **Key placement** rules (env file +
 missing-key guard, or hardcoded constant + comment) **before** writing the init module —
 the snippets below read the key from wherever you placed it, and a fetched-but-unplaced
@@ -318,8 +331,12 @@ skip the pointer. Tool shows nothing (or only autocapture) after ~a minute → f
 to the debug list below; do not claim success.
 
 **Fallback — the server exposes no ingestion-check tool** (it may be gated or not rolled
-out to this org): have the user start the app and watch the **checklist on their
-Amplitude Setup page** (the `/setup` URL from Step 2). It flips to confirmed the moment
+out to this org). Confirm absence before falling back — check the server's tool list;
+if an ingestion/recent-event check exists, the primary applies, not this. The anti-fake
+rule above applies here too: the event must come from the running app's real flow. Then:
+have the user start the app and watch the **checklist on their Amplitude Setup page**
+(the `/setup` URL from Step 2 — if you never resolved that URL, stop and resolve the
+slug with the user now; without the tool or the URL there is no verification path). It flips to confirmed the moment
 any event arrives (usually seconds) — that proves *something* landed. The specific proof
 is their **chosen event name** showing up in the project's live event stream (the Setup
 page's event feed). Both together = done. **Do not claim success before the user
@@ -331,8 +348,8 @@ If nothing shows within a minute:
    `serverZone: 'EU'` to the init options (Step 4).
 2. Restart the dev server — env vars load at startup.
 3. Try an incognito window / disable ad blockers — both silently drop analytics requests.
-4. Re-check the key (env file or init module) against the Setup page — or, on the MCP
-   path, re-fetch it with the key tool and compare — no extra spaces or quotes.
+4. Re-check the key (env file or init module) against the Setup page — or re-fetch it
+   with the key tool (if the server exposes one) and compare — no extra spaces or quotes.
 
 ## Non-negotiables — enforce, don't ratify
 

--- a/plugins/amplitude/skills/send-first-event/SKILL.md
+++ b/plugins/amplitude/skills/send-first-event/SKILL.md
@@ -1,23 +1,35 @@
 ---
 name: send-first-event
 description: >
-  Installs the Amplitude SDK from zero and verifies the first event reaches the user's
-  project. Use when the user asks "set up Amplitude", "install Amplitude", "add Amplitude
-  to this app", "add analytics to my app", "get my first event into Amplitude", or
-  "instrument this app with Amplitude" and the repo has no Amplitude tracking yet. If
-  tracking already exists, use discover-analytics-patterns or add-analytics-instrumentation
-  instead. Stops at one verified event.
+  Installs the Amplitude SDK from zero and verifies one real event from the user's own
+  app lands in their project. Use when the user asks "set up Amplitude", "install
+  Amplitude", "add Amplitude to this app", "add analytics to my app", "get my first event
+  into Amplitude", or "instrument this app with Amplitude" and the repo has no Amplitude
+  tracking yet. If tracking already exists, use discover-analytics-patterns or
+  add-analytics-instrumentation instead. Stops at one verified event.
 ---
 
 # send-first-event
 
-You are setting up Amplitude in the user's project and verifying one real event reaches their
-Amplitude project. Goal: **detect → install + init → fire one verify event → confirm.**
-Nothing more — no tracking plan, no custom event design, no dashboards.
+You are setting up Amplitude in the user's project and verifying one real event — chosen
+with the user from their own codebase — reaches their Amplitude project. Goal:
+**preflight → detect → find their event → install + init → instrument → confirm.**
+Nothing more — no tracking plan, no event taxonomy, no dashboards.
 
-> **Scope rule (enforce):** do not add any events beyond the single verify event below — no
-> click or interaction tracking, no event taxonomy; autocapture already covers interactions.
-> If the user wants more events, finish the first event, then hand off (see **Done**).
+> **Scope rule (enforce):** exactly one explicit event, and only the one the user chose —
+> no additional click or interaction tracking, no taxonomy; autocapture already covers
+> generic interactions. If the user wants more events, finish this one, then hand off
+> (see **Done**).
+
+> **Conflict rule:** if the user's instructions conflict with anything this skill does —
+> in either direction — say so explicitly and let them decide. Never silently override.
+
+## Step 0: Preflight — is Amplitude already here?
+
+Scan before touching anything: `@amplitude/*` in any `package.json`, and Amplitude
+`init(` / `initAll(` / `track(` patterns in source. If found, **stop — make no changes** —
+and route: discover-analytics-patterns to map what exists, then
+add-analytics-instrumentation to extend it.
 
 ## Step 1: Detect the framework
 
@@ -26,26 +38,31 @@ first match, top-down:
 
 | Dependency | Branch | Entry point | Env var prefix | SDK |
 |---|---|---|---|---|
-| `next` | Next.js | client component imported by `app/layout.tsx` | `NEXT_PUBLIC_` | `@amplitude/unified` |
+| `next` (has `app/`) | Next.js App Router | client component imported by `app/layout.tsx` | `NEXT_PUBLIC_` | `@amplitude/unified` |
+| `next` (has `pages/`) | Next.js Pages Router | init module imported in `pages/_app.*` | `NEXT_PUBLIC_` | `@amplitude/unified` |
 | `react` + `vite` | React + Vite | `src/main.tsx` | `VITE_` | `@amplitude/unified` |
 | `vue` + `vite` | Vue + Vite | `src/main.ts` | `VITE_` | `@amplitude/unified` |
 | `vite` (plain JS) | JS + Vite | `src/main.js` | `VITE_` | `@amplitude/unified` |
 | none of the above, has a server entry | Node backend | server entry file | none — `process.env` | `@amplitude/analytics-node` |
 
+- **Monorepo:** operate on the workspace that owns the runnable app. If it's ambiguous
+  which one that is, ask before touching anything.
 - **Not a JavaScript-family project** (no `package.json`, or Python/Go/mobile/etc.): stop —
   make no code changes. Tell the user this skill covers JS apps today and point them to
   the platform SDK docs at https://amplitude.com/docs/sdks.
-- Framework not in the table but JS-based: keep the same steps, use the closest row, and
-  adapt file names and env access — never invent SDK option names.
+- Framework not in the table but JS-based: keep the same steps and adapt file names and
+  env access — but if you cannot confidently map the client boundary or the env access,
+  stop and say so instead of improvising. Never invent SDK option names.
 
-## Step 2: Get the API key into an env var
+## Step 2: Get the API key, data center, and Setup page
 
 Ask the user for their **project API key** — it's on their Amplitude **Setup page** (if they
 have no project yet: sign up, create one, the Setup page appears after that).
 
 Also ask which **data center** their project is on — **EU or US**. Quick check: if their
 Amplitude URL when logged in is `app.eu.amplitude.com`, it's EU; `app.amplitude.com` is US.
-You'll need this in Step 3.
+Settle this **now, before any code is generated** — it changes the init options in Step 4,
+and events sent to the wrong endpoint never arrive.
 
 To point them at the Setup page directly, ask for their org's **URL slug** — the segment
 right after `/analytics/` in their Amplitude URL when logged in (not the org display name;
@@ -71,10 +88,31 @@ AMPLITUDE_API_KEY=<key>             # Node backend
 
 Never hardcode the key in source.
 
-## Step 3: Install and initialize — exactly once
+## Step 3: Find the first event
 
-Install with the project's package manager, pinned to the verified major (npm shown as
-the example):
+The first event should be a real product moment from **their** app — not a placeholder.
+Scan the repo for low-hanging meaningful moments:
+
+- routes / pages → `Viewed Home Page`
+- auth flows → `Signed Up`
+- the primary CTA → e.g. `Started Checkout`
+
+Propose 1–3 candidates **with file evidence** (the path and line of the route, handler, or
+component each one comes from). Recommend the candidate that fires at load/mount time — it
+confirms in seconds without anyone having to click. Be honest about the trade-off:
+autocapture (Step 4) already logs generic page views; an explicit named event gives them a
+clean, chartable, named moment of their own.
+
+The user picks — or names their own; their word is final. Bare scaffold with nothing
+meaningful in it yet → default to `Viewed Home Page`. Naming guidance, one line: Title
+Case, past-tense action ("Signed Up", "Viewed Home Page").
+
+**Exactly one event.** More events are a hand-off (see **Done**), not a bigger Step 3.
+
+## Step 4: Install and initialize — exactly once
+
+Install with the project's package manager, pinned to the minimum verified version within
+major 1 (npm shown as the example):
 
 ```bash
 npm install @amplitude/unified@^1.1.20     # browser branches
@@ -82,8 +120,13 @@ npm install @amplitude/analytics-node@^1   # Node backend branch
 ```
 
 Initialize **once**, at the app entry. The file paths and placement below are an example
-integration — adapt them to this repo's conventions. The package, import style, and init
-call are **exact** — correct any deviation before proceeding.
+integration — adapt them to this repo's conventions, and match the repo's language: the
+init module's extension follows the repo (`.ts` / `.js`), and TypeScript-only syntax (like
+the `!` non-null assertion in these snippets) never goes into a `.js` file. The package,
+import style, and init call are **exact** — correct any deviation before proceeding.
+
+**EU projects:** the generated init call must include `serverZone: 'EU'` — it is marked in
+place in each snippet below. US projects omit that line. Not optional; see Non-negotiables.
 
 **React/Vue/JS + Vite** — create an init module (example: `src/amplitude.ts`):
 
@@ -91,35 +134,32 @@ call are **exact** — correct any deviation before proceeding.
 import * as amplitude from '@amplitude/unified';
 
 amplitude.initAll(import.meta.env.VITE_AMPLITUDE_API_KEY, {
+  serverZone: 'EU', // EU data center only — omit this line for US
   analytics: { autocapture: true },
 });
-amplitude.track('Setup Verified', { skill_version: 'BA395.4' });
 ```
-
-The verify event fires right after `initAll` on purpose — the SDK queues events fired
-before init completes, so this works in any Vite-family app with no framework hooks.
 
 Then add `import './amplitude';` as the **first** import in the entry file (example:
 `src/main.tsx`).
 
-**Next.js** — create a client component (example: `components/AmplitudeInit.tsx`; do NOT
-mark the root layout `"use client"`):
+**Next.js App Router** — create a client component (example: `components/AmplitudeInit.tsx`;
+do NOT mark the root layout `"use client"`):
 
 ```tsx
 'use client';
 import * as amplitude from '@amplitude/unified';
 import { useEffect } from 'react';
 
-let fired = false; // React StrictMode double-invokes effects in dev
+let initialized = false; // React StrictMode double-invokes effects in dev
 
 export default function AmplitudeInit() {
   useEffect(() => {
-    if (fired) return;
-    fired = true;
+    if (initialized) return;
+    initialized = true;
     amplitude.initAll(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY!, {
+      serverZone: 'EU', // EU data center only — omit this line for US
       analytics: { autocapture: true },
     });
-    amplitude.track('Setup Verified', { skill_version: 'BA395.4' });
   }, []);
   return null;
 }
@@ -127,83 +167,138 @@ export default function AmplitudeInit() {
 
 Render `<AmplitudeInit />` once inside the root layout's body (`app/layout.tsx`).
 
+**Next.js Pages Router** — create an init module (example: `lib/amplitude.ts`), guarded so
+it only runs in the browser (the module is also evaluated during server-side rendering):
+
+```ts
+import * as amplitude from '@amplitude/unified';
+
+if (typeof window !== 'undefined') {
+  amplitude.initAll(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY!, {
+    serverZone: 'EU', // EU data center only — omit this line for US
+    analytics: { autocapture: true },
+  });
+}
+```
+
+Then import it at the top of `pages/_app.*`.
+
 **Node backend** — at the server entry:
 
 ```ts
 import { init, track } from '@amplitude/analytics-node';
-init(process.env.AMPLITUDE_API_KEY!);
-```
 
-> **EU data center:** add top-level `serverZone: 'EU'` to the init options —
-> `amplitude.initAll(key, { serverZone: 'EU', analytics: { autocapture: true } })` (browser) /
-> `init(key, { serverZone: 'EU' })` (Node backend). US is the default; omit it for US projects.
+init(process.env.AMPLITUDE_API_KEY!, {
+  serverZone: 'EU', // EU data center only — omit this line for US
+});
+```
 
 > ⚠️ The package determines the init call, exactly: `@amplitude/unified` exposes
 > **`initAll`** (`init` does not exist there); `@amplitude/analytics-node` exposes
 > **`init`**. Never mix the two.
 
-## Step 4: Fire the one verify event
+## Step 5: Instrument the chosen event
 
-One explicit event, named exactly `Setup Verified` (Title Case, with the space), carrying
-the version property:
+Add the one chosen event at the moment it represents:
 
-```ts
-amplitude.track('Setup Verified', { skill_version: 'BA395.4' });
-```
+- **Load/mount-time event** (e.g. `Viewed Home Page`) — right after `initAll` in the init
+  module (App Router: inside the guarded effect, right after `initAll`). The SDK queues
+  events fired before init completes, so this is safe.
+- **Interaction event** (e.g. `Signed Up`) — in that action's existing handler, at the
+  point where the action has actually succeeded.
 
-Browser branches: already wired in Step 3 — the Vite init module fires it right after
-`initAll`, and the Next.js component fires it inside the guarded effect.
-
-Node backend — right after `init` at boot:
+Browser branches:
 
 ```ts
-track('Setup Verified', { skill_version: 'BA395.4' }, { user_id: 'setup-verify' });
+amplitude.track('Viewed Home Page', {
+  skill_version: 'BA395.5', // helps improve this setup flow — safe to remove
+});
 ```
 
-Autocapture will also collect real interactions — a bonus, but always fire this explicit
-event so success doesn't depend on the user clicking around.
+Node backend:
 
-## Step 5: Verify it compiles
+```ts
+track('Viewed Home Page', {
+  skill_version: 'BA395.5', // helps improve this setup flow — safe to remove
+}, { user_id: 'first-event-verify' });
+```
+
+Use the user's chosen event name — `Viewed Home Page` above is only the example. The
+`skill_version` property rides along on this one event and is safe to delete later.
+
+Autocapture will also collect real interactions — a bonus, but the chosen explicit event
+is the verification target, so success never depends on someone happening to click around.
+
+## Step 6: Verify it compiles
 
 Run the project's build (`npm run build`, or this project's equivalent). If Amplitude lines
 error, reconcile against the installed package's exported types — do not invent options or
 exports. If the error is in code you didn't touch, it's likely pre-existing — say so instead
 of fixing unrelated code. **Never claim success on a failing build.**
 
-## Step 6: Run and confirm
+## Step 7: Run and confirm
 
 Have the user start the app and watch the **checklist on their Amplitude Setup page** (the
-`/setup` URL built in Step 2) — it flips to confirmed the moment the first event lands
-(usually seconds). That in-app flip is
-the source of truth: **do not claim success before it flips.**
+`/setup` URL built in Step 2). It flips to confirmed the moment any event arrives (usually
+seconds) — that proves *something* landed. The specific proof is their **chosen event
+name** showing up in the project's live event stream (the Setup page's event feed). Both
+together = done. That in-app confirmation is the source of truth: **do not claim success
+before you have it.**
 
-If it doesn't flip within a minute:
+If nothing shows within a minute:
 
 1. EU project but `serverZone` not set — events went to the US endpoint. Add
-   `serverZone: 'EU'` to the init options (Step 3).
+   `serverZone: 'EU'` to the init options (Step 4).
 2. Restart the dev server — env vars load at startup.
 3. Try an incognito window / disable ad blockers — both silently drop analytics requests.
-4. Re-check the key in `.env` against the Setup page — no extra spaces or quotes.
+4. Re-check the key in the env file against the Setup page — no extra spaces or quotes.
 
 ## Non-negotiables — enforce, don't ratify
 
 These are exact, not suggestions. If anything deviates, fix it before moving on — never
 "that's fine":
 
-1. Package ↔ init call: `@amplitude/unified` exposes `amplitude.initAll(...)` (`init` does
+1. Exactly **one** explicit event, chosen with the user from their own codebase, carrying
+   the removable `skill_version` property.
+2. Package ↔ init call: `@amplitude/unified` exposes `amplitude.initAll(...)` (`init` does
    not exist there); `@amplitude/analytics-node` exposes `init(...)`. Never mix the two.
-2. Wrong package installed → uninstall it, install the right one.
-3. Event name `Setup Verified` exactly.
-4. The verify event carries `skill_version`.
-5. Key in an env var, never in source.
-6. No events beyond the verify event.
+3. Region correct for their data center: EU project → `serverZone: 'EU'` in the init call.
+4. Key in an env var, never in source.
+5. No events the user didn't choose — never invent a taxonomy.
+6. Never claim success you didn't observe.
+
+## Complete when
+
+Audit this list before your final message — every box, honestly:
+
+- [ ] Build passes.
+- [ ] Exactly one explicit event exists — the chosen one, `skill_version` present.
+- [ ] Package ↔ init call correct for the branch.
+- [ ] Region correct for their data center.
+- [ ] Key lives in an env file, not in source.
+- [ ] The user confirmed the landing — checklist flip plus their event name in the stream.
+      You cannot observe this yourself; if unconfirmed, say so and stop.
+
+Anything unchecked → report it plainly. Never claim completion over an unchecked box.
 
 ## Done
 
-Once the checklist confirms, tell the user their first event landed and where to go next:
+Open with their result: **"Your `<chosen event>` landed, and autocapture is collecting real
+usage alongside it."** (Node backend: their event landed — no autocapture claim.)
 
-- **Ongoing / repo-wide instrumentation** → the add-analytics-instrumentation skill
-  (start with discover-analytics-patterns if the repo may already have tracking).
+Then one default next step: if the Amplitude MCP is connected, offer to build a first chart
+of their chosen event over time via the create-chart skill — a modest smoke-test of their
+new data. No MCP → point them at the chart builder in the Amplitude UI.
+
+Then ask ONE question — **more events, session replay, or a guided taxonomy?** — and expand
+only the matching handoff:
+
+- **More events** → the add-analytics-instrumentation skill (start with
+  discover-analytics-patterns if the repo may already have tracking you didn't create).
+- **Session replay** → its own enablement decision (sampling rate, privacy, masking) — do
+  not embed that configuration here. Once sessions exist, debug-replay and replay-ux-audit
+  consume them.
 - **Guided taxonomy / dashboards** → the Amplitude wizard: `npx @amplitude/wizard`.
 
-Do not design tracking plans or dashboards here — hand off.
+If a named skill or MCP isn't available in this environment, describe the Amplitude-UI
+equivalent instead. Do not design tracking plans or dashboards here — hand off.

--- a/plugins/amplitude/skills/send-first-event/SKILL.md
+++ b/plugins/amplitude/skills/send-first-event/SKILL.md
@@ -76,17 +76,31 @@ https://app.eu.amplitude.com/analytics/<slug>/setup   # EU
 Have the user confirm that URL loads. If they don't know the slug, have them log in at the
 data center's host URL and open Setup from there.
 
-Put the key in an env file, following the repo's existing env-file convention (fall back to
-`.env` at the project root; create it if missing, keep existing lines), using the
-framework's public prefix from the table:
+**Key placement — follow the repo's convention:**
 
-```
-VITE_AMPLITUDE_API_KEY=<key>        # Vite family
-NEXT_PUBLIC_AMPLITUDE_API_KEY=<key> # Next.js
-AMPLITUDE_API_KEY=<key>             # Node backend
-```
+- **Repo already uses env machinery** (existing `.env*` files or framework env config) →
+  put the key in the env file the repo already uses (create it if missing, keep existing
+  lines), with the framework's public prefix from the table:
 
-Never hardcode the key in source.
+  ```
+  VITE_AMPLITUDE_API_KEY=<key>        # Vite family
+  NEXT_PUBLIC_AMPLITUDE_API_KEY=<key> # Next.js
+  AMPLITUDE_API_KEY=<key>             # Node backend
+  ```
+
+  Prefixed vars are inlined at build time, so an unset var is a **silent** production
+  failure — every snippet that reads the key carries a missing-key guard (see Step 4)
+  that warns loudly instead.
+
+- **Bare repo, no env system** → hardcode the key in the init module, with this comment:
+
+  ```ts
+  // Amplitude ingestion key — public by design (ships in the bundle either way);
+  // consider moving to an env var when you set up environments — see the final step.
+  const AMPLITUDE_API_KEY = '<key>';
+  ```
+
+Either way, the key must never be silently absent.
 
 ## Step 3: Find the first event
 
@@ -121,9 +135,10 @@ npm install @amplitude/analytics-node@^1   # Node backend branch
 
 Initialize **once**, at the app entry. The file paths and placement below are an example
 integration — adapt them to this repo's conventions, and match the repo's language: the
-init module's extension follows the repo (`.ts` / `.js`), and TypeScript-only syntax (like
-the `!` non-null assertion in these snippets) never goes into a `.js` file. The package,
-import style, and init call are **exact** — correct any deviation before proceeding.
+init module's extension follows the repo (`.ts` / `.js`), and TypeScript-only syntax never
+goes into a `.js` file. The package, import style, and init call are **exact** — correct
+any deviation before proceeding. On the bare-repo branch (hardcoded key per Step 2),
+replace each env read below with the commented constant from Step 2.
 
 **EU projects:** the generated init call must include `serverZone: 'EU'` — it is marked in
 place in each snippet below. US projects omit that line. Not optional; see Non-negotiables.
@@ -133,10 +148,15 @@ place in each snippet below. US projects omit that line. Not optional; see Non-n
 ```ts
 import * as amplitude from '@amplitude/unified';
 
-amplitude.initAll(import.meta.env.VITE_AMPLITUDE_API_KEY, {
-  serverZone: 'EU', // EU data center only — omit this line for US
-  analytics: { autocapture: true },
-});
+const key = import.meta.env.VITE_AMPLITUDE_API_KEY;
+if (key) {
+  amplitude.initAll(key, {
+    serverZone: 'EU', // EU data center only — omit this line for US
+    analytics: { autocapture: true },
+  });
+} else {
+  console.warn('[amplitude] VITE_AMPLITUDE_API_KEY is not set — analytics disabled');
+}
 ```
 
 Then add `import './amplitude';` as the **first** import in the entry file (example:
@@ -156,7 +176,12 @@ export default function AmplitudeInit() {
   useEffect(() => {
     if (initialized) return;
     initialized = true;
-    amplitude.initAll(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY!, {
+    const key = process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY;
+    if (!key) {
+      console.warn('[amplitude] NEXT_PUBLIC_AMPLITUDE_API_KEY is not set — analytics disabled');
+      return;
+    }
+    amplitude.initAll(key, {
       serverZone: 'EU', // EU data center only — omit this line for US
       analytics: { autocapture: true },
     });
@@ -173,11 +198,16 @@ it only runs in the browser (the module is also evaluated during server-side ren
 ```ts
 import * as amplitude from '@amplitude/unified';
 
+const key = process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY;
 if (typeof window !== 'undefined') {
-  amplitude.initAll(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY!, {
-    serverZone: 'EU', // EU data center only — omit this line for US
-    analytics: { autocapture: true },
-  });
+  if (key) {
+    amplitude.initAll(key, {
+      serverZone: 'EU', // EU data center only — omit this line for US
+      analytics: { autocapture: true },
+    });
+  } else {
+    console.warn('[amplitude] NEXT_PUBLIC_AMPLITUDE_API_KEY is not set — analytics disabled');
+  }
 }
 ```
 
@@ -188,14 +218,20 @@ Then import it at the top of `pages/_app.*`.
 ```ts
 import { init, track } from '@amplitude/analytics-node';
 
-init(process.env.AMPLITUDE_API_KEY!, {
-  serverZone: 'EU', // EU data center only — omit this line for US
-});
+const key = process.env.AMPLITUDE_API_KEY;
+if (key) {
+  init(key, {
+    serverZone: 'EU', // EU data center only — omit this line for US
+  });
+} else {
+  console.warn('[amplitude] AMPLITUDE_API_KEY is not set — analytics disabled');
+}
 ```
 
-> ⚠️ The package determines the init call, exactly: `@amplitude/unified` exposes
-> **`initAll`** (`init` does not exist there); `@amplitude/analytics-node` exposes
-> **`init`**. Never mix the two.
+> ⚠️ The package determines the init call, exactly: `@amplitude/unified` also exports
+> `init`, but it initializes analytics ONLY — session replay, experiment, and engagement
+> are silently dropped. Never use `init` with unified; always **`initAll`**.
+> (`@amplitude/analytics-node`'s correct call IS `init`.)
 
 ## Step 5: Instrument the chosen event
 
@@ -211,7 +247,7 @@ Browser branches:
 
 ```ts
 amplitude.track('Viewed Home Page', {
-  skill_version: 'BA395.5', // helps improve this setup flow — safe to remove
+  skill_version: 'BA395.6', // helps improve this setup flow — safe to remove
 });
 ```
 
@@ -219,7 +255,7 @@ Node backend:
 
 ```ts
 track('Viewed Home Page', {
-  skill_version: 'BA395.5', // helps improve this setup flow — safe to remove
+  skill_version: 'BA395.6', // helps improve this setup flow — safe to remove
 }, { user_id: 'first-event-verify' });
 ```
 
@@ -251,7 +287,8 @@ If nothing shows within a minute:
    `serverZone: 'EU'` to the init options (Step 4).
 2. Restart the dev server — env vars load at startup.
 3. Try an incognito window / disable ad blockers — both silently drop analytics requests.
-4. Re-check the key in the env file against the Setup page — no extra spaces or quotes.
+4. Re-check the key (env file or init module) against the Setup page — no extra spaces or
+   quotes.
 
 ## Non-negotiables — enforce, don't ratify
 
@@ -260,10 +297,13 @@ These are exact, not suggestions. If anything deviates, fix it before moving on 
 
 1. Exactly **one** explicit event, chosen with the user from their own codebase, carrying
    the removable `skill_version` property.
-2. Package ↔ init call: `@amplitude/unified` exposes `amplitude.initAll(...)` (`init` does
-   not exist there); `@amplitude/analytics-node` exposes `init(...)`. Never mix the two.
+2. Package ↔ init call: with `@amplitude/unified`, always `amplitude.initAll(...)` — its
+   `init` export initializes analytics only and silently drops session replay, experiment,
+   and engagement. `@amplitude/analytics-node`'s correct call IS `init(...)`.
 3. Region correct for their data center: EU project → `serverZone: 'EU'` in the init call.
-4. Key in an env var, never in source.
+4. Key placed per the repo's convention — env file with a missing-key guard where the repo
+   has env machinery, hardcoded with the explanatory comment on bare repos. Either way it
+   must never be silently absent.
 5. No events the user didn't choose — never invent a taxonomy.
 6. Never claim success you didn't observe.
 
@@ -275,7 +315,8 @@ Audit this list before your final message — every box, honestly:
 - [ ] Exactly one explicit event exists — the chosen one, `skill_version` present.
 - [ ] Package ↔ init call correct for the branch.
 - [ ] Region correct for their data center.
-- [ ] Key lives in an env file, not in source.
+- [ ] Key placed per the repo's convention — env file + missing-key guard, or hardcoded +
+      explanatory comment — and never silently absent.
 - [ ] The user confirmed the landing — checklist flip plus their event name in the stream.
       You cannot observe this yourself; if unconfirmed, say so and stop.
 
@@ -289,6 +330,9 @@ usage alongside it."** (Node backend: their event landed — no autocapture clai
 Then one default next step: if the Amplitude MCP is connected, offer to build a first chart
 of their chosen event over time via the create-chart skill — a modest smoke-test of their
 new data. No MCP → point them at the chart builder in the Amplitude UI.
+
+If the key is hardcoded: when you set up environments or deploys, move it to an env var
+(and consider per-environment projects).
 
 Then ask ONE question — **more events, session replay, or a guided taxonomy?** — and expand
 only the matching handoff:

--- a/plugins/amplitude/skills/setup-amplitude-first-event/SKILL.md
+++ b/plugins/amplitude/skills/setup-amplitude-first-event/SKILL.md
@@ -44,6 +44,10 @@ Read `package.json` and match against this table:
 Ask the user for their **project API key** — it's on their Amplitude **Setup page** (if they
 have no project yet: sign up, create one, the Setup page appears after that).
 
+Also ask which **data center** their project is on — **EU or US**. Quick check: if their
+Amplitude Setup page URL is `app.eu.amplitude.com`, it's EU; `app.amplitude.com` is US.
+You'll need this in Step 3.
+
 Put it in `.env` at the project root (create the file if missing, keep existing lines),
 using the framework's public prefix from the table:
 
@@ -92,7 +96,7 @@ export default function AmplitudeInit() {
     amplitude.initAll(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY!, {
       analytics: { autocapture: true },
     });
-    amplitude.track('Setup Verified', { skill_version: 'BA395.2' });
+    amplitude.track('Setup Verified', { skill_version: 'BA395.3' });
   }, []);
   return null;
 }
@@ -107,6 +111,10 @@ import { init, track } from '@amplitude/analytics-node';
 init(process.env.AMPLITUDE_API_KEY!);
 ```
 
+> **EU data center:** add top-level `serverZone: 'EU'` to the init options —
+> `amplitude.initAll(key, { serverZone: 'EU', analytics: { autocapture: true } })` (browser) /
+> `init(key, { serverZone: 'EU' })` (Node backend). US is the default; omit it for US projects.
+
 > ⚠️ Browser branches use **`amplitude.initAll`** exactly — `amplitude.init(...)` is a
 > different, analytics-only entry point and is NOT acceptable there. The Node package's
 > correct call IS `init(...)` — do not swap `initAll` into the backend branch.
@@ -118,13 +126,13 @@ the version property. Browser (Vite family) — in the component that first moun
 run-once `useEffect` (Next.js: already included in the snippet above):
 
 ```ts
-amplitude.track('Setup Verified', { skill_version: 'BA395.2' });
+amplitude.track('Setup Verified', { skill_version: 'BA395.3' });
 ```
 
 Node backend — right after `init` at boot:
 
 ```ts
-track('Setup Verified', { skill_version: 'BA395.2' }, { user_id: 'setup-verify' });
+track('Setup Verified', { skill_version: 'BA395.3' }, { user_id: 'setup-verify' });
 ```
 
 Autocapture will also collect real interactions — a bonus, but always fire this explicit
@@ -145,9 +153,11 @@ the source of truth: **do not claim success before it flips.**
 
 If it doesn't flip within a minute:
 
-1. Restart the dev server — env vars load at startup.
-2. Try an incognito window / disable ad blockers — both silently drop analytics requests.
-3. Re-check the key in `.env` against the Setup page — no extra spaces or quotes.
+1. EU project but `serverZone` not set — events went to the US endpoint. Add
+   `serverZone: 'EU'` to the init options (Step 3).
+2. Restart the dev server — env vars load at startup.
+3. Try an incognito window / disable ad blockers — both silently drop analytics requests.
+4. Re-check the key in `.env` against the Setup page — no extra spaces or quotes.
 
 ## Non-negotiables — enforce, don't ratify
 

--- a/plugins/amplitude/skills/setup-amplitude-first-event/SKILL.md
+++ b/plugins/amplitude/skills/setup-amplitude-first-event/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: setup-amplitude-first-event
+description: >
+  Installs the Amplitude SDK from zero and verifies the first event reaches the user's
+  project — detect the framework, install and initialize, fire one verify event, confirm on
+  the Amplitude Setup page. Use when the user asks "set up Amplitude", "install Amplitude",
+  "add Amplitude to this app", "add analytics to my app", "get my first event into
+  Amplitude", or "instrument this app with Amplitude" and the repo has no working Amplitude
+  tracking yet. Do not use when tracking already exists — use discover-analytics-patterns or
+  add-analytics-instrumentation instead. Not for tracking plans, taxonomies, or dashboards —
+  this skill stops at one verified event.
+---
+
+# setup-amplitude-first-event
+
+You are setting up Amplitude in the user's project and verifying one real event reaches their
+Amplitude project. Goal: **detect → install + init → fire one verify event → confirm.**
+Nothing more — no tracking plan, no custom event design, no dashboards.
+
+> **Scope rule (enforce):** do not add any events beyond the single verify event below — no
+> click or interaction tracking, no event taxonomy; autocapture already covers interactions.
+> If the user wants more events, finish the first event, then hand off (see **Done**).
+
+## Step 1: Detect the framework
+
+Read `package.json` and match against this table:
+
+| Dependency | Branch | Entry point | Env var prefix | SDK |
+|---|---|---|---|---|
+| `next` | Next.js | client component imported by `app/layout.tsx` | `NEXT_PUBLIC_` | `@amplitude/unified` |
+| `react` + `vite` | React + Vite | `src/main.tsx` | `VITE_` | `@amplitude/unified` |
+| `vue` + `vite` | Vue + Vite | `src/main.ts` | `VITE_` | `@amplitude/unified` |
+| `vite` (plain JS) | JS + Vite | `src/main.js` | `VITE_` | `@amplitude/unified` |
+| none of the above, has a server entry | Node backend | server entry file | none — `process.env` | `@amplitude/analytics-node` |
+
+- **Not a JavaScript-family project** (no `package.json`, or Python/Go/mobile/etc.): stop —
+  make no code changes. Tell the user this skill covers JS apps today and point them to
+  the platform SDK docs at https://amplitude.com/docs/sdks.
+- Framework not in the table but JS-based: keep the same steps, use the closest row, and
+  adapt file names and env access — never invent SDK option names.
+
+## Step 2: Get the API key into an env var
+
+Ask the user for their **project API key** — it's on their Amplitude **Setup page** (if they
+have no project yet: sign up, create one, the Setup page appears after that).
+
+Put it in `.env` at the project root (create the file if missing, keep existing lines),
+using the framework's public prefix from the table:
+
+```
+VITE_AMPLITUDE_API_KEY=<key>        # Vite family
+NEXT_PUBLIC_AMPLITUDE_API_KEY=<key> # Next.js
+AMPLITUDE_API_KEY=<key>             # Node backend
+```
+
+Never hardcode the key in source.
+
+## Step 3: Install and initialize — exactly once
+
+Install, pinned to the verified major:
+
+```bash
+npm install @amplitude/unified@^1.1.20     # browser branches
+npm install @amplitude/analytics-node@^1   # Node backend branch
+```
+
+Initialize **once**, at the app entry. The package, import style, and init call are
+**exact** — correct any deviation before proceeding.
+
+**React/Vue/JS + Vite** — create `src/amplitude.ts`:
+
+```ts
+import * as amplitude from '@amplitude/unified';
+
+amplitude.initAll(import.meta.env.VITE_AMPLITUDE_API_KEY, {
+  analytics: { autocapture: true },
+});
+```
+
+Then add `import './amplitude';` as the **first** import in the entry file (`src/main.tsx`).
+
+**Next.js** — create `components/AmplitudeInit.tsx` (client component; do NOT mark the root
+layout `"use client"`):
+
+```tsx
+'use client';
+import * as amplitude from '@amplitude/unified';
+import { useEffect } from 'react';
+
+export default function AmplitudeInit() {
+  useEffect(() => {
+    amplitude.initAll(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY!, {
+      analytics: { autocapture: true },
+    });
+    amplitude.track('Setup Verified', { skill_version: 'BA395.2' });
+  }, []);
+  return null;
+}
+```
+
+Render `<AmplitudeInit />` once inside `app/layout.tsx`'s body.
+
+**Node backend** — at the server entry:
+
+```ts
+import { init, track } from '@amplitude/analytics-node';
+init(process.env.AMPLITUDE_API_KEY!);
+```
+
+> ⚠️ Browser branches use **`amplitude.initAll`** exactly — `amplitude.init(...)` is a
+> different, analytics-only entry point and is NOT acceptable there. The Node package's
+> correct call IS `init(...)` — do not swap `initAll` into the backend branch.
+
+## Step 4: Fire the one verify event
+
+One explicit event, named exactly `Setup Verified` (Title Case, with the space), carrying
+the version property. Browser (Vite family) — in the component that first mounts, inside a
+run-once `useEffect` (Next.js: already included in the snippet above):
+
+```ts
+amplitude.track('Setup Verified', { skill_version: 'BA395.2' });
+```
+
+Node backend — right after `init` at boot:
+
+```ts
+track('Setup Verified', { skill_version: 'BA395.2' }, { user_id: 'setup-verify' });
+```
+
+Autocapture will also collect real interactions — a bonus, but always fire this explicit
+event so success doesn't depend on the user clicking around.
+
+## Step 5: Verify it compiles
+
+Run the project's build (`npm run build`, or this project's equivalent). If Amplitude lines
+error, reconcile against the installed package's exported types — do not invent options or
+exports. If the error is in code you didn't touch, it's likely pre-existing — say so instead
+of fixing unrelated code. **Never claim success on a failing build.**
+
+## Step 6: Run and confirm
+
+Have the user start the app and watch the **checklist on their Amplitude Setup page** — it
+flips to confirmed the moment the first event lands (usually seconds). That in-app flip is
+the source of truth: **do not claim success before it flips.**
+
+If it doesn't flip within a minute:
+
+1. Restart the dev server — env vars load at startup.
+2. Try an incognito window / disable ad blockers — both silently drop analytics requests.
+3. Re-check the key in `.env` against the Setup page — no extra spaces or quotes.
+
+## Non-negotiables — enforce, don't ratify
+
+These are exact, not suggestions. If anything deviates, fix it before moving on — never
+"that's fine":
+
+1. Browser branches: package `@amplitude/unified`, init `amplitude.initAll(...)`. Wrong
+   package → uninstall it, install the right one.
+2. Node branch: package `@amplitude/analytics-node`, init `init(...)`.
+3. Event name `Setup Verified` exactly.
+4. The verify event carries `skill_version`.
+5. Key in an env var, never in source.
+6. No events beyond the verify event.
+
+## Done
+
+Once the checklist confirms, tell the user their first event landed and where to go next:
+
+- **Ongoing / repo-wide instrumentation** → [add-analytics-instrumentation](../add-analytics-instrumentation/SKILL.md)
+  (start with [discover-analytics-patterns](../discover-analytics-patterns/SKILL.md) if the
+  repo may already have tracking).
+- **Guided taxonomy / dashboards** → the Amplitude wizard: `npx @amplitude/wizard`.
+
+Do not design tracking plans or dashboards here — hand off.

--- a/plugins/amplitude/skills/setup-amplitude-first-event/SKILL.md
+++ b/plugins/amplitude/skills/setup-amplitude-first-event/SKILL.md
@@ -2,13 +2,11 @@
 name: setup-amplitude-first-event
 description: >
   Installs the Amplitude SDK from zero and verifies the first event reaches the user's
-  project — detect the framework, install and initialize, fire one verify event, confirm on
-  the Amplitude Setup page. Use when the user asks "set up Amplitude", "install Amplitude",
-  "add Amplitude to this app", "add analytics to my app", "get my first event into
-  Amplitude", or "instrument this app with Amplitude" and the repo has no working Amplitude
-  tracking yet. Do not use when tracking already exists — use discover-analytics-patterns or
-  add-analytics-instrumentation instead. Not for tracking plans, taxonomies, or dashboards —
-  this skill stops at one verified event.
+  project. Use when the user asks "set up Amplitude", "install Amplitude", "add Amplitude
+  to this app", "add analytics to my app", "get my first event into Amplitude", or
+  "instrument this app with Amplitude" and the repo has no Amplitude tracking yet. If
+  tracking already exists, use discover-analytics-patterns or add-analytics-instrumentation
+  instead. Stops at one verified event.
 ---
 
 # setup-amplitude-first-event
@@ -45,11 +43,24 @@ Ask the user for their **project API key** — it's on their Amplitude **Setup p
 have no project yet: sign up, create one, the Setup page appears after that).
 
 Also ask which **data center** their project is on — **EU or US**. Quick check: if their
-Amplitude Setup page URL is `app.eu.amplitude.com`, it's EU; `app.amplitude.com` is US.
+Amplitude URL when logged in is `app.eu.amplitude.com`, it's EU; `app.amplitude.com` is US.
 You'll need this in Step 3.
 
-Put it in `.env` at the project root (create the file if missing, keep existing lines),
-using the framework's public prefix from the table:
+To point them at the Setup page directly, ask for their org's **URL slug** — the segment
+right after `/analytics/` in their Amplitude URL when logged in (not the org display name;
+the two can differ) — and build the link:
+
+```
+https://app.amplitude.com/analytics/<slug>/setup      # US
+https://app.eu.amplitude.com/analytics/<slug>/setup   # EU
+```
+
+Have the user confirm that URL loads. If they don't know the slug, have them log in at the
+data center's host URL and open Setup from there.
+
+Put the key in an env file, following the repo's existing env-file convention (fall back to
+`.env` at the project root; create it if missing, keep existing lines), using the
+framework's public prefix from the table:
 
 ```
 VITE_AMPLITUDE_API_KEY=<key>        # Vite family
@@ -61,17 +72,19 @@ Never hardcode the key in source.
 
 ## Step 3: Install and initialize — exactly once
 
-Install, pinned to the verified major:
+Install with the project's package manager, pinned to the verified major (npm shown as
+the example):
 
 ```bash
 npm install @amplitude/unified@^1.1.20     # browser branches
 npm install @amplitude/analytics-node@^1   # Node backend branch
 ```
 
-Initialize **once**, at the app entry. The package, import style, and init call are
-**exact** — correct any deviation before proceeding.
+Initialize **once**, at the app entry. The file paths and placement below are an example
+integration — adapt them to this repo's conventions. The package, import style, and init
+call are **exact** — correct any deviation before proceeding.
 
-**React/Vue/JS + Vite** — create `src/amplitude.ts`:
+**React/Vue/JS + Vite** — create an init module (example: `src/amplitude.ts`):
 
 ```ts
 import * as amplitude from '@amplitude/unified';
@@ -79,30 +92,39 @@ import * as amplitude from '@amplitude/unified';
 amplitude.initAll(import.meta.env.VITE_AMPLITUDE_API_KEY, {
   analytics: { autocapture: true },
 });
+amplitude.track('Setup Verified', { skill_version: 'BA395.4' });
 ```
 
-Then add `import './amplitude';` as the **first** import in the entry file (`src/main.tsx`).
+The verify event fires right after `initAll` on purpose — the SDK queues events fired
+before init completes, so this works in any Vite-family app with no framework hooks.
 
-**Next.js** — create `components/AmplitudeInit.tsx` (client component; do NOT mark the root
-layout `"use client"`):
+Then add `import './amplitude';` as the **first** import in the entry file (example:
+`src/main.tsx`).
+
+**Next.js** — create a client component (example: `components/AmplitudeInit.tsx`; do NOT
+mark the root layout `"use client"`):
 
 ```tsx
 'use client';
 import * as amplitude from '@amplitude/unified';
 import { useEffect } from 'react';
 
+let fired = false; // React StrictMode double-invokes effects in dev
+
 export default function AmplitudeInit() {
   useEffect(() => {
+    if (fired) return;
+    fired = true;
     amplitude.initAll(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY!, {
       analytics: { autocapture: true },
     });
-    amplitude.track('Setup Verified', { skill_version: 'BA395.3' });
+    amplitude.track('Setup Verified', { skill_version: 'BA395.4' });
   }, []);
   return null;
 }
 ```
 
-Render `<AmplitudeInit />` once inside `app/layout.tsx`'s body.
+Render `<AmplitudeInit />` once inside the root layout's body (`app/layout.tsx`).
 
 **Node backend** — at the server entry:
 
@@ -115,24 +137,26 @@ init(process.env.AMPLITUDE_API_KEY!);
 > `amplitude.initAll(key, { serverZone: 'EU', analytics: { autocapture: true } })` (browser) /
 > `init(key, { serverZone: 'EU' })` (Node backend). US is the default; omit it for US projects.
 
-> ⚠️ Browser branches use **`amplitude.initAll`** exactly — `amplitude.init(...)` is a
-> different, analytics-only entry point and is NOT acceptable there. The Node package's
-> correct call IS `init(...)` — do not swap `initAll` into the backend branch.
+> ⚠️ The package determines the init call, exactly: `@amplitude/unified` exposes
+> **`initAll`** (`init` does not exist there); `@amplitude/analytics-node` exposes
+> **`init`**. Never mix the two.
 
 ## Step 4: Fire the one verify event
 
 One explicit event, named exactly `Setup Verified` (Title Case, with the space), carrying
-the version property. Browser (Vite family) — in the component that first mounts, inside a
-run-once `useEffect` (Next.js: already included in the snippet above):
+the version property:
 
 ```ts
-amplitude.track('Setup Verified', { skill_version: 'BA395.3' });
+amplitude.track('Setup Verified', { skill_version: 'BA395.4' });
 ```
+
+Browser branches: already wired in Step 3 — the Vite init module fires it right after
+`initAll`, and the Next.js component fires it inside the guarded effect.
 
 Node backend — right after `init` at boot:
 
 ```ts
-track('Setup Verified', { skill_version: 'BA395.3' }, { user_id: 'setup-verify' });
+track('Setup Verified', { skill_version: 'BA395.4' }, { user_id: 'setup-verify' });
 ```
 
 Autocapture will also collect real interactions — a bonus, but always fire this explicit
@@ -147,8 +171,9 @@ of fixing unrelated code. **Never claim success on a failing build.**
 
 ## Step 6: Run and confirm
 
-Have the user start the app and watch the **checklist on their Amplitude Setup page** — it
-flips to confirmed the moment the first event lands (usually seconds). That in-app flip is
+Have the user start the app and watch the **checklist on their Amplitude Setup page** (the
+`/setup` URL built in Step 2) — it flips to confirmed the moment the first event lands
+(usually seconds). That in-app flip is
 the source of truth: **do not claim success before it flips.**
 
 If it doesn't flip within a minute:
@@ -164,9 +189,9 @@ If it doesn't flip within a minute:
 These are exact, not suggestions. If anything deviates, fix it before moving on — never
 "that's fine":
 
-1. Browser branches: package `@amplitude/unified`, init `amplitude.initAll(...)`. Wrong
-   package → uninstall it, install the right one.
-2. Node branch: package `@amplitude/analytics-node`, init `init(...)`.
+1. Package ↔ init call: `@amplitude/unified` exposes `amplitude.initAll(...)` (`init` does
+   not exist there); `@amplitude/analytics-node` exposes `init(...)`. Never mix the two.
+2. Wrong package installed → uninstall it, install the right one.
 3. Event name `Setup Verified` exactly.
 4. The verify event carries `skill_version`.
 5. Key in an env var, never in source.
@@ -176,9 +201,8 @@ These are exact, not suggestions. If anything deviates, fix it before moving on 
 
 Once the checklist confirms, tell the user their first event landed and where to go next:
 
-- **Ongoing / repo-wide instrumentation** → [add-analytics-instrumentation](../add-analytics-instrumentation/SKILL.md)
-  (start with [discover-analytics-patterns](../discover-analytics-patterns/SKILL.md) if the
-  repo may already have tracking).
+- **Ongoing / repo-wide instrumentation** → the add-analytics-instrumentation skill
+  (start with discover-analytics-patterns if the repo may already have tracking).
 - **Guided taxonomy / dashboards** → the Amplitude wizard: `npx @amplitude/wizard`.
 
 Do not design tracking plans or dashboards here — hand off.


### PR DESCRIPTION
## Summary

- The send-first-event skill now **requires a connected Amplitude MCP server**: project API key retrieved just-in-time while writing the init module, completion verified server-side with the MCP's recent-event ingestion check. No MCP in the environment → the skill stops before any changes and points the user at the install docs.
- Both MCP tools this depends on now exist on the public MCP server, which removes the skill's last Setup-page dependencies — the original reason this PR was parked as draft. The copy-paste prompt on the Setup page remains the no-MCP entry path; this skill ships where the MCP comes bundled (plugin/marketplace), so it assumes it.
- Ask-the-user asks survive only as in-step fallbacks for context gaps: data center not exposed → ask EU/US; no dedicated key tool → ask for the key; ingestion-check tool not exposed → the user confirms via their Setup-page checklist. The key lands per repo convention regardless of how it was obtained, and verification only counts when the tool result names the chosen event in the confirmed project.
- `skill_version` stamp bumped to BA395.7 so per-version conversion stays readable in the data.

## Test plan

- Content-only change to one SKILL.md; manifest untouched.
- Before merge: eval-rig pass (same bar as prior versions) plus one live tool-path run once the ingestion-check tool's flag opens — the tool is currently flag-gated, so merging waits on that.

Follow-up (separate change): add send-first-event to the README's What's-Included table.