### PR TITLE
Add search-events-and-properties skill (flag-gated) + document skill visibility flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,60 @@ plugins/
 
 ---
 
+## Skill visibility flags
+
+Skills in this repo are also served by the Amplitude MCP server as MCP resources.
+**By default a skill is visible to everyone** — no configuration needed, which is why
+most `SKILL.md` files have nothing beyond `name` and `description`.
+
+To roll a skill out gradually, or to swap one for a replacement, declare an Amplitude
+Experiment flag in the skill's own frontmatter:
+
+| Key | Effect |
+| --- | --- |
+| `x-amp-flags` | Show the skill **only** when every listed flag evaluates to `on` |
+| `x-amp-exclude-when-flags` | **Hide** the skill when any listed flag is `on` |
+
+```yaml
+---
+name: my-new-skill
+description: What it does and when to use it.
+x-amp-flags: [mcp-skill-my-new-skill]
+---
+```
+
+Both YAML list styles work — `[a, b]` or a `-` block.
+
+### Replacing a skill with a new version
+
+Use one flag on both sides. The old skill is hidden by exactly the flag that reveals the
+new one, so the two can never both appear or both vanish:
+
+```yaml
+# skills/analyze-chart/SKILL.md
+x-amp-exclude-when-flags: [mcp-consolidate-charts]
+
+# skills/analyze-chart-consolidated/SKILL.md
+x-amp-flags: [mcp-consolidate-charts]
+```
+
+This is the mechanism for a skill whose instructions reference tools that only exist
+behind a flag — the skill has to ramp together with the tools it names.
+
+### Things to know
+
+- **The flag must already exist** in Amplitude Experiment (local evaluation mode, variant
+  value `on`). A skill gated on a flag that was never created is visible to nobody.
+- **Once the flag exists, changing who sees the skill needs no deploy** — ramp it in
+  Experiment and it applies on the next request.
+- **A typo hides the skill.** Nothing in CI validates this frontmatter, so the MCP server
+  treats an unparseable gate as "hide" rather than publishing the skill ungated.
+- **Gating only applies to the MCP server.** Installing this plugin directly into Claude
+  Code or Cursor copies every skill in the repo — the flag is read server-side, so local
+  plugin installs are unaffected by it.
+
+---
+
 ## Contributing
 
 We welcome contributions! Whether it's a new skill or improvement:

--- a/plugins/amplitude/skills/search-events-and-properties/SKILL.md
+++ b/plugins/amplitude/skills/search-events-and-properties/SKILL.md
@@ -7,6 +7,7 @@ description: >
   a query returned no data and a wrong name is suspected, when checking whether something
   is already tracked before instrumenting it, or whenever an event or property name is
   needed and has not been confirmed against the project.
+x-amp-flags: [mcp-skill-search-events-and-properties]
 ---
 
 # Search Events & Properties

--- a/plugins/amplitude/skills/search-events-and-properties/SKILL.md
+++ b/plugins/amplitude/skills/search-events-and-properties/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: search-events-and-properties
+description: >
+  Finds the events and properties that exist in an Amplitude project and returns their
+  exact names, so later analysis filters on real taxonomy instead of guessed strings.
+  Use when the user names an event or property informally ("signups", "plan tier"), when
+  a query returned no data and a wrong name is suspected, when checking whether something
+  is already tracked before instrumenting it, or whenever an event or property name is
+  needed and has not been confirmed against the project.
+---
+
+# Search Events & Properties
+
+## When to Use
+
+- The user refers to an event or property by an informal name and the real one is unknown
+- A chart or query came back empty and a mistyped event/property name is a likely cause
+- You need to know whether an event already exists before recommending instrumentation
+- You need the valid values of a property before filtering or grouping on it
+- Any workflow is about to pass an event or property name into another tool
+
+**Never guess an event or property name.** They are project-specific. A guessed name
+silently returns zero rows rather than erroring, which produces confidently wrong
+analysis.
+
+## Instructions
+
+### Step 0: Establish the project
+
+Call `Amplitude:get_amplitude_context` with no arguments to list accessible projects.
+If the user has not named a project and more than one is available, ask which to use —
+do not pick for them. Every tool below needs the resulting `projectId`.
+
+### Step 1: Search broadly first
+
+Start with `Amplitude:search`. It matches across entity types and tolerates informal
+phrasing, so it is the fastest way from "signups" to the real event name.
+
+Prefer it over enumeration: listing an entire taxonomy to eyeball it wastes context on
+large projects.
+
+### Step 2: Resolve exact event names
+
+Once you have candidates, confirm them with `Amplitude:get_events`, filtering with
+`eventTypes` to the specific names you are checking.
+
+If search returned nothing, fall back to a paged listing — `get_events` supports `limit`
+and `cursor`. Page rather than raising the limit indiscriminately.
+
+Report back the **exact** event name as stored. Do not normalise casing, spacing, or
+punctuation; downstream filters are literal.
+
+### Step 3: Resolve properties
+
+Call `Amplitude:get_properties` with the `propertyType` that matches what you need — it
+is a discriminated union, and the wrong type returns the wrong taxonomy:
+
+| `propertyType` | Returns |
+| --- | --- |
+| `event` | Properties attached to events (scope with the event name) |
+| `user` | User-level properties |
+| `group` | Group properties (filter with group types) |
+| `lookup` | Lookup-table properties |
+| `channel` | Channel properties |
+| `persisted` | Persisted properties |
+
+For event properties, scope to the event resolved in Step 2 rather than pulling the
+whole project's property list.
+
+### Step 4: Return a usable answer
+
+Report:
+
+- The exact event name(s), spelled as stored
+- The relevant property names, with their `propertyType`
+- Any candidate that looked plausible but does **not** exist, called out explicitly
+
+That last point matters most. Saying "there is no `user_signup` event; the project uses
+`Signed Up`" is what prevents the next step from querying nothing.
+
+## Notes
+
+- If nothing matches, say so plainly rather than proposing the closest-looking name as
+  if it were confirmed. The event may genuinely not be instrumented — check with
+  `Amplitude:check_for_recent_event_ingestion` before concluding it is missing versus
+  simply not sending data.
+- To create or modify taxonomy rather than read it, this is the wrong skill — use the
+  `taxonomy` skill, which covers naming standards and governance.


### PR DESCRIPTION
Adds a skill that resolves informal event/property references to their exact stored names before any downstream tool filters on them, ships it behind a flag, and documents the visibility-flag convention that had no docs.

## Why the skill

Event and property names are project-specific, and a guessed name **returns zero rows rather than erroring**. The failure mode is confidently wrong analysis rather than a visible error. The skill pushes the agent to confirm names against the project, and — the part that actually saves the next step — to explicitly call out a plausible-looking name that does *not* exist.

It covers establishing the project via `get_amplitude_context`, searching broadly with `search` before enumerating, confirming exact names with `get_events`, resolving properties with the right `get_properties` `propertyType` (it is a discriminated union, and the wrong type silently returns the wrong taxonomy), and distinguishing "not instrumented" from "instrumented but not sending" via `check_for_recent_event_ingestion`.

## Why it is gated

A brand-new skill going straight to every MCP client is unvalidated surface area, so it ships dark behind `x-amp-flags: [mcp-skill-search-events-and-properties]` and ramps in Experiment.

**That flag does not exist yet.** Until it is created in Amplitude Experiment (local evaluation mode, variant value `on`), this skill is visible to nobody through the MCP server. That is the intended state for merge.

## Why the README change

The `x-amp-flags` / `x-amp-exclude-when-flags` convention was introduced server-side in amplitude/javascript#138811 and documented **nowhere in the repo skill authors actually work in**. The README now covers both keys, the one-flag swap pattern for replacing a skill with a new version, and the three things that surprise people:

- The flag must already exist, or the skill is visible to nobody
- A typo in the frontmatter **hides** the skill rather than publishing it ungated — nothing in CI validates these keys
- Local plugin installs into Claude Code / Cursor copy **every** skill regardless, because the gate is read server-side

Default behaviour is unchanged: a skill with no `x-amp-*` keys is visible to everyone, which is why the existing 27 skills need no edits.

## Verification

- Gate parsing and application checked against the real corpus: flag off → hidden, flag on → visible; it is the only gated entry
- All tool references validated against the live **external** registry with `scripts/audit-skill-tool-refs.ts` — zero stale refs in this skill (the audit does report pre-existing ones elsewhere, e.g. `get_context` and `query_chart`, untouched here)

Related: [MCP-565](https://linear.app/amplitude/issue/MCP-565) and amplitude/javascript#138811.