### PR TITLE
DMT-1221 [taxonomy skill] add utilization attribution

### DIFF
--- a/plugins/amplitude/skills/discover-analytics-patterns/SKILL.md
+++ b/plugins/amplitude/skills/discover-analytics-patterns/SKILL.md
@@ -49,9 +49,13 @@ Use two approaches based on what's available.
 ### If the Amplitude MCP is connected
 
 Call `get_events` (or equivalent) to fetch a sample of event names from the
-project. Use those results to choose a few representative non-system product
-events, then call `get_event_properties` for those events to inspect real
-property names. This is your primary naming reference.
+project. If its input schema accepts `_client`, every `get_events` call made by
+this skill MUST include the top-level argument
+`"_client": { "type": "skill", "skill_name": "discover-analytics-patterns" }`
+in the tool arguments; otherwise, omit `_client`. Use those results to choose a
+few representative non-system product events, then call `get_event_properties`
+for those events to inspect real property names. This is your primary naming
+reference.
 
 Do not infer naming conventions from bracket-prefixed Amplitude system names
 such as `[Amplitude], [Guides-Surveys], [Assistant], [Experiment]` for either events or properties. Exclude those from

--- a/plugins/amplitude/skills/discover-event-surfaces/SKILL.md
+++ b/plugins/amplitude/skills/discover-event-surfaces/SKILL.md
@@ -102,9 +102,13 @@ target. You need a `projectId` for the next call.
 
 ### Pull existing events
 
-Call `get_events` with the resolved `projectId` (no cursor needed — just the first
-page is enough for pattern detection). This returns event objects with fields like
-`eventType`, `category`, `description`, etc.
+Call `get_events` with the resolved `projectId`. If its input schema accepts
+`_client`, every `get_events` call made by this skill MUST include the top-level
+argument
+`"_client": { "type": "skill", "skill_name": "discover-event-surfaces" }`
+in the tool arguments. Otherwise, omit `_client`. No cursor is needed — just the
+first page is enough for pattern detection. This returns event objects with
+fields like `eventType`, `category`, `description`, etc.
 
 ### Build naming references and an existing event index
 

--- a/plugins/amplitude/skills/taxonomy/SKILL.md
+++ b/plugins/amplitude/skills/taxonomy/SKILL.md
@@ -423,6 +423,14 @@ Get workspace settings including approval workflow status. Check before writing 
 ### `get_events`
 Retrieve events from a project with filtering by event types, limit, and cursor pagination. Returns full event objects including category and active status.
 
+If the connected MCP server's `get_events` input schema accepts `_client`, every
+`get_events` call made by this skill MUST include this top-level caller
+attribution exactly. Otherwise, omit `_client`.
+
+```json
+"_client": { "type": "skill", "skill_name": "taxonomy" }
+```
+
 - Use `search` first to find the event you're looking for.
 - If `search` doesn't return it, call `get_events` without `eventTypes` to paginate through all events.
 - If you know exact event type names, pass them via `eventTypes` for precise lookup.


### PR DESCRIPTION
## Summary

- identify taxonomy Skill get_events calls through optional _client metadata when the connected MCP schema supports it
- enable Amplitude to understand Skill utilization and use that signal to prioritize improvements to the Skills
- preserve compatibility with MCP servers that do not advertise _client by explicitly omitting the metadata

## Validation

- validated capability-aware attribution and frontmatter identity across all three Skills
- git diff --check
