### PR TITLE
Add Governance PE as taxonomy code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,10 @@
 # Published and experimental plugin content.
 plugins/amplitude/** @amplitude/mcp @amplitude/amplitude-mcp
 plugins/amplitude-experimental/** @amplitude/mcp @amplitude/amplitude-mcp
+
+# Taxonomy and data governance skills also require Governance PE review.
+plugins/amplitude/skills/discover-analytics-patterns/** @amplitude/mcp @amplitude/amplitude-mcp @amplitude/governance-pe
+plugins/amplitude/skills/discover-event-surfaces/** @amplitude/mcp @amplitude/amplitude-mcp @amplitude/governance-pe
+plugins/amplitude/skills/instrument-events/** @amplitude/mcp @amplitude/amplitude-mcp @amplitude/governance-pe
+plugins/amplitude/skills/taxonomy/** @amplitude/mcp @amplitude/amplitude-mcp @amplitude/governance-pe
+plugins/amplitude-experimental/skills/event-description-generator/** @amplitude/mcp @amplitude/amplitude-mcp @amplitude/governance-pe


### PR DESCRIPTION
## Summary

- add @amplitude/governance-pe as a code owner for taxonomy-related skills
- retain the existing MCP code owners

## Validation

- git diff --check