### PR TITLE
MCP-433 [skills] consolidated-tool skill updates + data-driven job skills

### DIFF
--- a/plugins/amplitude/skills/analyze-ai-topics/SKILL.md
+++ b/plugins/amplitude/skills/analyze-ai-topics/SKILL.md
@@ -12,7 +12,7 @@ You analyze what users ask AI agents about and how well each topic is served —
 
 ### Step 1: Get Context and Schema
 
-1. **Get context.** Call `Amplitude:get_context` to identify projects and user role.
+1. **Get context.** Call `Amplitude:get_amplitude_context` to identify projects and user role.
 2. **Get AI schema.** Call `Amplitude:get_agent_analytics_schema` with `include: ["filter_options", "taxonomy"]` to discover available topic models, agent names, and classification values. The schema tells you what topic dimensions exist (e.g., product_area, intent, error_domain) — these vary by project.
 3. **Determine scope.** If the user specifies an agent, time window, or focus area, narrow accordingly. Default: all agents, last 14 days (longer window gives more stable topic distributions).
 

--- a/plugins/amplitude/skills/analyze-chart/SKILL.md
+++ b/plugins/amplitude/skills/analyze-chart/SKILL.md
@@ -18,7 +18,7 @@ x-amp-exclude-when-flags: [mcp-consolidate-charts]
 ### Step 0: Identify the Chart
 
 - Accept a chart **URL or chart ID**
-- If the user provides a URL, use `Amplitude:getting_data_from_url` to extract the chart ID
+- If the user provides a URL, use `Amplitude:get_from_url` to extract the chart ID
 - If no chart identifier is provided, ask explicitly for the chart URL or ID and stop
 
 ---

--- a/plugins/amplitude/skills/analyze-dashboard/SKILL.md
+++ b/plugins/amplitude/skills/analyze-dashboard/SKILL.md
@@ -17,7 +17,7 @@ description: Deeply analyze Amplitude dashboards by analyzing key charts, surfac
 
 ### Step 0: Identify the Dashboard ID
 
-If the user gives a URL, use `Amplitude:getting_data_from_url` to get the dashboard ID
+If the user gives a URL, use `Amplitude:get_from_url` to get the dashboard ID
 
 ### Step 1: Retrieve the Dashboard
 

--- a/plugins/amplitude/skills/analyze-experiment-consolidated/SKILL.md
+++ b/plugins/amplitude/skills/analyze-experiment-consolidated/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: analyze-experiments
+name: analyze-experiment-consolidated
 description: Designs A/B tests with proper metrics and variants, analyzes running or completed experiments, and interprets results with statistical rigor. Use when setting up experiments, checking experiment status, analyzing results, or making ship decisions.
-x-amp-exclude-when-flags: [mcp-consolidate-flags-experiments]
+x-amp-flags: [mcp-consolidate-flags-experiments]
 ---
 
 # Experiment Analyst
@@ -48,7 +48,7 @@ Perform comprehensive, detailed deep-dive analysis of experiments to make data-d
 
 ### Step 1: Retrieve and Validate Setup
 
-Use `Amplitude:get_experiments` with experiment ID to capture:
+Use `Amplitude:use_amp_experiments` with experiment ID to capture:
 
 - Experiment name, key, description, and state
 - Start/end dates and duration
@@ -79,7 +79,21 @@ If incomplete, explain what's missing and stop.
 
 ### Step 2: Check Data Quality (with explicit thresholds)
 
-Use `Amplitude:query_experiment` (primary metric only) to assess:
+**Assignment-segment queries (the hard part, learned from production sessions):**
+when you need ad hoc per-variant numbers outside `analyze` (entry-point
+funnels, custom slices, cross-checks against another warehouse):
+
+- Discover the assignment event first: `search` for the experiment's flag
+  key and existing charts that filter on it — do not guess the event name.
+- Read how an existing experiment chart structures its variant segments
+  (`get_amplitude_charts` with `include: "typed"` on one) and copy that
+  pattern exactly — including the bucketing property (`subject_id_type`
+  varies per experiment).
+- Verify assignment volume before analyzing: `query_dataset` for unique
+  assignments per variant since launch. Zero or lopsided assignment =
+  bucketing/ramp problem, not a metric result.
+
+Use `Amplitude:use_amp_experiments` (primary metric only) to assess:
 
 **Traffic Balance (SRM Check):**
 - Report actual traffic split per variant (e.g., 48.2% control, 51.8% treatment)
@@ -120,7 +134,7 @@ Use `Amplitude:query_experiment` (primary metric only) to assess:
 
 **Comprehensive Data Quality Flags:**
 
-The `Amplitude:query_experiment` API returns multiple boolean flags that assess statistical validity. Check and document each:
+The `Amplitude:use_amp_experiments` API returns multiple boolean flags that assess statistical validity. Check and document each:
 
 1. **statsAssumptionsMetForWholeExperiment:**
    - Indicates whether core statistical assumptions are satisfied (normality, independence)
@@ -175,7 +189,7 @@ The `Amplitude:query_experiment` API returns multiple boolean flags that assess 
 
 ### Step 3: Analyze Primary Metric
 
-Use `Amplitude:query_experiment` **without metricIds** to get primary metric only.
+Use `Amplitude:use_amp_experiments` **without metricIds** to get primary metric only.
 
 **Use metric name from Step 1** - Report using the human-readable metric name, not the metric ID.
 
@@ -201,7 +215,7 @@ Extract and report:
 
 ### Step 4: Analyze Secondary Metrics & Guardrails
 
-Use `Amplitude:query_experiment` **with metricIds** for all metrics.
+Use `Amplitude:use_amp_experiments` **with metricIds** for all metrics.
 
 **Use metric names from Step 1** - Report using human-readable metric names, not metric IDs.
 
@@ -223,7 +237,7 @@ Use `Amplitude:query_experiment` **with metricIds** for all metrics.
 
 ### Step 5: Comprehensive Segment Analysis
 
-Use `Amplitude:query_experiment` with `groupBy` parameter (one at a time).
+Use `Amplitude:use_amp_experiments` with `groupBy` parameter (one at a time).
 
 Test 3-4 high-signal segments:
 1. **Platform** (iOS, Android, Web)
@@ -521,7 +535,7 @@ If user wants to **design a new experiment**, guide them through:
    - Use `Amplitude:query_charts` to check metric's historical variance
 
 4. **Create experiment:**
-   - Use `Amplitude:create_experiment` with projectIds, variants, and metrics
+   - Use `Amplitude:use_amp_experiments` with projectIds, variants, and metrics
    - Return experiment ID, URL, and deployment key for engineering
 
 For detailed setup guidance, consider using the `setup-experiment-and-flags` skill.

--- a/plugins/amplitude/skills/build-charts-with-typed-params/SKILL.md
+++ b/plugins/amplitude/skills/build-charts-with-typed-params/SKILL.md
@@ -31,8 +31,8 @@ name that doesn't exist won't error — it returns a well-formed chart with
 
 Resolve names first with `search`, and `get_properties`
 (`propertyType: 'event'` or `'user'`). Use the exact name **and scope** that
-comes back. There is no `get_event_properties` tool — if a description mentions
-it, use `get_properties`.
+comes back. There is no `get_event_properties` tool — server descriptions and
+error messages sometimes mention it; use `get_properties` instead.
 
 ## Two workflows
 
@@ -63,8 +63,10 @@ These are shared across every chart kind.
 ```
 
 `op`: `is`, `is not`, `contains`, `does not contain`, `greater than`,
-`less than`, `set`, `is not null`. Use `contains` for prefix/substring matching
-and `set` / `is not null` for presence. `scope`: `event`, `user`, `group`,
+`less than`, `set`, `is not null`. Use `contains` for prefix/substring matching.
+**For presence checks prefer `set`** — `is not null` is rejected by some chart
+kinds (`data_table` segments) even though error hints suggest it; `set` works
+everywhere. `scope`: `event`, `user`, `group`,
 `session`, or `derivedV2` for computed properties — take the scope from the
 taxonomy lookup rather than guessing. Group-scoped properties also need
 `group_type` (e.g. `"org id"`).
@@ -94,6 +96,11 @@ Omit `segments` entirely for all users. In `performed`, `time_type` defaults to
 ```
 
 Optional `timezone` is an IANA name; omit for the project default.
+
+The relative range's **unit must match the `interval`**: with weekly interval
+write `"Last 12 Weeks"`, monthly `"Last 6 Months"` — `"Last 3 Years"` with a
+weekly interval is rejected. Re-denominate the window in the interval's unit
+or change the interval to match.
 
 **Interval** — a word, not a number: `hour`, `day` (default), `week`, `month`,
 `quarter`. Sub-daily intervals only allow short windows (`hour` caps around
@@ -131,7 +138,9 @@ Also available: `rolling_window` (days), `cumulative`, `period_over_period`
 ### `funnel`
 
 Needs `steps` (at least two) and `conversion_window` — `{value, unit}` where
-unit is `second`, `minute`, `hour`, `day`, or `week`.
+unit is `second`, `minute`, `hour`, `day`, or `week`. **Both fields are
+required** — `{value: 7}` alone fails compile with
+`conversion_window.unit: Field required`.
 
 `mode` is `ordered` (default), `unordered`, or `sequential`. `measured_as.as`
 is `conversion` (default), `conversion_over_time`, `time_to_convert`,
@@ -184,6 +193,21 @@ by plan:
   "interval": "week"
 }
 ```
+
+## Compile errors
+
+`CompileChart` failures come back as a 400 naming the offending field with a
+fix-oriented hint — read the hint, fix that one field, and retry. Do not
+rebuild the whole chart. The three seen most in production:
+
+1. **Range/interval unit mismatch** — `Invalid range format: Last 3 Years …
+   Match the relative range's unit to the interval`. Re-denominate the range
+   in the interval's unit (`Last 30 Days` at weekly interval → `Last 4 Weeks`).
+2. **Missing funnel window field** — `conversion_window.unit: Field required`.
+   Pass both `value` and `unit`.
+3. **Unknown operator** — the valid operator list differs per chart kind; the
+   fix hint in the message is usually right, but for presence checks use `set`
+   (works in every kind) rather than `is not null`.
 
 ## When results come back empty
 

--- a/plugins/amplitude/skills/chart-link-analysis/SKILL.md
+++ b/plugins/amplitude/skills/chart-link-analysis/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: chart-link-analysis
+description: Answers questions from an Amplitude chart or dashboard link — fetch the definition, pull the data, explain or adapt it. Use when the user pastes an Amplitude URL, asks "what does this chart show", wants a report refreshed from a dashboard, or wants to clone/adapt an existing analysis.
+---
+
+# Chart Link Analysis
+
+Second most common job: the user pastes a link and wants the analysis
+understood, refreshed, or adapted.
+
+## The arc
+
+1. **Resolve the URL.** `get_from_url` returns the entity type, IDs, and
+   (for charts) the current definition. One call handles chart, dashboard,
+   experiment, notebook, and cohort links — use it instead of asking the
+   user for IDs.
+2. **Read the definition.** For a chart: `get_amplitude_charts` with
+   `include: 'typed'` — the typed params mirror the chart-builder UI and are
+   the fastest way to see how the project spells events/properties. If
+   `typed` fails to lower the chart ("advanced features are not modeled"),
+   fall back to `include: 'definition'` for the raw form. For a dashboard:
+   `use_amp_dashboards` `action: 'get'` (batch ≤3) to get its chart list,
+   then read the charts that matter.
+3. **Pull the data.** `get_amplitude_charts` `include: 'data'` with the
+   chart IDs, ≤3 IDs per call. For a report refresh, request the granularity
+   the report needs (daily for week-over-week, weekly for monthlies).
+4. **Adapt or fork.** Edit the typed params, then call
+   `query_amplitude_data` with the edited `chart` **and** `chartId` set to
+   the saved chart's id — the parent's params fill gaps the typed model
+   omits, and the edit stays linked to its parent. Render the result with
+   `render_amplitude_chart`; the user saves it from the widget's **Save
+   chart** button (there is no model-facing save tool). To replicate a whole
+   dashboard in a new context: read the reference dashboard, then rebuild
+   each chart — do not try to "copy" in one call.
+
+## Expectations to set
+
+- `get_from_url` does not run the chart — it returns metadata/definition.
+  Data always comes from `get_amplitude_charts` `include: 'data'` (saved
+  charts) or `query_amplitude_data` (ad hoc).
+- `include: 'data'` returns the same numbers the UI shows, including
+  Amplitude's timezone bucketing — when comparing against external sources
+  (e.g. BigQuery), call out timezone and partial-day differences explicitly.
+- Definition reads are cheap; data reads are the expensive calls. Read all
+  definitions first, then decide which 1–3 charts actually need data.
+- Just need the link for the user? `include: 'link'` (the default) validates
+  the ids and returns URLs without running anything.
+
+## Legacy surface
+
+If `get_amplitude_charts` is not in the tool list: `get_charts` reads
+definitions, `query_charts` (≤3 ids) pulls data, `query_dataset` runs ad
+hoc, and `save_chart_edits` persists edits. The arc is unchanged.

--- a/plugins/amplitude/skills/compare-user-journeys/SKILL.md
+++ b/plugins/amplitude/skills/compare-user-journeys/SKILL.md
@@ -20,8 +20,8 @@ Investigate what distinguishes two user groups by pulling session replays and me
 - **`Amplitude:search`** — Search for existing charts, funnels, dashboards, events, and cohorts relevant to the comparison. Always check for existing analysis before building from scratch.
 - **`Amplitude:get_cohorts`** — Discover existing cohorts that define the groups (e.g., "power users", "churned", "converted").
 - **`Amplitude:get_events`** — Discover valid event names. Never guess event names.
-- **`Amplitude:get_event_properties`** — Discover properties available for segmentation.
-- **`Amplitude:query_chart`** / **`Amplitude:query_charts`** — Pull quantitative metrics segmented by the two groups for statistical grounding.
+- **`Amplitude:get_properties`** — Discover properties available for segmentation.
+- **`Amplitude:query_charts`** / **`Amplitude:query_charts`** — Pull quantitative metrics segmented by the two groups for statistical grounding.
 - **`Amplitude:get_feedback_insights`** / **`Amplitude:get_feedback_mentions`** — Check if feedback themes differ between groups.
 
 ---
@@ -49,18 +49,18 @@ If the user's request is ambiguous (e.g., "compare power users"), ask: "What def
 
 ### Step 2: Get Context and Discover Segments
 
-1. Call `Amplitude:get_context`. If multiple projects, ask which to compare within.
+1. Call `Amplitude:get_amplitude_context`. If multiple projects, ask which to compare within.
 2. Call `Amplitude:get_cohorts` to check if existing cohorts match the requested groups. Existing cohorts encode institutional knowledge — prefer them over ad-hoc definitions.
 3. Call `Amplitude:get_events` to discover events relevant to the comparison (the goal event for conversion comparisons, engagement events for activity comparisons, etc.).
-4. Call `Amplitude:get_event_properties` for the key events to discover available segmentation properties.
+4. Call `Amplitude:get_properties` for the key events to discover available segmentation properties.
 
 ### Step 3: Quantitative Comparison (Metrics)
 
 Before watching replays, establish the statistical picture. Budget: 3-4 chart queries.
 
-**First, search for existing analysis.** Call `Amplitude:search` with keywords related to the comparison (e.g., "onboarding funnel", "agent creation", "checkout conversion"). Existing charts and funnels encode institutional knowledge and save query budget. If you find a relevant funnel or segmented chart, use `Amplitude:query_chart` on it instead of building from scratch.
+**First, search for existing analysis.** Call `Amplitude:search` with keywords related to the comparison (e.g., "onboarding funnel", "agent creation", "checkout conversion"). Existing charts and funnels encode institutional knowledge and save query budget. If you find a relevant funnel or segmented chart, use `Amplitude:query_charts` on it instead of building from scratch.
 
-Use `Amplitude:query_chart` or `Amplitude:query_charts` to compare the two groups on:
+Use `Amplitude:query_charts` or `Amplitude:query_charts` to compare the two groups on:
 
 1. **Volume & composition**: How many users are in each group? What's the ratio?
 2. **Key metrics segmented by group**: Conversion rates, session frequency, feature adoption, retention — whatever metrics are most relevant to the comparison.

--- a/plugins/amplitude/skills/create-chart/SKILL.md
+++ b/plugins/amplitude/skills/create-chart/SKILL.md
@@ -73,7 +73,7 @@ Amplitude:search with entity_types=['EVENT', 'CUSTOM_EVENT']
 
 **Get properties:**
 ```
-Amplitude:get_event_properties for exact property names/values
+Amplitude:get_properties for exact property names/values
 ```
 
 **Find cohorts:**
@@ -224,7 +224,7 @@ Search for cohort, get ID, then:
 
 1. **Get context:**
 ```
-Amplitude:get_context (for projectId)
+Amplitude:get_amplitude_context (for projectId)
 ```
 
 2. **Discover events** (BROAD search first):
@@ -248,7 +248,7 @@ Amplitude:get_charts to see definition structure
 
 5. **Get properties if needed:**
 ```
-Amplitude:get_event_properties
+Amplitude:get_properties
 ```
 
 6. **Build definition** using discovered names
@@ -294,7 +294,7 @@ Amplitude:save_chart_edits with editId from query_dataset
 **Verification:**
 - Always verify event exists before using
 - Check similar charts to understand event usage
-- Confirm properties with get_event_properties
+- Confirm properties with get_properties
 
 **Comparisons:**
 - Use segments for comparing user groups on same chart

--- a/plugins/amplitude/skills/create-dashboard/SKILL.md
+++ b/plugins/amplitude/skills/create-dashboard/SKILL.md
@@ -14,7 +14,7 @@ Create new team or initiative dashboards, organize scattered charts, build execu
 Before building, understand what you're tracking:
 - Search for existing dashboards/charts related to the topic
 - Search for relevant events: `Amplitude:search` with entityTypes: ["EVENT", "CUSTOM_EVENT"]
-- Use `get_event_properties` to understand available properties for segmentation
+- Use `get_properties` to understand available properties for segmentation
 - Ask user for clarification on primary goals, key segments, or time horizons
 
 ### Step 1: Define Dashboard Purpose

--- a/plugins/amplitude/skills/daily-brief/SKILL.md
+++ b/plugins/amplitude/skills/daily-brief/SKILL.md
@@ -15,15 +15,15 @@ You are a proactive analytics advisor that delivers a concise, actionable daily 
 Before scanning data, build context about who you're talking to and what they care about.
 
 1. **Detect persona.** Ask or infer the user's role: executive, PM, analyst, growth, or engineering. This determines the language, depth, and framing of the entire briefing.
-2. **Bootstrap context (1 call first, then 2 discovery calls in parallel).** Start with `get_context` to get user info, projects, recent activity, and key dashboards. Then run **two searches in parallel** — one for org-wide signal, one for the user's own activity:
+2. **Bootstrap context (1 call first, then 2 discovery calls in parallel).** Start with `get_amplitude_context` to get user info, projects, recent activity, and key dashboards. Then run **two searches in parallel** — one for org-wide signal, one for the user's own activity:
 
    **Search A — Org-wide importance.** `search` with `isOfficial: true`, `sortOrder: "viewCount"`, `limitPerQuery: 10`. Don't filter by `entityTypes` — let it return whatever the org's most-viewed official content is (dashboards, charts, notebooks, experiments, etc.). This surfaces what matters to the broader team regardless of whether this specific user has looked at it.
 
-   **Search B — User-personalized activity.** `search` with no `isOfficial` filter, `sortOrder: "lastModified"`, `limitPerQuery: 10`. Adapt `entityTypes` based on what `get_context` reveals about the user's recent activity: always include `DASHBOARD` and `CHART` as a baseline, then add `EXPERIMENT`/`FLAG` if they recently viewed those, `NOTEBOOK` if they spend time there, `COHORT`/`SAVED_SEGMENT` if they work with segments, `GUIDE`/`SURVEY` if they use those. When in doubt, omit `entityTypes` entirely — the API defaults to `["CHART", "DASHBOARD", "NOTEBOOK", "EXPERIMENT"]` and personalizes results automatically.
+   **Search B — User-personalized activity.** `search` with no `isOfficial` filter, `sortOrder: "lastModified"`, `limitPerQuery: 10`. Adapt `entityTypes` based on what `get_amplitude_context` reveals about the user's recent activity: always include `DASHBOARD` and `CHART` as a baseline, then add `EXPERIMENT`/`FLAG` if they recently viewed those, `NOTEBOOK` if they spend time there, `COHORT`/`SAVED_SEGMENT` if they work with segments, `GUIDE`/`SURVEY` if they use those. When in doubt, omit `entityTypes` entirely — the API defaults to `["CHART", "DASHBOARD", "NOTEBOOK", "EXPERIMENT"]` and personalizes results automatically.
 
    **Merge and deduplicate** the results from both searches. Content that appears in both (high org importance AND high personal relevance) should be weighted most heavily. Content that appears only in Search A surfaces things the user wouldn't find on their own — this is where the briefing adds the most value.
 
-   Also call `get_project_context` if you already know the project ID from a previous conversation; otherwise get it from `get_context` results first.
+   Also call `get_amplitude_context` with `projectId` if you already know the project ID from a previous conversation; otherwise get it from `get_amplitude_context` results first.
 
 3. **Note focus areas.** If the user mentions specific concerns (e.g., "how's the new onboarding flow?"), weight those heavily. Otherwise, use the merged discovery results to balance the user's personal focus areas with what's most active across the org.
 
@@ -35,7 +35,7 @@ Gather data with a tight recency focus. The primary time window is **today (so f
 
 Run these in parallel where possible:
 
-1. **Fetch dashboards (1-2 calls).** Take the dashboard IDs from Phase 1 discovery plus the user's top 2-3 personal dashboards (from `get_context` results). Deduplicate and call `get_dashboard` in batches of 3 (max 2 calls = 6 dashboards). This gives you all the chart IDs you need. If Phase 1 returned fewer than 3 dashboards, run one additional `search` with `entityTypes: ["DASHBOARD"]`, `sortOrder: "viewCount"`, `limitPerQuery: 5` to fill in — otherwise skip this.
+1. **Fetch dashboards (1-2 calls).** Take the dashboard IDs from Phase 1 discovery plus the user's top 2-3 personal dashboards (from `get_amplitude_context` results). Deduplicate and call `get_dashboard` in batches of 3 (max 2 calls = 6 dashboards). This gives you all the chart IDs you need. If Phase 1 returned fewer than 3 dashboards, run one additional `search` with `entityTypes: ["DASHBOARD"]`, `sortOrder: "viewCount"`, `limitPerQuery: 5` to fill in — otherwise skip this.
 2. **Query charts in bulk (2-4 calls).** Collect all unique chart IDs from the dashboards above, plus any standalone chart/metric IDs from Phase 1 discovery. Use `query_charts` (plural) to query them in bulk batches with daily granularity over the last 7 days. Compare today and yesterday against the prior 5 days. Flag any metric where today or yesterday deviates >15% from the recent daily average or falls outside the prior 5-day range. Explicitly note if today's data is partial (e.g., "as of 2pm UTC, today is tracking at X vs. Y full-day yesterday").
 3. **Anomaly scan (no additional calls).** From the chart results already fetched, compute day-over-day deltas for every metric. Rank by absolute magnitude of change. Surface the top 5-10 biggest movers regardless of which dashboard they live on. This is analytical work on data you already have — no new tool calls needed.
 4. **Experiment check (1-2 calls).** Call `get_experiments` once. Only call `query_experiment` for experiments that appear to have changed status recently or that the user owns. Skip querying experiments that are clearly irrelevant.
@@ -103,7 +103,7 @@ Transform your analysis into a concise, narrative briefing the user could forwar
 
 Before delivering, verify your work. Prefer reviewing data you already have over making new tool calls.
 
-1. **Fact-check**: Review the data already fetched for the 2-3 most consequential claims. Only re-query with `query_chart` or `query_dataset` if you're genuinely uncertain about a number — not as a routine step. If the data came from a `query_charts` result, trust it.
+1. **Fact-check**: Review the data already fetched for the 2-3 most consequential claims. Only re-query with `query_charts` or `query_dataset` if you're genuinely uncertain about a number — not as a routine step. If the data came from a `query_charts` result, trust it.
 2. **Recency check**: Verify every finding is anchored to yesterday or today. If a finding is really about a week-long or month-long trend, either reframe it around what changed in the last 1-2 days or move it to brief background context.
 3. **Partial-day check**: If you cited today's data, confirm you noted it as partial and compared pace rather than raw totals.
 4. **Actionability gate**: Every finding MUST have at least one concrete action. If it doesn't, either add one or drop the finding.

--- a/plugins/amplitude/skills/debug-replay/SKILL.md
+++ b/plugins/amplitude/skills/debug-replay/SKILL.md
@@ -21,7 +21,7 @@ This skill operates on three Amplitude Session Replay tools. Use them in this or
 Supporting tools used in this skill:
 - **`Amplitude:get_users`** — Look up users by email, user ID, or other identifiers.
 - **`Amplitude:get_events`** — Discover valid event names before filtering. Never guess event names.
-- **`Amplitude:get_event_properties`** — Discover properties available on an event for filtering.
+- **`Amplitude:get_properties`** — Discover properties available on an event for filtering.
 - **`Amplitude:get_deployments`** — Check if error aligns with a recent deploy.
 
 ---
@@ -41,7 +41,7 @@ If the report is vague (e.g., "something is broken in checkout"), ask one clarif
 
 ### Step 2: Get Context and Find the Error Event
 
-1. Call `Amplitude:get_context`. If multiple projects, ask which to investigate.
+1. Call `Amplitude:get_amplitude_context`. If multiple projects, ask which to investigate.
 2. Call `Amplitude:get_events` to confirm the error event name exists in the project. Common patterns:
    - `[Amplitude] Error Logged` — auto-captured JS errors
    - `[Amplitude] Network Request` with status code filters — API failures

--- a/plugins/amplitude/skills/diagnose-errors/SKILL.md
+++ b/plugins/amplitude/skills/diagnose-errors/SKILL.md
@@ -33,7 +33,7 @@ All three share: `[Amplitude] Page Path`, `[Amplitude] Page URL`, `[Amplitude] S
 
 ### Step 1: Context & Scope
 
-1. Call `Amplitude:get_context`. If multiple projects, ask which to investigate.
+1. Call `Amplitude:get_amplitude_context`. If multiple projects, ask which to investigate.
 2. Determine the investigation scope from the user's request:
    - **Broad triage**: "What's broken?" → scan all three event types for the biggest problems
    - **Targeted**: "Network errors are up" → start with `[Amplitude] Network Request`, then check if they cascade into JS errors
@@ -86,7 +86,7 @@ This is where the skill adds value beyond looking at each event in isolation.
 For the top 2-3 error patterns from Step 3:
 
 1. **User scope.** Use `Amplitude:query_dataset` to count unique users affected. Compare to total active users for an impact percentage.
-2. **Segment breakdown.** Group by available user properties (platform, browser, country, plan tier, org) to determine if errors concentrate in a specific segment. Call `Amplitude:get_event_properties` if you need to discover available properties.
+2. **Segment breakdown.** Group by available user properties (platform, browser, country, plan tier, org) to determine if errors concentrate in a specific segment. Call `Amplitude:get_properties` if you need to discover available properties.
 3. **Session Replays.** For the most impactful error pattern, call `Amplitude:get_session_replays` filtered to sessions containing the error event. Provide 2-3 replay links so the user can see exactly what happened.
 
 ### Step 5: Root Cause Hypothesis

--- a/plugins/amplitude/skills/discover-analytics-patterns/SKILL.md
+++ b/plugins/amplitude/skills/discover-analytics-patterns/SKILL.md
@@ -53,7 +53,7 @@ project. If its input schema accepts `_client`, every `get_events` call made by
 this skill MUST include the top-level argument
 `"_client": { "type": "skill", "skill_name": "discover-analytics-patterns" }`
 in the tool arguments; otherwise, omit `_client`. Use those results to choose a
-few representative non-system product events, then call `get_event_properties`
+few representative non-system product events, then call `get_properties`
 for those events to inspect real property names. This is your primary naming
 reference.
 
@@ -141,7 +141,7 @@ Use this precedence order:
    inference for whatever it specifies. Only fall through when the file is absent
    or silent on naming.
 2. **Amplitude MCP second.** If the observed `eventType` values and
-   property names returned by `get_event_properties` for a few representative
+   property names returned by `get_properties` for a few representative
    non-system events show a clear dominant convention, use that. Do not use
    bracket-prefixed Amplitude system names as naming evidence.
 3. **Codebase third.** If the MCP evidence is unavailable, sparse, or

--- a/plugins/amplitude/skills/discover-event-surfaces/SKILL.md
+++ b/plugins/amplitude/skills/discover-event-surfaces/SKILL.md
@@ -97,7 +97,7 @@ avoid duplicates and match the naming convention already in use.
 ### Resolve the project
 
 If the change_brief includes an Amplitude `projectId`, use it directly. Otherwise,
-call `get_context` to resolve the project name or ask the user which project to
+call `get_amplitude_context` to resolve the project name or ask the user which project to
 target. You need a `projectId` for the next call.
 
 ### Pull existing events

--- a/plugins/amplitude/skills/discover-opportunities/SKILL.md
+++ b/plugins/amplitude/skills/discover-opportunities/SKILL.md
@@ -14,7 +14,7 @@ You are a product analytics investigator that discovers high-impact opportunitie
 
 Before investigating, build context about the product and what matters.
 
-1. **Bootstrap context.** Call `get_context` to get the user's org, projects, and recent activity. Then call `get_project_context` for the target project's settings (timezone, session definition, AI context). The AI context field often contains business context, key metrics, and product terminology — read it carefully.
+1. **Bootstrap context.** Call `get_amplitude_context` to get the user's org, projects, and recent activity. Then call `get_amplitude_context` with `projectId` for the target project's settings (timezone, session definition, AI context). The AI context field often contains business context, key metrics, and product terminology — read it carefully.
 
 2. **Discover what exists (2 parallel searches).**
 
@@ -48,7 +48,7 @@ For each funnel chart discovered, examine:
 - The step with the largest absolute drop-off
 - Whether drop-off is getting worse or better over time
 
-If no funnel charts exist but the user mentioned a flow, use `query_dataset` to build an ad-hoc funnel. Call `get_event_properties` for the relevant events first to discover which properties are available for segmentation (platform, plan, country, etc.) — don't guess property names.
+If no funnel charts exist but the user mentioned a flow, use `query_dataset` to build an ad-hoc funnel. Call `get_properties` for the relevant events first to discover which properties are available for segmentation (platform, plan, country, etc.) — don't guess property names.
 
 #### 2c. Experiment Insights
 

--- a/plugins/amplitude/skills/investigate-ai-session/SKILL.md
+++ b/plugins/amplitude/skills/investigate-ai-session/SKILL.md
@@ -108,7 +108,7 @@ Structure the output as a root cause analysis.
 
 7. **Recommended fixes** (2-4 numbered items): Concrete actions. Examples:
    - "Add a retry with exponential backoff for the query_dataset tool — 8 of 15 failures are transient timeouts"
-   - "The agent is calling get_events before get_context, causing a missing project ID error — fix the tool ordering in the agent prompt"
+   - "The agent is calling get_events before get_amplitude_context, causing a missing project ID error — fix the tool ordering in the agent prompt"
    - "Users asking about retention are getting routed to the Chart Agent instead of the Funnel Agent — update the routing logic"
 
 8. **Follow-on prompt**: Offer next steps — "Want me to check if this tool timeout affects other agents, search for similar user complaints, or monitor this pattern over the next few days?"

--- a/plugins/amplitude/skills/live-data-forensics/SKILL.md
+++ b/plugins/amplitude/skills/live-data-forensics/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: live-data-forensics
+description: Investigates live product issues against Amplitude data — "is X firing today", "did the release break Y", "which users are affected by Z". Covers the verify-then-query loop, query_amplitude_data parameterization, and its common failure modes. Use for incident analysis, instrumentation checks, and affected-user discovery.
+---
+
+# Live Data Forensics
+
+The most common multi-tool job on this MCP server: verify live event
+behavior, quantify impact, find affected users. Calls observed in the wild
+follow one arc — follow it too.
+
+## The arc
+
+1. **Context.** `get_amplitude_context` (no args) → again with `projectId`.
+   Do not guess project IDs.
+2. **Reuse before rebuild.** `search` for existing analyses of the same
+   area — saved charts already encode correct event names and segments.
+3. **Verify taxonomy before querying.** `manage_amp_events` `action: 'get'`
+   to confirm candidate event names exist (returns category, isInSchema,
+   isQueryable), `get_properties`
+   (`propertyType: 'event' | 'user' | 'group'`) for the exact property names
+   **and scope** (`event` vs `user` vs `derived`). Never guess names — a wrong
+   name returns a well-formed chart with empty data, which reads as "zero".
+4. **Check the event is live.** `check_for_recent_event_ingestion` confirms
+   first-seen/last-seen before you query — a silent event means the chart
+   will be empty no matter how correct the definition is.
+5. **Quantify.** `query_amplitude_data` bursts — one slice per call (by
+   version, by reason property, by platform), not one mega-query. Prefer the
+   typed `chart` parameter (`kind: 'segmentation'`, events + where/group_by +
+   date_range); it compiles server-side and validation + taxonomy checks run
+   automatically — no separate pre-flight call needed. Compare prod vs
+   staging/UAT projects when the question is environment-specific.
+6. **Find affected users.** `query_amplitude_data` with a user-ID group_by
+   to rank affected users → `use_amplitude_cohorts` `action: 'find'` for the
+   full set.
+7. **Reconstruct timelines.** `get_amp_user_data` `include: 'timeline'` per
+   user, batched (10–20 parallel calls is normal for population analysis;
+   the tool accepts up to 10 identifiers per call).
+
+## query_amplitude_data parameterization (this is where most errors come from)
+
+- **Compile errors are self-serve.** The typed path fails with a 400 naming
+  the offending field plus a fix hint — fix that one field and retry, don't
+  rebuild. The three seen most: relative range whose unit doesn't match
+  `interval` ("Last 3 Years" at weekly interval — re-denominate as
+  "Last 156 Weeks" or change the interval); funnel `conversion_window`
+  missing `unit`; unknown filter operator for that chart kind (use `set`
+  for presence — works in every kind).
+- **Date range is required** — set `date_range` explicitly, either
+  `{relative: "Last 30 Days"}` or `{start, end}` epoch seconds, never both.
+  Sub-daily intervals only allow short windows (`hour` caps ~8 days); daily
+  granularity caps around 30 days.
+- **Every filter needs a valid operator and matching scope** — take `op`
+  and `scope` from the taxonomy lookup, not intuition. A scope mismatch
+  ("property X is not tracked on this event_type") means you used a user
+  property as an event property or vice versa.
+- **Segments combine property conditions and behaviors** — `where` (property
+  conditions) plus `performed` ("users who did event ≥N times in a window").
+  Omit `segments` entirely for all users.
+- **Raw `definition` fallback** (composition, revenueLtv, advanced params):
+  on failure the response embeds the chart-type schema with valid enums and
+  a working example — fix from that and retry.
+- `read ETIMEDOUT` is a backend timeout — narrow the date range/filters and
+  retry once.
+
+## Legacy surface
+
+If `query_amplitude_data` is not in the tool list, the caller is on the
+unramped surface: use `query_dataset` (same job; prototype with
+`get_chart_definition_params` + `verify_chart_definition` first),
+`get_events` for taxonomy, `get_users` for user sets, and
+`get_user_timeline` for timelines. The arc is unchanged.
+
+## What to report back
+
+- Whether the event fires at all, volume, and since when (first-seen).
+- Impact: affected-user count and share of active users.
+- The slices that matter (version, platform, reason property).
+- Affected-user evidence: top users by volume + 2–3 reconstructed timelines.

--- a/plugins/amplitude/skills/manage-amp-context/SKILL.md
+++ b/plugins/amplitude/skills/manage-amp-context/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: manage-amp-context
+description: Lists projects for an employee-accessible organization or writes organization/project AI context with `manage_amp_context`; use `get_amplitude_context` for reads.
+x-amp-flags: [mcp-consolidate-context]
+---
+
+# Manage Amp Context
+
+## Choose an action
+
+- `list_projects`: list projects for a customer organization when the caller is an Amplitude employee with an admin grant.
+- `set_org_context`: replace organization-level AI context.
+- `set_project_context`: replace project-level AI context.
+- For all context reads and accessible-project discovery, use `get_amplitude_context`, not this tool.
+
+## Required inputs
+
+- `list_projects`: pass the customer `orgId`.
+- `set_org_context`: pass non-empty `context` up to 10,000 characters; org-admin access is required.
+- `set_project_context`: pass `projectId` and non-empty `context` up to 10,000 characters; project manager/admin access is required.
+
+## Output and guardrails
+
+Context writes overwrite the existing value. Confirm the target scope and exact replacement text before writing, and do not use `list_projects` for ordinary customer project discovery.

--- a/plugins/amplitude/skills/monitor-ai-quality/SKILL.md
+++ b/plugins/amplitude/skills/monitor-ai-quality/SKILL.md
@@ -12,7 +12,7 @@ You are a proactive AI operations advisor that delivers a concise, actionable he
 
 ### Phase 1: Get Context and Schema
 
-1. **Get context.** Call `Amplitude:get_context` to identify the user's projects and role.
+1. **Get context.** Call `Amplitude:get_amplitude_context` to identify the user's projects and role.
 2. **Get AI schema.** Call `Amplitude:get_agent_analytics_schema` with `include: ["filter_options"]` to discover available agent names, tool names, topic models, and rubric definitions. This tells you what's in the data before you query it.
 3. **Determine scope.** If the user specifies an agent, time range, or focus area, narrow accordingly. Otherwise default to all agents over the last 7 days.
 

--- a/plugins/amplitude/skills/monitor-experiments-consolidated/SKILL.MD
+++ b/plugins/amplitude/skills/monitor-experiments-consolidated/SKILL.MD
@@ -1,7 +1,7 @@
 ---
-name: monitor-experiments
+name: monitor-experiments-consolidated
 description: Monitors all active and recently completed experiments across Amplitude projects, triages them by importance, then runs deep analysis and reporting on the most impactful ones. Use when the user asks to "check on experiments", "experiment status", "experiment review", "what experiments are running", or wants a periodic experiment health report.
-x-amp-exclude-when-flags: [mcp-consolidate-flags-experiments]
+x-amp-flags: [mcp-consolidate-flags-experiments]
 ---
 
 # Experiment Monitor & Report Generator
@@ -14,8 +14,8 @@ This is a **monitoring** skill — keep output accessible to non-experts. Avoid 
 
 ## CRITICAL: Managing Response Sizes
 
-1. **`get_experiments`: 3-5 IDs max per call.** Filter using `search` results BEFORE fetching.
-2. **`query_experiment` responses are large.** Extract only `summary` objects and validity flags. Ignore `timeseries`, `xValues`, bulk arrays.
+1. **`use_amp_experiments` action `get`: 3-5 IDs max per call.** Filter using `search` results BEFORE fetching.
+2. **`use_amp_experiments` action `analyze` responses are large.** Extract only `summary` objects and validity flags. Ignore `timeseries`, `xValues`, bulk arrays.
 3. **Metric name resolution**: `search` does NOT match metric IDs in `queries`. Search with `entityTypes: ["METRIC"]`, empty `queries`, `limitPerQuery: 50`, scoped to project. Match IDs from results.
 
 ---
@@ -56,11 +56,11 @@ Amplitude:search({
 
 ### Step 2: Fetch Metadata, Metric Names & Primary Results
 
-1. Call `Amplitude:get_experiments` in batches of 3-5 IDs (only the filtered set from Step 1).
+1. Call `Amplitude:use_amp_experiments` with `action: "get"` and `ids` in batches of 3-5 (only the filtered set from Step 1).
 2. Extract: state, dates/duration, variants, metric IDs (primary where recommendation=true), decision, owner.
 3. Apply the filtering rules from Step 1 again using the detailed metadata (some fields like stale status or decision may only be available here).
 4. Resolve metric names via `Amplitude:search({ entityTypes: ["METRIC"], appIds: [projectId], queries: [], limitPerQuery: 50 })`. Build `{ id: name }` mapping.
-5. For experiments that have metrics configured, call `Amplitude:query_experiment({ id: "<id>" })` (no metricIds) to get primary metric results and data quality flags. This data feeds both the summary table and the deep-dives.
+5. For experiments that have metrics configured, call `Amplitude:use_amp_experiments({ action: "analyze", id: "<id>" })` (no metricIds) to get primary metric results and data quality flags. This data feeds both the summary table and the deep-dives.
 
 **CRITICAL: Never show raw metric IDs to the user.** If a metric name can't be resolved, describe it by its role (e.g., "primary metric", "guardrail metric") — do NOT display strings like "rrgtky08" or "Metric gvgb5efj". Metric IDs are internal identifiers that mean nothing to a human reader.
 
@@ -206,7 +206,7 @@ Add one sentence on practical significance only if lift is very small (<2%) or v
 
 **Guardrails & Secondary Metrics:**
 
-Call `Amplitude:query_experiment({ id: "<id>", metricIds: [...] })`.
+Call `Amplitude:use_amp_experiments({ action: "analyze", id: "<id>", metricIds: [...] })`.
 
 Focus on catching regressions, not narrating every metric.
 
@@ -299,7 +299,7 @@ Each experiment appears in exactly one detail section. Do NOT list an experiment
 - **Response too large / saved to disk:** Extract `summary` + validity flags only
 - **No metrics configured:** List in "Needs Setup" section, don't deep-dive
 - **All experiments are stale:** Report that there are no active experiments to monitor
-- **Query error from `query_experiment`:** Report the error clearly with the experiment owner's name. Flag as "Fix config" in the summary. Common causes: broken exposure event property, misconfigured experiment key.
+- **Query error from `use_amp_experiments` action `analyze`:** Report the error clearly with the experiment owner's name. Flag as "Fix config" in the summary. Common causes: broken exposure event property, misconfigured experiment key.
 - **Traffic allocation changed mid-experiment:** Flag in data quality. Compare current weights to cumulative exposure distribution. Note which variants are no longer receiving traffic.
 - **Survey/nudge experiments (NPS, etc.):** Note in summary as N/A. No analysis needed — skip deep-dive.
 - **Severely imbalanced traffic (e.g., 5%/95% or 0%/100%):** Flag as "Fix config" — can't run a valid experiment without a meaningful control group. Note in needs-setup with owner.

--- a/plugins/amplitude/skills/monitor-reliability/SKILL.md
+++ b/plugins/amplitude/skills/monitor-reliability/SKILL.md
@@ -53,7 +53,7 @@ If the user provides a deployment date or says "did the release break anything,"
 
 ### Phase 1: Context & Baseline
 
-1. Call `Amplitude:get_context`. If multiple projects, ask which to monitor. Call `Amplitude:get_project_context` for project settings.
+1. Call `Amplitude:get_amplitude_context`. If multiple projects, ask which to monitor. Call `Amplitude:get_amplitude_context` for project settings.
 2. Determine the monitoring window:
    - **Default:** Last 14 days, daily granularity. Days 1-7 = baseline, days 8-14 = current.
    - **Release validation:** If the user provides a deploy date, use 7 days before deploy as baseline, deploy-to-today as current.

--- a/plugins/amplitude/skills/replay-ux-audit/SKILL.md
+++ b/plugins/amplitude/skills/replay-ux-audit/SKILL.md
@@ -18,8 +18,8 @@ Watch 5-10 session replays for a specific feature, page, or flow, then synthesiz
 
 **Supporting tools:**
 - **`Amplitude:get_events`** — Discover valid event names. Never guess event names.
-- **`Amplitude:get_event_properties`** — Discover properties for filtering (page path, feature area, etc.).
-- **`Amplitude:query_chart`** — Pull quantitative context (funnel conversion rates, feature adoption) to anchor the qualitative replay findings.
+- **`Amplitude:get_properties`** — Discover properties for filtering (page path, feature area, etc.).
+- **`Amplitude:query_charts`** — Pull quantitative context (funnel conversion rates, feature adoption) to anchor the qualitative replay findings.
 - **`Amplitude:get_feedback_insights`** / **`Amplitude:get_feedback_mentions`** — Cross-reference replay friction with customer feedback themes.
 
 ---
@@ -41,7 +41,7 @@ Also determine:
 
 ### Step 2: Get Context and Discover Events
 
-1. Call `Amplitude:get_context`. If multiple projects, ask which to audit.
+1. Call `Amplitude:get_amplitude_context`. If multiple projects, ask which to audit.
 2. Call `Amplitude:get_events` to find events related to the target area. Look for:
    - Page view or navigation events for the target area
    - Key interaction events (clicks, form submissions) within the flow
@@ -52,7 +52,7 @@ Also determine:
 
 Before watching replays, establish context with 1-2 chart queries. Budget: 2 calls max.
 
-- If auditing a **funnel**: Use `Amplitude:query_chart` to get the current conversion rate and identify the worst drop-off step. This tells you where to focus your replay attention.
+- If auditing a **funnel**: Use `Amplitude:query_charts` to get the current conversion rate and identify the worst drop-off step. This tells you where to focus your replay attention.
 - If auditing a **page**: Query the page's traffic volume and any error rates to understand scale.
 - If auditing a **feature**: Query adoption/usage frequency to understand how many users interact with it.
 

--- a/plugins/amplitude/skills/review-agent-insights/SKILL.md
+++ b/plugins/amplitude/skills/review-agent-insights/SKILL.md
@@ -16,7 +16,7 @@ Surface everything Amplitude's AI agents have found recently. Query **every avai
 - **`Amplitude:get_agent_results`** — Retrieve pre-computed analyses from Amplitude's AI agents. Supports multiple agent types (check the tool's `agent_type` enum for the current list). Each agent type is queried separately. All support filtering by `created_after`, `created_before`, `query`, `agent_params`, and `limit`.
 
 **Supporting tools:**
-- **`Amplitude:get_context`** / **`Amplitude:get_project_context`** — Bootstrap user, org, and project info.
+- **`Amplitude:get_amplitude_context`** / **`Amplitude:get_amplitude_context`** — Bootstrap user, org, and project info.
 - **`Amplitude:get_deployments`** — Check whether fixes have shipped for flagged issues (staleness validation).
 
 ---
@@ -25,8 +25,8 @@ Surface everything Amplitude's AI agents have found recently. Query **every avai
 
 ### Step 1: Bootstrap Context (1-2 calls)
 
-1. Call `Amplitude:get_context` to get the user's org, projects, recent activity, and key dashboards. If multiple projects, ask which to review — or review all if the user wants a broad scan.
-2. Call `Amplitude:get_project_context` for the target project's settings and AI context.
+1. Call `Amplitude:get_amplitude_context` to get the user's org, projects, recent activity, and key dashboards. If multiple projects, ask which to review — or review all if the user wants a broad scan.
+2. Call `Amplitude:get_amplitude_context` for the target project's settings and AI context.
 
 Determine the **review window** from the user's request:
 - Default: **last 7 days** (good balance of recency and coverage).

--- a/plugins/amplitude/skills/scheduled-report-refresh/SKILL.md
+++ b/plugins/amplitude/skills/scheduled-report-refresh/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: scheduled-report-refresh
+description: Refreshes recurring reports (daily briefings, WBRs, experiment briefs) from saved Amplitude content — fetch the dashboard, re-pull its charts, fill gaps with ad hoc queries, summarize deltas. Use for "run the daily/weekly report", "refresh this dashboard's numbers", or scheduled custom-agent report runs.
+---
+
+# Scheduled Report Refresh
+
+The dominant *automated* job on this MCP server: custom agents and
+scheduled runs re-pulling a known set of charts and summarizing changes.
+
+## The arc
+
+1. **Anchor on saved content.** `use_amp_dashboards` `action: 'get'`
+   (batch ≤3) for the report's chart list, or `get_from_url` if the run
+   input is a link. Saved charts are the contract — do not rebuild
+   definitions from scratch.
+2. **Re-pull data.** `get_amplitude_charts` `include: 'data'`, ≤3 chart IDs
+   per call, at the report's granularity (daily for daily/weekly briefs).
+   For each chart compare the current period against the trailing baseline
+   the report uses.
+3. **Fill gaps ad hoc.** `query_amplitude_data` (typed `chart`) only for
+   numbers no saved chart covers (a new funnel step, a one-off slice).
+4. **Context for movement.** `get_deployments` once — recent deploys are
+   the first hypothesis for any metric movement.
+5. **Report.** Delta table first (metric, current, baseline, % change),
+   then notable movers with hypotheses. State explicitly when the current
+   period is partial ("today is tracking at X vs Y full-day yesterday").
+
+## Expectations to set
+
+- `get_amplitude_charts` `include: 'data'` on a saved chart returns exactly
+  what the UI shows — trust it; don't re-validate every number with
+  `query_amplitude_data`.
+- Keep definition reads (`include: 'definition'` / `'typed'`) minimal on
+  refresh runs — the dashboard chart list plus data is enough unless a chart
+  looks misconfigured.
+- If a chart errors or returns empty, report it as a broken report item
+  rather than silently dropping it — a missing tile in a recurring report
+  is itself a finding.
+
+## Legacy surface
+
+If `use_amp_dashboards` / `get_amplitude_charts` are not in the tool list:
+`get_dashboard` reads the chart list, `query_charts` (≤3 ids) pulls data,
+and `query_dataset` fills gaps. The arc is unchanged.

--- a/plugins/amplitude/skills/taxonomy/SKILL.md
+++ b/plugins/amplitude/skills/taxonomy/SKILL.md
@@ -406,10 +406,10 @@ These are the actual Amplitude MCP server tools available for taxonomy work. Too
 
 ## Context
 
-### `get_context`
+### `get_amplitude_context`
 Get information about the current user, organization, and accessible projects. Call this first to discover project IDs.
 
-### `get_project_context`
+### `get_amplitude_context` with `projectId`
 Get project-specific settings: time zone, currency, session definition, AI context. Use to understand project configuration before making changes.
 
 ### `search`

--- a/plugins/amplitude/skills/use-amp-guides-surveys/SKILL.md
+++ b/plugins/amplitude/skills/use-amp-guides-surveys/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: use-amp-guides-surveys
+description: Lists Amplitude Guides and Surveys or reads one item's full configuration with `use_amp_guides_surveys`.
+x-amp-flags: [mcp-read-guide-survey-external, mcp-consolidate-guides-surveys]
+---
+
+# Use Amp Guides Surveys
+
+## Choose an action
+
+- `list` (default): discover or compare guides and surveys with project, type, platform, creator, date, archive, and pagination filters.
+- `get`: read one guide or survey's rollout, targeting, triggers, variants, and step content.
+
+## Required inputs
+
+- Always pass `projectId`; use `get_amplitude_context` first when it is unknown.
+- For `get`, also pass `nudgeId`. For `list`, pass only filters supported by the tool and reuse `nextCursor` when more results are available.
+
+## Output and guardrails
+
+Call guides and surveys by those user-facing names, not “nudges.” Link each returned title to its URL; keep lists compact and summarize detailed configuration around the user's question.

--- a/plugins/amplitude/skills/user-cohort-forensics/SKILL.md
+++ b/plugins/amplitude/skills/user-cohort-forensics/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: user-cohort-forensics
+description: Investigates individual users and user populations in Amplitude — resolve users by email/ID, read profiles, batch-analyze event timelines, spot-check cohort membership. Use for "what did user X do", attribution audits, population sampling, and email-to-user-ID resolution.
+---
+
+# User & Cohort Forensics
+
+## The arcs
+
+**Single user deep-dive:** `get_amp_user_data` `include: 'id'` (resolve the
+user: email, user ID, device ID, or amplitude ID) → `include: 'profile'`
+(lifecycle, acquisition, usage stats) → `include: 'timeline'` (session-aware
+event history). `include: 'both'` gets profile + timeline in one call when
+you know you'll need both. Summarize journeys; don't dump raw events.
+
+**Population analysis (batched):** build the user set first
+(`query_amplitude_data` with a user-ID group_by to rank by volume, or
+`use_amplitude_cohorts` `action: 'find'` for a filtered set) →
+`get_amp_user_data` `include: 'timeline'` in parallel batches — up to 10
+identifiers per call, 10–20 calls in flight is normal for population
+analysis; hundreds of calls total is fine. Keep each call narrow (event
+types, window) so responses stay small.
+
+**Cohort spot-check:** prefer existing cohorts — `use_amplitude_cohorts`
+`action: 'list'` (backed by `search`) or `action: 'get'` before building ad
+hoc definitions. `action: 'membership'` verifies specific users. Check a
+member's timeline for the exact markers (purchase, typing, checkout events)
+rather than trusting the cohort definition blindly.
+
+**Email → ID resolution:** `get_amp_user_data` `include: 'id'` per email;
+uploaded email lists are resolved in batches of ≤10 identifiers per call.
+For bulk exports, batch and note the retry pattern on individual failures.
+
+## Parameterization notes
+
+- `include: 'timeline'`: always bound the window (last 30 days by default)
+  and pass event-type filters when you know what you're looking for —
+  unfiltered timelines are large and slow.
+- Rate-limit failures come back flagged `retryable` with `retryAfterMs` —
+  back off instead of churning.
+- User identity: a user can match multiple IDs (device, user, email). Say
+  which identity you resolved and flag ambiguous matches instead of picking
+  one silently.
+
+## Legacy surface
+
+If `get_amp_user_data` / `use_amplitude_cohorts` are not in the tool list:
+`get_users` resolves and lists users, `get_user_profile` / `get_user_timeline`
+read one user each, and `get_cohorts` / `check_cohort_membership` cover
+cohorts. The arcs are unchanged.

--- a/plugins/amplitude/skills/weekly-brief/SKILL.md
+++ b/plugins/amplitude/skills/weekly-brief/SKILL.md
@@ -15,15 +15,15 @@ You are a proactive analytics advisor that delivers a concise, actionable weekly
 Before scanning data, build context about who you're talking to and what they care about.
 
 1. **Detect persona.** Ask or infer the user's role: executive, PM, analyst, growth, or engineering. This determines the language, depth, and framing of the entire briefing.
-2. **Bootstrap context (1 call first, then 2 discovery calls in parallel).** Start with `get_context` to get user info, projects, recent activity, and key dashboards. Then run **two searches in parallel** — one for org-wide signal, one for the user's own activity:
+2. **Bootstrap context (1 call first, then 2 discovery calls in parallel).** Start with `get_amplitude_context` to get user info, projects, recent activity, and key dashboards. Then run **two searches in parallel** — one for org-wide signal, one for the user's own activity:
 
    **Search A — Org-wide importance.** `search` with `isOfficial: true`, `sortOrder: "viewCount"`, `limitPerQuery: 10`. Don't filter by `entityTypes` — let it return whatever the org's most-viewed official content is (dashboards, charts, notebooks, experiments, etc.). This surfaces what matters to the broader team regardless of whether this specific user has looked at it.
 
-   **Search B — User-personalized activity.** `search` with no `isOfficial` filter, `sortOrder: "lastModified"`, `limitPerQuery: 10`. Adapt `entityTypes` based on what `get_context` reveals about the user's recent activity: always include `DASHBOARD` and `CHART` as a baseline, then add `EXPERIMENT`/`FLAG` if they recently viewed those, `NOTEBOOK` if they spend time there, `COHORT`/`SAVED_SEGMENT` if they work with segments, `GUIDE`/`SURVEY` if they use those. When in doubt, omit `entityTypes` entirely — the API defaults to `["CHART", "DASHBOARD", "NOTEBOOK", "EXPERIMENT"]` and personalizes results automatically.
+   **Search B — User-personalized activity.** `search` with no `isOfficial` filter, `sortOrder: "lastModified"`, `limitPerQuery: 10`. Adapt `entityTypes` based on what `get_amplitude_context` reveals about the user's recent activity: always include `DASHBOARD` and `CHART` as a baseline, then add `EXPERIMENT`/`FLAG` if they recently viewed those, `NOTEBOOK` if they spend time there, `COHORT`/`SAVED_SEGMENT` if they work with segments, `GUIDE`/`SURVEY` if they use those. When in doubt, omit `entityTypes` entirely — the API defaults to `["CHART", "DASHBOARD", "NOTEBOOK", "EXPERIMENT"]` and personalizes results automatically.
 
    **Merge and deduplicate** the results from both searches. Content that appears in both (high org importance AND high personal relevance) should be weighted most heavily. Content that appears only in Search A surfaces things the user wouldn't find on their own.
 
-   Also call `get_project_context` if you already know the project ID from a previous conversation; otherwise get it from `get_context` results first.
+   Also call `get_amplitude_context` with `projectId` if you already know the project ID from a previous conversation; otherwise get it from `get_amplitude_context` results first.
 
 3. **Note focus areas.** If the user mentions specific concerns, weight those heavily. Otherwise, use the merged discovery results to balance the user's personal focus areas with what's most active across the org.
 
@@ -35,7 +35,7 @@ Gather data with a full-week lens. The primary time window is **the last 7 compl
 
 Run these in parallel where possible:
 
-1. **Fetch dashboards (1-2 calls).** Take the dashboard IDs from Phase 1 discovery plus the user's top 2-3 personal dashboards (from `get_context` results). Deduplicate and call `get_dashboard` in batches of 3 (max 2 calls = 6 dashboards). This gives you all the chart IDs you need. If Phase 1 returned fewer than 3 dashboards, run one additional `search` with `entityTypes: ["DASHBOARD"]`, `sortOrder: "viewCount"`, `limitPerQuery: 5` to fill in — otherwise skip this.
+1. **Fetch dashboards (1-2 calls).** Take the dashboard IDs from Phase 1 discovery plus the user's top 2-3 personal dashboards (from `get_amplitude_context` results). Deduplicate and call `get_dashboard` in batches of 3 (max 2 calls = 6 dashboards). This gives you all the chart IDs you need. If Phase 1 returned fewer than 3 dashboards, run one additional `search` with `entityTypes: ["DASHBOARD"]`, `sortOrder: "viewCount"`, `limitPerQuery: 5` to fill in — otherwise skip this.
 2. **Query charts in bulk (2-4 calls).** Collect all unique chart IDs from the dashboards above, plus any standalone chart/metric IDs from Phase 1 discovery. Use `query_charts` (plural) to query them in bulk batches with **weekly granularity over the last 5 weeks**. Compare this week against the prior 4-week average. Flag any metric where this week deviates >10% from the trailing 4-week average or shows a consistent multi-week trend (3+ weeks in the same direction). Note if the current week is partial and adjust comparisons accordingly.
 3. **Trend detection (no additional calls).** From the chart results already fetched, compute week-over-week deltas for every metric. Identify: (a) **accelerating trends** — metrics that moved >10% WoW for 2+ consecutive weeks, (b) **inflection points** — metrics that reversed direction this week, (c) **new highs/lows** — metrics that hit their best or worst value in the 5-week window. Rank by magnitude and strategic importance.
 4. **Experiment check (1-2 calls).** Call `get_experiments` once. Focus on experiments that concluded this week, hit significance this week, or have been running >14 days without a call. Only call `query_experiment` for the most relevant ones.
@@ -104,7 +104,7 @@ Transform your analysis into a concise, narrative briefing the user could forwar
 
 Before delivering, verify your work. Prefer reviewing data you already have over making new tool calls.
 
-1. **Fact-check**: Review the data already fetched for the 2-3 most consequential claims. Only re-query with `query_chart` or `query_dataset` if you're genuinely uncertain about a number — not as a routine step. If the data came from a `query_charts` result, trust it.
+1. **Fact-check**: Review the data already fetched for the 2-3 most consequential claims. Only re-query with `query_charts` or `query_dataset` if you're genuinely uncertain about a number — not as a routine step. If the data came from a `query_charts` result, trust it.
 2. **Trend check**: Verify every finding is framed as a week-over-week or multi-week trend, not a single-day event. If a finding is really a daily story, either reframe it in weekly context or flag it as a one-day spike within the weekly narrative.
 3. **Partial-week check**: If you cited this week's data and it's incomplete, confirm you compared pace rather than raw totals and noted the partial status.
 4. **Actionability gate**: Every finding MUST have at least one concrete action. If it doesn't, either add one or drop the finding.


### PR DESCRIPTION
## What

Updates the amplitude skill corpus for the consolidated MCP tool surface, and adds four data-driven job skills built from production usage analysis (tool rationale fields, session call-sequences, and Datadog error catalogs).

**Legacy skills (22 updated)**
- Renamed stale tool references to current external names (`get_amplitude_context`, `query_charts`, `get_from_url`, `get_properties`, …) — verified by `scripts/audit-skill-tool-refs.ts` (35 skills, 0 stale refs).
- `analyze-experiment` / `monitor-experiments` now carry `x-amp-exclude-when-flags: [mcp-consolidate-flags-experiments]`, paired with new gated `-consolidated` variants.

**New flag-gated consolidated-variant skills**
- `analyze-experiment-consolidated`, `monitor-experiments-consolidated` → `mcp-consolidate-flags-experiments`
- `manage-amp-context` → `mcp-consolidate-context`
- `use-amp-guides-surveys` → `mcp-read-guide-survey-external` + `mcp-consolidate-guides-surveys`

**New data-driven job skills** (the top observed multi-tool jobs, with parameterization + failure-mode guidance)
- `live-data-forensics` — verify-then-query incident loop
- `chart-link-analysis` — URL → definition → data → fork arc
- `user-cohort-forensics` — user resolution, batched timelines, cohort spot-checks
- `scheduled-report-refresh` — dashboard re-pull + delta reporting

These four are **consolidated-first** (`query_amplitude_data` typed `chart`, `get_amplitude_charts` modes, `use_amp_dashboards`, `get_amp_user_data`, `use_amplitude_cohorts`, `manage_amp_events`) with a compact "Legacy surface" fallback note instead of gated pairs: prod already runs those consolidation flags, the jobs span 3–4 independently-ramped flags each, and `x-amp-flags` is AND-semantics — gated pairs would leave a coverage gap mid-ramp.

**`build-charts-with-typed-params`** — restored the `get_event_properties` inoculation note (no such tool exists; server descriptions reference it), added the top-3 production `CompileChart` errors with fixes (range/interval unit mismatch, funnel `conversion_window.unit` required, `set` vs `is not null` presence op).

## Notes for reviewers

- No manifest changes; version bump handled by auto-version-bump on merge.
- Skills are served as MCP resources gated by `mcp-skills-as-resources`; new ungated skills (the 4 job skills) become visible wherever that master flag is on.
- Server-side follow-ups filed separately (not this repo): phantom `get_event_properties` references in 4 server descriptions, Langley's contradictory `is not null` operator hint on data_table.