### PR TITLE
Add Amplitude Wave opportunity workflow plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,6 +15,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity"
+    },
+    {
+      "name": "wave",
+      "source": {
+        "source": "local",
+        "path": "./plugins/wave"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -41,6 +41,30 @@
       "category": "analytics"
     },
     {
+      "name": "wave",
+      "source": "./plugins/wave",
+      "description": "Run the Amplitude Wave self-improving product loop from codebase-validated opportunity to review-ready PR, optional experiment, measured outcome, and workflow refinement",
+      "version": "1.0.0",
+      "author": {
+        "name": "Amplitude",
+        "email": "support@amplitude.com",
+        "url": "https://amplitude.com"
+      },
+      "homepage": "https://github.com/amplitude/mcp-marketplace",
+      "repository": "https://github.com/amplitude/mcp-marketplace",
+      "license": "MIT",
+      "keywords": [
+        "amplitude",
+        "wave",
+        "opportunities",
+        "product",
+        "automation",
+        "experiments",
+        "self-improving"
+      ],
+      "category": "productivity"
+    },
+    {
       "name": "amplitude-experimental",
       "source": "./plugins/amplitude-experimental",
       "description": "Experimental skills from Amplitude",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -41,6 +41,30 @@
       "category": "analytics"
     },
     {
+      "name": "wave",
+      "source": "./plugins/wave",
+      "description": "Run the Amplitude Wave self-improving product loop from codebase-validated opportunity to review-ready PR, optional experiment, measured outcome, and workflow refinement",
+      "version": "1.0.0",
+      "author": {
+        "name": "Amplitude",
+        "email": "support@amplitude.com",
+        "url": "https://amplitude.com"
+      },
+      "homepage": "https://github.com/amplitude/mcp-marketplace",
+      "repository": "https://github.com/amplitude/mcp-marketplace",
+      "license": "MIT",
+      "keywords": [
+        "amplitude",
+        "wave",
+        "opportunities",
+        "product",
+        "automation",
+        "experiments",
+        "self-improving"
+      ],
+      "category": "productivity"
+    },
+    {
       "name": "amplitude-experimental",
       "source": "./plugins/amplitude-experimental",
       "description": "Experimental skills from Amplitude",

--- a/.github/workflows/wave-plugin-validate.yml
+++ b/.github/workflows/wave-plugin-validate.yml
@@ -1,0 +1,18 @@
+name: Wave Plugin Validate
+
+on:
+  pull_request:
+    paths:
+      - "plugins/wave/**"
+      - ".github/workflows/wave-plugin-validate.yml"
+
+jobs:
+  validate:
+    name: Validate Wave plugin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Run Wave plugin validator
+        run: python3 plugins/wave/scripts/validate_plugin.py

--- a/README.md
+++ b/README.md
@@ -12,12 +12,17 @@ Works with **Claude Code**, **Cursor**, **Codex**, **Gemini CLI**, and **Claude*
 
 ```
 claude plugin install amplitude
+claude plugin install wave
 ```
+
+`amplitude` is analytics and instrumentation. `wave` is Opportunity Manager workflows
+and already bundles Amplitude MCP — you do not need both unless you want both skill sets.
 
 Or from inside Claude Code:
 
 ```
 /plugin install amplitude
+/plugin install wave
 /reload-plugins
 ```
 
@@ -56,6 +61,8 @@ To work on the plugin from a local checkout in Claude Code:
 ```bash
 git clone https://github.com/amplitude/mcp-marketplace
 claude --plugin-dir ./mcp-marketplace/plugins/amplitude
+# or, for Wave opportunity workflows:
+claude --plugin-dir ./mcp-marketplace/plugins/wave
 ```
 
 Then run `/mcp` from inside Claude Code, select `plugin:amplitude:amplitude`, and follow the browser prompts to authenticate.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ Then run `/mcp` from inside Claude Code, select `plugin:amplitude:amplitude`, an
 | Plugin | Description |
 | --- | --- |
 | [amplitude](./plugins/amplitude/) | Reusable analysis and instrumentation skills covering charts, dashboards, experiments, session replays, reliability, AI agent analytics, and analytics tracking workflows |
+| [wave](./plugins/wave/) | End-to-end Wave opportunity workflows covering codebase validation, coding-agent handoff, PR verification, experiments, outcome measurement, and pipeline refinement |
+
+---
+
+## Wave Plugin
+
+The Wave plugin runs the self-improving product loop from product signal to measured
+outcome. Its nine skills reconcile existing work, validate opportunities against current
+code, dispatch isolated coding agents, shepherd pull requests to review-ready, prepare
+optional experiments, record outcomes, and refine the workflow.
+
+Pull-request merge and live experiment launch always remain explicit human gates. See the
+[Wave plugin README](./plugins/wave/) for configuration, skills, and example prompts.
 
 ---
 

--- a/plugins/wave/.claude-plugin/plugin.json
+++ b/plugins/wave/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "wave",
+  "description": "Use Amplitude Wave to turn product signals into codebase-validated opportunities, review-ready pull requests, optional experiments, measured outcomes, and a self-improving product loop",
+  "author": {
+    "name": "Amplitude",
+    "email": "support@amplitude.com",
+    "url": "https://amplitude.com"
+  }
+}

--- a/plugins/wave/.codex-plugin/plugin.json
+++ b/plugins/wave/.codex-plugin/plugin.json
@@ -1,0 +1,44 @@
+{
+  "name": "wave",
+  "version": "1.0.0",
+  "description": "Run the Amplitude Wave opportunity loop from product signal to measured outcome, with review-ready PRs, optional experiments, and hard human gates.",
+  "author": {
+    "name": "Amplitude",
+    "email": "support@amplitude.com",
+    "url": "https://amplitude.com"
+  },
+  "homepage": "https://github.com/amplitude/mcp-marketplace",
+  "repository": "https://github.com/amplitude/mcp-marketplace",
+  "license": "MIT",
+  "keywords": [
+    "amplitude",
+    "wave",
+    "opportunities",
+    "product",
+    "automation",
+    "experiments",
+    "self-improving"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Amplitude Wave",
+    "shortDescription": "Work Wave opportunities from signal to measured outcome.",
+    "longDescription": "Review and improve Wave opportunities against current code, dispatch coding agents, drive PRs to review-ready, prepare optional experiments, measure outcomes, and refine the workflow. Merge and live experiment launch always require humans.",
+    "developerName": "Amplitude",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://amplitude.com",
+    "privacyPolicyURL": "https://amplitude.com/privacy",
+    "termsOfServiceURL": "https://amplitude.com/terms",
+    "defaultPrompt": [
+      "Show me the top Wave opportunities and recommend what to do next.",
+      "Run Wave autopilot on the top approved opportunity and stop at a review-ready PR.",
+      "Measure Wave opportunities that have completed their outcome window."
+    ],
+    "brandColor": "#005AF0"
+  }
+}

--- a/plugins/wave/.cursor-plugin/plugin.json
+++ b/plugins/wave/.cursor-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "wave",
+  "description": "Use Amplitude Wave to turn product signals into codebase-validated opportunities, review-ready pull requests, optional experiments, measured outcomes, and a self-improving product loop",
+  "author": {
+    "name": "Amplitude",
+    "email": "support@amplitude.com",
+    "url": "https://amplitude.com"
+  }
+}

--- a/plugins/wave/.mcp.json
+++ b/plugins/wave/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "amplitude": {
+      "type": "http",
+      "url": "https://mcp.amplitude.com/mcp"
+    }
+  }
+}

--- a/plugins/wave/README.md
+++ b/plugins/wave/README.md
@@ -30,6 +30,11 @@ Add `amplitude/mcp-marketplace`, run `/plugins`, select **Amplitude Wave**, and 
 
 Authenticate the bundled Amplitude MCP connection when prompted.
 
+This plugin already includes the Amplitude MCP server. Install **Amplitude Wave** for
+opportunity workflows. Install the separate **Amplitude** plugin only if you also want
+analytics skills (charts, dashboards, instrumentation). Installing both registers the
+same MCP server twice; prefer Wave alone unless you need those extra skills.
+
 ## Safety
 
 - Pull requests are never merged automatically.
@@ -44,11 +49,11 @@ Authenticate the bundled Amplitude MCP connection when prompted.
 
 | Skill | Job | Invocation |
 |---|---|---|
-| `wave-queue` | Read-only ranked queue and next-action routing | Natural language |
+| `wave-queue` | Read-only ranked queue; routes to evaluate, experiment, dispatch, babysit, or close-out | Natural language |
 | `wave-evaluate` | Confirm the problem in current code and improve its plan | Natural language; confirms writes |
 | `wave-dispatch-handoff` | Claim and launch isolated coding work | Explicit |
 | `wave-babysit` | Drive linked PRs through CI, review, and verification | Explicit |
-| `wave-close-out` | Measure shipped outcomes and record learning | Explicit or scheduled |
+| `wave-close-out` | Measure shipped outcomes and record learning | Natural language; confirms writes |
 | `wave-intake` | Configure product areas and submit deduplicated ideas | Explicit |
 | `wave-experiment` | Prepare, link, and monitor opportunity experiments | Explicit |
 | `wave-autopilot` | Orchestrate the complete bounded loop | Explicit or scheduled |
@@ -70,9 +75,10 @@ names, or personal skill dependencies.
 
 ## Configuration
 
-Copy `config/wave-config.example.json` to either:
+Put config in the **product repository** you will change, not in this marketplace
+checkout. Copy `config/wave-config.example.json` to either:
 
-- `wave-config.json` at the target code workspace root, or
+- `wave-config.json` at that workspace root, or
 - `.amplitude/wave-config.json`.
 
 Set the Amplitude project ID, repositories, base branches, and available setup/test/lint/

--- a/plugins/wave/README.md
+++ b/plugins/wave/README.md
@@ -1,0 +1,133 @@
+# Amplitude Wave
+
+Use Amplitude Wave from Cursor, Claude Code, Codex, and other AI coding tools to run the
+self-improving product loop:
+
+**queue → codebase validation → implementation → PR verification → experiment/direct ship
+→ outcome measurement → workflow refinement**
+
+The plugin composes the existing Amplitude MCP Wave, analytics, flag, experiment, and
+metric tools. It does not duplicate or proxy MCP APIs.
+
+## Installation
+
+### Claude Code
+
+```text
+claude plugin install wave
+```
+
+Or run `/plugin install wave`, then `/reload-plugins`.
+
+### Cursor
+
+Install **Amplitude Wave** from the Cursor Marketplace or add the Amplitude marketplace
+in Cursor Settings → Plugins.
+
+### Codex
+
+Add `amplitude/mcp-marketplace`, run `/plugins`, select **Amplitude Wave**, and install.
+
+Authenticate the bundled Amplitude MCP connection when prompted.
+
+## Safety
+
+- Pull requests are never merged automatically.
+- Experiments and flags are never launched to real traffic without explicit human
+  approval in the current run.
+- Evaluation improves real opportunities and dismisses only demonstrably obsolete or
+  invalid problem statements, with human confirmation.
+- Writes are reconcile-first and idempotent.
+- Unattended runs are capped and park human decisions instead of blocking or guessing.
+
+## Skills
+
+| Skill | Job | Invocation |
+|---|---|---|
+| `wave-queue` | Read-only ranked queue and next-action routing | Natural language |
+| `wave-evaluate` | Confirm the problem in current code and improve its plan | Natural language; confirms writes |
+| `wave-dispatch-handoff` | Claim and launch isolated coding work | Explicit |
+| `wave-babysit` | Drive linked PRs through CI, review, and verification | Explicit |
+| `wave-close-out` | Measure shipped outcomes and record learning | Explicit or scheduled |
+| `wave-intake` | Configure product areas and submit deduplicated ideas | Explicit |
+| `wave-experiment` | Prepare, link, and monitor opportunity experiments | Explicit |
+| `wave-autopilot` | Orchestrate the complete bounded loop | Explicit or scheduled |
+| `wave-refine` | Audit pipeline quality and propose improvements | Natural language/read-only |
+
+“Optional experiment” means optional for a particular opportunity, not omitted from the
+plugin. `wave-autopilot` includes the experiment decision and preparation path.
+
+## Prerequisites
+
+- Access to Amplitude Wave and an Amplitude project.
+- Local or cloud access to the target source repository.
+- GitHub/SCM credentials when the workflow should create or update pull requests.
+- Amplitude Experiment access when using `wave-experiment`.
+
+All IDs and project-specific taxonomy are discovered from the authenticated customer's
+Amplitude environment. The plugin contains no customer-specific IDs, repositories, event
+names, or personal skill dependencies.
+
+## Configuration
+
+Copy `config/wave-config.example.json` to either:
+
+- `wave-config.json` at the target code workspace root, or
+- `.amplitude/wave-config.json`.
+
+Set the Amplitude project ID, repositories, base branches, and available setup/test/lint/
+build commands. Merge and live experiment launch are hard-coded human gates rather than
+configuration switches.
+
+If config is absent, attended skills ask for required context. Unattended autopilot runs
+only read-only reconciliation, parks the setup gap, and stops.
+
+## Example prompts
+
+```text
+Show me the top Wave opportunities for onboarding and what should happen next.
+```
+
+```text
+Evaluate Wave opportunity 1a2b3c4d against this codebase and improve its plan.
+```
+
+```text
+Dispatch the approved Wave opportunity to a coding agent and stop at a PR-ready gate.
+```
+
+```text
+Prepare an Amplitude experiment for this Wave opportunity, but do not launch traffic.
+```
+
+```text
+Run Wave autopilot unattended for product area <id>, maximum two opportunities.
+```
+
+```text
+Measure Wave opportunities that shipped at least 14 days ago.
+```
+
+## Scheduled autopilot
+
+Use a Cursor/Codex automation or Claude scheduled task to start a fresh agent session:
+
+```text
+Run wave-autopilot in unattended mode. Reconcile existing work first. Scope to product
+area <id>, process at most 2 opportunities with at most 2 concurrent agents, never merge,
+never launch experiment traffic, and return the wave_run summary.
+```
+
+The automation starts the session; MCP itself does not launch sessions.
+
+## Local development
+
+From the marketplace repository:
+
+```bash
+claude --plugin-dir ./plugins/wave
+python3 plugins/wave/scripts/validate_plugin.py
+```
+
+The validator checks manifests, skill metadata, line limits, references, current tool
+names, hard gates, generic configuration, and scenario coverage without dependencies.

--- a/plugins/wave/config/wave-config.example.json
+++ b/plugins/wave/config/wave-config.example.json
@@ -1,0 +1,26 @@
+{
+  "projectId": "YOUR_PROJECT_ID",
+  "defaults": {
+    "mode": "attended",
+    "maxOpportunitiesPerRun": 3,
+    "maxConcurrentAgents": 2,
+    "maxNewIdeasPerRun": 1,
+    "maxRetriesPerStage": 2,
+    "leaseTtlSeconds": 1800,
+    "staleLeaseGraceMinutes": 30,
+    "stalePrInactivityDays": 5,
+    "measurementWindowDays": 14,
+    "minOpportunitiesForRefine": 20,
+    "dryRun": false
+  },
+  "repos": [
+    {
+      "repository": "your-org/your-app",
+      "baseBranch": "main",
+      "setup": "pnpm install",
+      "test": "pnpm test",
+      "lint": "pnpm lint",
+      "build": "pnpm build"
+    }
+  ]
+}

--- a/plugins/wave/references/decision-rubrics.md
+++ b/plugins/wave/references/decision-rubrics.md
@@ -1,0 +1,110 @@
+# Wave Decision Rubrics
+
+Use these rules for decisions that should remain consistent across skills.
+
+## Codebase validation
+
+An opportunity is current when the described user-visible behavior or missing capability
+still follows from the present code and no merged/in-flight change resolves it.
+
+Check, in order:
+
+1. Referenced repository and files exist.
+2. Current code still contains the relevant path, behavior, or gap.
+3. Recent commits and linked/open PRs have not fixed it.
+4. Cited analytics, feedback, or replay evidence still supports the problem when fresh
+   evidence is accessible.
+
+Code proves implementation state; product evidence proves impact. A code-only mismatch
+usually calls for a corrected plan, not dismissal.
+
+## Verdict
+
+| Finding | Verdict |
+|---|---|
+| Problem real; plan fits | `APPROVE` |
+| Problem real; plan/repo/ACs need correction | `NEEDS_REPLAN`, then improve it |
+| Problem plausible; product/security judgment needed | `NEEDS_HUMAN_REVIEW` |
+| Problem demonstrably obsolete or invalid | `DISMISS` |
+
+Do not dismiss because the proposed solution is bad. Replace the solution and preserve
+the evidence-backed problem. `DISMISS` becomes status `DISMISSED` only after explicit
+human confirmation; unattended runs park the proposal.
+
+## RICE
+
+`score = (reach × impact × confidence) / effort`
+
+Use RICE to rank workable opportunities, not to determine whether a real problem exists.
+Agent-compressed coding effort may be lower, but review, rollout, coordination, and
+measurement effort remain.
+
+## Experiment versus direct ship
+
+Lean toward an experiment when most are true:
+
+- It is a behavioral bet whose metric effect is uncertain.
+- The affected surface has enough traffic to decide in a useful window.
+- It is reversible and safe to expose to a fraction of users.
+- A wrong full-rollout decision would be costly.
+- A primary success metric and at least one guardrail are available.
+
+Lean toward direct ship when any decisive condition applies:
+
+- Correctness, security, accessibility, or reliability has an obviously right outcome.
+- Traffic is too low to power a useful test.
+- The change is infrastructure-only or not safely reversible by variant.
+- Delaying the fix to experiment would harm users.
+
+When experimenting, flag-gate the implementation in the PR. Prefer an existing flag
+already linked in code/opportunity context. Prepare the experiment with:
+
+- control and treatment variants,
+- primary recommendation metric,
+- at least one guardrail,
+- deployment,
+- a proxy exposure event at the tested surface when available.
+
+Never enable real traffic without explicit human approval.
+
+## Metric selection
+
+Stop at the first valid option:
+
+1. Existing metric linked by the opportunity.
+2. Closest trusted existing metric, chart, or event used by the product area.
+3. Minimal new metric definition over existing events/properties.
+4. Instrumentation recommendation when no existing signal can measure the outcome.
+
+Discover event/property names through taxonomy tools; never guess. Creating new tracking
+or taxonomy is a separate, explicit user decision.
+
+## Concurrency and staleness
+
+Defer when any work signal is fresh:
+
+- unexpired `INVESTIGATED_BY` lease,
+- open linked PR with recent commits,
+- active implementation agent relation,
+- recent `IN_PROGRESS` / `FOR_REVIEW` update.
+
+Take over only with evidence:
+
+- lease expired beyond configured grace,
+- PR closed without merge,
+- open PR inactive beyond `stalePrInactivityDays`,
+- no PR and status stale beyond the configured threshold.
+
+Comment with takeover evidence before claiming. Re-read after the soft claim and defer if
+another fresh claim won.
+
+## Measurement readiness
+
+Move `SHIPPED` to `MEASURED` only when one is true:
+
+- Experiment has a decision and guardrails were checked.
+- Direct-ship target metric has an adequate before/after readout with caveats.
+- Explicit fallback records that measurement is impossible/pending, why, and what signal
+  is missing.
+
+Never present direct-ship correlation as causal proof.

--- a/plugins/wave/references/output-contracts.md
+++ b/plugins/wave/references/output-contracts.md
@@ -14,7 +14,7 @@ problemSummary: <one sentence>
 evidenceSummary: <one sentence>
 repository: <org/repo|null>
 existingWork: <none|agent|branch|pr|blocked>
-recommendedNextSkill: <wave-evaluate|wave-babysit|wave-close-out>
+recommendedNextSkill: <wave-evaluate|wave-experiment|wave-dispatch-handoff|wave-babysit|wave-close-out>
 reason: <one sentence>
 ```
 

--- a/plugins/wave/references/output-contracts.md
+++ b/plugins/wave/references/output-contracts.md
@@ -1,0 +1,164 @@
+# Wave Output Contracts
+
+Use these compact structures so skills can hand work to each other without reparsing prose.
+
+## Queue item
+
+```yaml
+opportunityId: <uuid>
+productAreaId: <id>
+title: <title>
+status: <status>
+riceScore: <number|null>
+problemSummary: <one sentence>
+evidenceSummary: <one sentence>
+repository: <org/repo|null>
+existingWork: <none|agent|branch|pr|blocked>
+recommendedNextSkill: <wave-evaluate|wave-babysit|wave-close-out>
+reason: <one sentence>
+```
+
+## Evaluation handoff comment
+
+Place this fenced block in the approval/replan comment:
+
+```yaml
+wave_handoff:
+  version: 1
+  verdict: APPROVE
+  problem_confirmed: true
+  codebase_checked:
+    repository: <org/repo>
+    paths: []
+    recent_change_check: <summary>
+  improved_plan:
+    summary: <implementation direction>
+    repositories: []
+    steps: []
+  acceptance_criteria:
+    - <observable criterion>
+  measurement:
+    target_metric_id: <id|null>
+    experiment_recommended: <true|false>
+    rationale: <one sentence>
+  risks: []
+```
+
+For `NEEDS_REPLAN` or `NEEDS_HUMAN_REVIEW`, change `verdict` and include the unresolved
+decision. Never emit `APPROVE` with `problem_confirmed: false`.
+
+For a proposed dismissal:
+
+```yaml
+wave_handoff:
+  version: 1
+  verdict: DISMISS
+  problem_confirmed: false
+  invalidation:
+    reason: <obsolete|already_resolved|invalid_evidence>
+    code_evidence: []
+    product_evidence: []
+  status_transition:
+    from: <current status>
+    to: DISMISSED
+    confirmed_by_human: <true|false>
+```
+
+Do not apply the transition until `confirmed_by_human` is true. Unattended runs park this
+block at a human-review gate with status unchanged.
+
+## Dispatch handoff
+
+```yaml
+wave_dispatch:
+  version: 1
+  opportunity_id: <uuid>
+  product_area_id: <id>
+  repository: <org/repo>
+  base_branch: <branch>
+  branch: <branch>
+  acceptance_criteria: []
+  target_metric_id: <id|null>
+  experiment_recommended: <true|false>
+  existing_pr: <url|null>
+  claim:
+    relation_id: <id|null>
+    expires_at: <timestamp|null>
+```
+
+## PR-ready comment
+
+```yaml
+wave_pr_ready:
+  version: 1
+  pr_url: <url>
+  commit: <sha>
+  checks:
+    test: <pass|fail|not_run>
+    lint: <pass|fail|not_run>
+    build: <pass|fail|not_run>
+    review: <pass|issues>
+  acceptance_criteria:
+    - index: 1
+      status: <verified|unverified>
+      artifact_id: <id|null>
+  experiment:
+    required: <true|false>
+    id: <id|null>
+    launch_status: <not_applicable|prepared_human_gate>
+```
+
+## Parked-at-gate comment
+
+```yaml
+wave_gate:
+  version: 1
+  gate: <merge|experiment_launch|human_review>
+  opportunity_id: <uuid>
+  ready: <true|false>
+  decision_needed: <single clear decision>
+  evidence: []
+  resume_with: <skill name and input>
+```
+
+## Outcome comment
+
+```yaml
+wave_outcome:
+  version: 1
+  measurement_type: <experiment|before_after|fallback>
+  window: <dates>
+  result: <win|flat|regression|inconclusive|not_measurable>
+  primary_metric:
+    id: <id|null>
+    before: <number|null>
+    after: <number|null>
+    change: <number|string|null>
+  guardrails: []
+  confidence: <high|medium|low>
+  caveats: []
+  learning: <one sentence>
+  follow_up: <opportunity id|null>
+```
+
+## Automation run summary
+
+```yaml
+wave_run:
+  version: 1
+  mode: <attended|unattended>
+  started_at: <timestamp>
+  finished_at: <timestamp>
+  counts:
+    reconciled: 0
+    evaluated: 0
+    dispatched: 0
+    pr_ready: 0
+    measured: 0
+    dismissed: 0
+    deferred: 0
+    parked: 0
+  opportunities: []
+  gates: []
+  errors: []
+```

--- a/plugins/wave/references/skill-design-checklist.md
+++ b/plugins/wave/references/skill-design-checklist.md
@@ -1,0 +1,18 @@
+# Skill Design Checklist
+
+Apply when adding or changing a Wave skill.
+
+- Description is third-person and says both what the skill does and when it triggers.
+- Trigger language does not overlap ambiguously with sibling skills.
+- Skill owns one job; orchestration references other skills instead of copying them.
+- `SKILL.md` contains only Wave-specific goals, constraints, workflow, output, and gotchas.
+- Detailed contracts and rubrics are linked directly from `SKILL.md`.
+- Judgment steps allow contextual freedom; fragile writes use exact preconditions.
+- Output contract defines what done means.
+- Gotchas capture observed failure modes.
+- Negative boundaries state where the skill stops.
+- Consequential workflows use explicit invocation and human gates.
+- IDs are discovered, never guessed.
+- Writes are reconcile-first and idempotent.
+- Skill remains under 500 lines.
+- Natural-language and explicit invocation are represented in test scenarios.

--- a/plugins/wave/references/wave-pipeline-contract.md
+++ b/plugins/wave/references/wave-pipeline-contract.md
@@ -31,8 +31,8 @@ wrap or duplicate MCP tools.
 | Find events/properties | `search_amp_data_taxonomy` |
 | Read saved charts | `get_amplitude_charts` |
 | Run ad-hoc analytics | `query_amplitude_data` |
-| Flags/deployments | `use_amp_flags` |
-| Experiments | `use_amp_experiments` |
+| Flags/deployments | `use_amp_flags` (`create` takes a `flags` array; prepare with `enabled: false`) |
+| Experiments | `use_amp_experiments` (`create` requires `projectIds` as an array, not `projectId`) |
 | Metric definitions | `use_amplitude_metrics` |
 
 `get_amplitude_context` accepts a numeric project ID. Wave tools accept `projectId` as a
@@ -46,9 +46,10 @@ Resolve product areas through `query_wave_product_areas`.
 
 ## Customer configuration
 
-At the start of every skill, look for `wave-config.json` in the workspace root and then
-`.amplitude/wave-config.json`. Use it when present for project ID, repository mapping,
-commands, measurement window, staleness, and per-run caps.
+At the start of every skill, look for `wave-config.json` in the **application** workspace
+root and then `.amplitude/wave-config.json`. This file belongs in the product repository
+being changed, not in the marketplace checkout. Use it when present for project ID,
+repository mapping, commands, measurement window, staleness, and per-run caps.
 
 - Validate the configured project ID against `get_amplitude_context`; never trust or guess
   an inaccessible ID.

--- a/plugins/wave/references/wave-pipeline-contract.md
+++ b/plugins/wave/references/wave-pipeline-contract.md
@@ -1,0 +1,251 @@
+# Wave Pipeline Contract
+
+Shared operating contract for every skill in the Amplitude Wave plugin. Read this file
+before querying or mutating Wave. Live tool schemas take precedence if they change.
+
+## Scope
+
+Wave opportunities are product-improvement work in Amplitude Wave Opportunity Manager.
+They are not Salesforce opportunities, CRM records, sales pipeline, or generic business
+opportunities. Use only the `*_wave_*` tools for Wave records.
+
+The plugin is a workflow layer powered by the existing Amplitude MCP server. It does not
+wrap or duplicate MCP tools.
+
+## Current tool map
+
+| Need | Tool and action |
+|---|---|
+| Resolve org/projects | `get_amplitude_context` without `projectId` |
+| Resolve project settings | `get_amplitude_context` with numeric `projectId` |
+| List/get product areas | `query_wave_product_areas` `list` / `get` |
+| Create/update product areas | `manage_wave_product_areas` `create` / `update` |
+| Browse/search/get opportunities | `query_wave_opportunities` `list` / `search` / `get` |
+| Traverse relations | `query_wave_opportunities` `get_relations` |
+| Update opportunity | `manage_wave_opportunities` `update` |
+| Submit idea | `manage_wave_opportunities` `submit_idea` |
+| Add context | `manage_wave_opportunities` `add_comment` |
+| Add relation | `manage_wave_opportunities` `add_opportunity_relation` |
+| Attach proof | `manage_wave_verification_artifacts` |
+| Find analytics entities | `search_amp_entities` |
+| Find events/properties | `search_amp_data_taxonomy` |
+| Read saved charts | `get_amplitude_charts` |
+| Run ad-hoc analytics | `query_amplitude_data` |
+| Flags/deployments | `use_amp_flags` |
+| Experiments | `use_amp_experiments` |
+| Metric definitions | `use_amplitude_metrics` |
+
+`get_amplitude_context` accepts a numeric project ID. Wave tools accept `projectId` as a
+string; convert the discovered app ID to a string rather than guessing another ID.
+
+## Product areas, not objectives
+
+The current Wave API organizes opportunities with `productAreaId`. Older source skills
+refer to `objectiveId`, `list_objectives`, and `PRODUCT_NODE`; do not use those names.
+Resolve product areas through `query_wave_product_areas`.
+
+## Customer configuration
+
+At the start of every skill, look for `wave-config.json` in the workspace root and then
+`.amplitude/wave-config.json`. Use it when present for project ID, repository mapping,
+commands, measurement window, staleness, and per-run caps.
+
+- Validate the configured project ID against `get_amplitude_context`; never trust or guess
+  an inaccessible ID.
+- Standalone dispatch/babysit skills use the repository commands from this config.
+- Standalone close-out uses its measurement window.
+- Missing config is acceptable in attended mode; ask only for context the task needs.
+- Missing config in unattended autopilot permits read-only reconcile only, then park.
+- Merge and live experiment launch gates are not configurable.
+
+## Query discipline
+
+1. Use `list` or semantic `search` only to discover candidate IDs.
+2. List/search descriptions are truncated snippets. Call `get` before any verdict,
+   status change, dispatch, or relation write.
+3. Do not paginate through the entire backlog. Use the first page plus `totalCount`, then
+   narrow by status, tags, product area, or semantic search.
+4. For each candidate, query relations in both directions when the workflow depends on
+   PRs, agents, blockers, parents, children, charts, or metrics.
+5. Never invent project, product-area, opportunity, relation-target, metric, chart,
+   flag, experiment, deployment, PR, or agent IDs.
+
+## Canonical lifecycle
+
+`NEW → PLANNED → INVESTIGATING → IN_PROGRESS → FOR_REVIEW → SHIPPED → MEASURED`
+
+`DISMISSED` is terminal unless a human explicitly reopens the opportunity.
+
+Status is coarse workflow state, not proof:
+
+| Status | Required interpretation |
+|---|---|
+| `NEW` | Surfaced but not ready for implementation |
+| `PLANNED` | Analyzed enough for codebase validation |
+| `INVESTIGATING` | Validated or actively being sharpened |
+| `IN_PROGRESS` | Implementation exists, but no reviewable PR is ready |
+| `FOR_REVIEW` | A real linked PR is open and reviewable |
+| `SHIPPED` | Delivery is verified merged/deployed |
+| `MEASURED` | Outcome evidence or an explicit measurement fallback is recorded |
+| `DISMISSED` | The problem itself is demonstrably invalid or obsolete |
+
+Never infer completion from status alone. Reconcile relations and external PR state.
+
+## Normalize every opportunity
+
+Build this in memory from `get` plus incoming and outgoing relations:
+
+```yaml
+id: <uuid>
+projectId: <string>
+productAreaId: <id>
+title: <title>
+status: <status>
+canonicalTags: []
+originalTags: []
+repositories: []
+executionPlan: {}
+acceptanceCriteria: []
+citations: []
+rice: {}
+relations:
+  incoming: []
+  outgoing: []
+prs: []
+agents: []
+measurement:
+  metrics: []
+  charts: []
+  experiments: []
+verificationArtifacts: []
+```
+
+Normalize repositories from execution-plan metadata, relation metadata, PR URLs, and
+comments. Preserve the raw values so a human can audit the inference.
+
+## Tags
+
+Normalize aliases in memory, but preserve useful raw tags on writes:
+
+| Canonical | Legacy alias |
+|---|---|
+| `execution-method.code` | `execution-method-code` |
+| `execution-method.hybrid` | `execution-method-hybrid` |
+| `execution-method.guide` | `execution-method-guide` |
+| `agent-autonomous.low` | `agent-autonomous-low` |
+| `agent-autonomous.medium` | `agent-autonomous-medium` |
+| `agent-autonomous.high` | `agent-autonomous-high` |
+| `location.frontend` | `location-frontend` |
+| `location.backend` | `location-backend` |
+| `location.mix` | `location-mix` |
+
+Workflow tags include `agent-approved`, `needs-human-review`, `needs-replan`, `pr-open`,
+`pr-ready`, `pr-merged`, `pr-closed`, `pr-blocked`, `agent-failed`,
+`retries-exhausted`, `instrumented`, and `needs-instrumentation`.
+
+Prefer `tagsToAdd` / `tagsToRemove`. If using full `tags`, merge intentionally; never
+erase domain, sizing, location, execution-method, or feedback tags accidentally.
+
+## Idempotent writes
+
+Before every mutation, re-read the opportunity and relevant relations.
+
+- Do not add a comment when an equivalent structured comment already exists.
+- Do not create a relation when the same source, type, and target already exist.
+- Do not open a PR when a matching open PR or active implementation relation exists.
+- Do not create a flag, experiment, or metric before searching for a linked/equivalent
+  entity.
+- Use `metadataPatch` for partial metadata changes; nested keys use `snake_case`.
+- Add a short `rationale` to every MCP mutation.
+- In attended mode, present the proposed batch and obtain confirmation before mass status
+  changes or dismissals.
+
+## Relations and claims
+
+Known relation conventions:
+
+- `DELIVERED_VIA` → `GITHUB_PR`, with the full PR URL as `targetId`.
+- `IMPLEMENTED_BY` → an agent/session only when a stable target ID exists.
+- `INVESTIGATED_BY` → an agent/session soft lease only when a stable target ID exists.
+- `TARGETS_METRIC` → `METRIC`.
+- Parent/child, blocker, chart, and other relation types may be reused when discovered in
+  the opportunity or confirmed by the live tool schema.
+
+`add_opportunity_relation` requires `sourceType`, `sourceId`, `relationType`,
+`targetType`, `targetId`, and `productAreaId`. For opportunity-originated relations use
+`sourceType: OPPORTUNITY` and the opportunity ID as `sourceId`; do not pass it as `id`.
+
+Claims are soft. Pass `leaseTtlSeconds`, re-read relations after claiming, and defer if a
+competing fresh claim won. Do not fabricate an agent ID just to claim work. If the host
+does not expose a stable session ID, record attribution in a comment and rely on PR state.
+
+## Dismiss conservatively
+
+The evaluator's job is to improve real opportunities, not clear the queue.
+
+Default outcomes:
+
+- `APPROVE`: problem is real; write a codebase-grounded improved plan.
+- `NEEDS_HUMAN_REVIEW`: evidence is ambiguous, sensitive, or needs product judgment.
+- `NEEDS_REPLAN`: problem is real but plan, repo, sizing, or strategy needs correction.
+
+Use `DISMISSED` only when the problem statement itself is demonstrably invalid or
+obsolete: already shipped and verified, unrecoverably inaccurate evidence, or the
+behavior no longer exists in both current code and relevant fresh evidence.
+
+Weak plans, wrong repositories, low RICE, questionable strategy, or non-code portions are
+replan/routing inputs—not automatic dismissals.
+
+Every dismissal requires explicit human confirmation. In unattended mode, record a
+proposed `DISMISS`, add `needs-human-review`, and park without changing status. After
+confirmation, map verdict `DISMISS` to status `DISMISSED`.
+
+## Verification
+
+For hosted proof use `create_link`. For a local screenshot, GIF, video, or log:
+
+1. `prepare_upload` with `opportunityId`, `filePath`, and `mimeType`.
+2. Execute the returned upload command exactly.
+3. `finalize_upload` with the returned `artifactId`.
+
+Use one-based `acceptanceCriterionIdx` to bind proof to a criterion. Frontend work should
+normally include a screenshot or GIF. Never mark `FOR_REVIEW` when required acceptance
+criteria remain unverified; leave the work `IN_PROGRESS` and explain the gap.
+
+## Experiment and measurement gates
+
+Decide experiment versus direct ship before implementation so experiment-worthy behavior
+is flag-gated in the PR.
+
+- Search before creating flags, metrics, or experiments.
+- Use an existing trusted metric before creating a new metric.
+- Create new tracking only after explicit user approval.
+- Preparing a disabled flag or draft experiment is allowed only in an explicitly invoked
+  experiment/autopilot workflow.
+- Never enable rollout to real users or launch an experiment without explicit human
+  approval in the current run.
+- Never merge a PR without explicit human approval in the current run.
+
+The Wave relation tool explicitly documents PRs, agents, charts, metrics, and opportunity
+relations. For flags/experiments, create a Wave relation only when the live descriptor or
+an existing relation proves the target type is supported. Otherwise persist the ID/key in
+opportunity metadata, add an idempotent comment, link back to the opportunity from the
+experiment, and always link the supported metric relation.
+
+## Durable memory
+
+Wave is the source of product truth. Store plan decisions, overrides, evidence, agent/PR
+links, experiment IDs, and outcomes in opportunity metadata/comments/relations. Store
+product-area-level preferences in product-area metadata when available.
+
+Local files hold only operational configuration, test fixtures, and run logs. They must
+not become a competing opportunity database.
+
+## Attended and unattended behavior
+
+- `attended`: may ask focused questions and must stop at confirmation gates.
+- `unattended`: never block on a question. Park the opportunity, add a concise comment
+  describing the decision needed, and continue within configured caps.
+
+Both modes reconcile before acting, resume idempotently, and stop at merge and live
+experiment launch.

--- a/plugins/wave/scripts/validate_plugin.py
+++ b/plugins/wave/scripts/validate_plugin.py
@@ -24,7 +24,6 @@ EXPECTED_SKILLS = {
 MANUAL_SKILLS = {
     "wave-autopilot",
     "wave-babysit",
-    "wave-close-out",
     "wave-dispatch-handoff",
     "wave-experiment",
     "wave-intake",
@@ -41,6 +40,7 @@ REQUIRED_SCENARIOS = {
     "intake-deduplication",
     "interrupted-run-resume",
     "queue-natural-language",
+    "queue-routes-to-dispatch",
     "real-problem-weak-plan",
     "refine-read-only",
     "scheduled-human-decision",
@@ -67,6 +67,12 @@ SCENARIO_TEXT_ASSERTIONS = {
         ("skills/wave-queue/SKILL.md", "read-only"),
         ("skills/wave-queue/SKILL.md", "Do not paginate"),
         ("skills/wave-queue/SKILL.md", "call `get`"),
+        ("skills/wave-queue/SKILL.md", "wave-dispatch-handoff"),
+    ],
+    "queue-routes-to-dispatch": [
+        ("skills/wave-queue/SKILL.md", "wave-dispatch-handoff"),
+        ("skills/wave-queue/SKILL.md", "wave-experiment"),
+        ("references/output-contracts.md", "wave-dispatch-handoff"),
     ],
     "real-problem-weak-plan": [
         ("skills/wave-evaluate/SKILL.md", "NEEDS_REPLAN"),
@@ -78,10 +84,13 @@ SCENARIO_TEXT_ASSERTIONS = {
     ],
     "existing-in-flight-pr": [
         ("skills/wave-dispatch-handoff/SKILL.md", "duplicate agent for an open/fresh PR"),
+        ("skills/wave-dispatch-handoff/SKILL.md", "do not code inline"),
     ],
     "experiment-worthy-change": [
         ("skills/wave-experiment/SKILL.md", "disabled"),
         ("skills/wave-experiment/SKILL.md", "Never enable a flag rollout"),
+        ("skills/wave-experiment/SKILL.md", "projectIds"),
+        ("skills/wave-experiment/SKILL.md", "enabled: false"),
     ],
     "direct-ship-correctness": [
         ("references/decision-rubrics.md", "Correctness, security, accessibility"),
@@ -95,6 +104,7 @@ SCENARIO_TEXT_ASSERTIONS = {
     ],
     "frontend-verification": [
         ("skills/wave-babysit/SKILL.md", "screenshot or GIF"),
+        ("skills/wave-babysit/SKILL.md", "Never mark `FOR_REVIEW` without"),
     ],
     "intake-deduplication": [
         ("skills/wave-intake/SKILL.md", "Do not submit a duplicate"),

--- a/plugins/wave/scripts/validate_plugin.py
+++ b/plugins/wave/scripts/validate_plugin.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Validate the distributable Amplitude Wave plugin without dependencies."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_SKILLS = {
+    "wave-autopilot",
+    "wave-babysit",
+    "wave-close-out",
+    "wave-dispatch-handoff",
+    "wave-evaluate",
+    "wave-experiment",
+    "wave-intake",
+    "wave-queue",
+    "wave-refine",
+}
+MANUAL_SKILLS = {
+    "wave-autopilot",
+    "wave-babysit",
+    "wave-close-out",
+    "wave-dispatch-handoff",
+    "wave-experiment",
+    "wave-intake",
+}
+REQUIRED_SCENARIOS = {
+    "already-fixed-problem",
+    "close-out-evidence-gate",
+    "direct-ship-correctness",
+    "duplicate-write-prevention",
+    "evaluate-repository-unavailable",
+    "existing-in-flight-pr",
+    "experiment-worthy-change",
+    "frontend-verification",
+    "intake-deduplication",
+    "interrupted-run-resume",
+    "queue-natural-language",
+    "real-problem-weak-plan",
+    "refine-read-only",
+    "scheduled-human-decision",
+    "unattended-missing-config",
+}
+LEGACY_TOOL_PATTERNS = {
+    r"`get_context`": "get_amplitude_context",
+    r"`get_project_context`": "get_amplitude_context",
+    r"`list_objectives`": "query_wave_product_areas",
+    r"`list_opportunities`": "query_wave_opportunities action list",
+    r"`search_opportunities`": "query_wave_opportunities action search",
+    r"`get_opportunity`": "query_wave_opportunities action get",
+    r"`update_opportunity_status`": "manage_wave_opportunities action update",
+    r"`update_opportunity`": "manage_wave_opportunities action update",
+    r"`add_opportunity_comment`": "manage_wave_opportunities action add_comment",
+    r"`create_relation`": "manage_wave_opportunities action add_opportunity_relation",
+    r"`submit_opportunity_idea`": "manage_wave_opportunities action submit_idea",
+    r"`create_flags`": "use_amp_flags action create",
+    r"`create_experiment`": "use_amp_experiments action create",
+    r"`query_experiment`": "use_amp_experiments action analyze",
+}
+SCENARIO_TEXT_ASSERTIONS = {
+    "queue-natural-language": [
+        ("skills/wave-queue/SKILL.md", "read-only"),
+        ("skills/wave-queue/SKILL.md", "Do not paginate"),
+        ("skills/wave-queue/SKILL.md", "call `get`"),
+    ],
+    "real-problem-weak-plan": [
+        ("skills/wave-evaluate/SKILL.md", "NEEDS_REPLAN"),
+        ("skills/wave-evaluate/SKILL.md", "Improve the plan"),
+    ],
+    "already-fixed-problem": [
+        ("skills/wave-evaluate/SKILL.md", "transition to `DISMISSED`"),
+        ("skills/wave-evaluate/SKILL.md", "Every dismissal requires explicit human confirmation"),
+    ],
+    "existing-in-flight-pr": [
+        ("skills/wave-dispatch-handoff/SKILL.md", "duplicate agent for an open/fresh PR"),
+    ],
+    "experiment-worthy-change": [
+        ("skills/wave-experiment/SKILL.md", "disabled"),
+        ("skills/wave-experiment/SKILL.md", "Never enable a flag rollout"),
+    ],
+    "direct-ship-correctness": [
+        ("references/decision-rubrics.md", "Correctness, security, accessibility"),
+    ],
+    "interrupted-run-resume": [
+        ("skills/wave-autopilot/SKILL.md", "Reconcile"),
+        ("skills/wave-autopilot/SKILL.md", "Resume existing"),
+    ],
+    "duplicate-write-prevention": [
+        ("references/wave-pipeline-contract.md", "Idempotent writes"),
+    ],
+    "frontend-verification": [
+        ("skills/wave-babysit/SKILL.md", "screenshot or GIF"),
+    ],
+    "intake-deduplication": [
+        ("skills/wave-intake/SKILL.md", "Do not submit a duplicate"),
+    ],
+    "refine-read-only": [
+        ("skills/wave-refine/SKILL.md", "read-only by default"),
+    ],
+    "close-out-evidence-gate": [
+        ("skills/wave-close-out/SKILL.md", "Transition to `MEASURED` only"),
+    ],
+    "unattended-missing-config": [
+        ("skills/wave-autopilot/SKILL.md", "run read-only queue/reconcile"),
+    ],
+    "evaluate-repository-unavailable": [
+        ("skills/wave-evaluate/SKILL.md", "NEEDS_HUMAN_REVIEW"),
+    ],
+    "scheduled-human-decision": [
+        ("skills/wave-autopilot/SKILL.md", "Never block on a prompt"),
+        ("skills/wave-autopilot/SKILL.md", "park"),
+    ],
+}
+
+
+def parse_frontmatter(path: Path) -> tuple[dict[str, str], str]:
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if not lines or lines[0] != "---":
+        raise ValueError("missing YAML frontmatter")
+    try:
+        end = lines.index("---", 1)
+    except ValueError as error:
+        raise ValueError("unterminated YAML frontmatter") from error
+
+    fields: dict[str, str] = {}
+    for line in lines[1:end]:
+        match = re.match(r"^([a-zA-Z0-9_-]+):(?:\s*(.*))?$", line)
+        if match:
+            fields[match.group(1)] = (match.group(2) or "").strip()
+    return fields, text
+
+
+def validate_skills(errors: list[str]) -> None:
+    found: set[str] = set()
+    for path in sorted((ROOT / "skills").glob("*/SKILL.md")):
+        relative = path.relative_to(ROOT)
+        try:
+            frontmatter, text = parse_frontmatter(path)
+        except ValueError as error:
+            errors.append(f"{relative}: {error}")
+            continue
+
+        name = frontmatter.get("name", "")
+        description = frontmatter.get("description", "")
+        found.add(name)
+        if name != path.parent.name or not re.fullmatch(r"[a-z0-9-]{1,64}", name):
+            errors.append(f"{relative}: invalid or mismatched skill name {name!r}")
+        if not description or len(description) > 1024 or "Use when" not in description:
+            errors.append(f"{relative}: description needs concrete 'Use when' triggers")
+        if len(text.splitlines()) > 500:
+            errors.append(f"{relative}: SKILL.md exceeds 500 lines")
+        if name in MANUAL_SKILLS and frontmatter.get("disable-model-invocation") != "true":
+            errors.append(f"{relative}: consequential skill must require explicit invocation")
+        for pattern, replacement in LEGACY_TOOL_PATTERNS.items():
+            if re.search(pattern, text):
+                errors.append(f"{relative}: legacy {pattern!r}; use {replacement}")
+        if "/Users/" in text or ".claude/skills" in text or ".cursor/skills" in text:
+            errors.append(f"{relative}: contains a personal/local dependency")
+        for target in re.findall(r"\]\(([^)]+\.md)\)", text):
+            if not (path.parent / target).resolve().is_file():
+                errors.append(f"{relative}: broken markdown reference {target}")
+
+    if found != EXPECTED_SKILLS:
+        errors.append(
+            f"skill set mismatch; missing={sorted(EXPECTED_SKILLS - found)}, "
+            f"extra={sorted(found - EXPECTED_SKILLS)}"
+        )
+
+
+def validate_manifests(errors: list[str]) -> None:
+    try:
+        claude = json.loads((ROOT / ".claude-plugin/plugin.json").read_text())
+        cursor = json.loads((ROOT / ".cursor-plugin/plugin.json").read_text())
+        codex = json.loads((ROOT / ".codex-plugin/plugin.json").read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        errors.append(f"manifest: invalid JSON: {error}")
+        return
+
+    if claude != cursor:
+        errors.append("Claude and Cursor plugin manifests must match")
+    if {claude.get("name"), cursor.get("name"), codex.get("name")} != {"wave"}:
+        errors.append("all plugin manifests must use name 'wave'")
+    if codex.get("version") != "1.0.0":
+        errors.append("Codex plugin version must be 1.0.0 for initial release")
+    if codex.get("skills") != "./skills/" or codex.get("mcpServers") != "./.mcp.json":
+        errors.append("Codex manifest must reference ./skills/ and ./.mcp.json")
+
+
+def validate_config_and_scenarios(errors: list[str]) -> None:
+    try:
+        mcp = json.loads((ROOT / ".mcp.json").read_text())
+        amplitude = mcp["mcpServers"]["amplitude"]
+        if amplitude != {"type": "http", "url": "https://mcp.amplitude.com/mcp"}:
+            errors.append(".mcp.json: unexpected Amplitude server configuration")
+    except (OSError, KeyError, TypeError, json.JSONDecodeError) as error:
+        errors.append(f".mcp.json: invalid config: {error}")
+
+    try:
+        config = json.loads((ROOT / "config/wave-config.example.json").read_text())
+        defaults = config["defaults"]
+        if config.get("projectId") != "YOUR_PROJECT_ID":
+            errors.append("config: projectId must be a generic placeholder")
+        if "allowMerge" in defaults or "allowExperimentLaunch" in defaults:
+            errors.append("config: human gates must not be configurable")
+        for cap in (
+            "maxOpportunitiesPerRun",
+            "maxConcurrentAgents",
+            "maxNewIdeasPerRun",
+            "maxRetriesPerStage",
+            "minOpportunitiesForRefine",
+        ):
+            if not isinstance(defaults.get(cap), int) or defaults[cap] < 0:
+                errors.append(f"config: {cap} must be a non-negative integer")
+    except (OSError, KeyError, TypeError, json.JSONDecodeError) as error:
+        errors.append(f"config: invalid example: {error}")
+
+    try:
+        scenarios = json.loads((ROOT / "tests/scenarios.json").read_text())["scenarios"]
+        ids = {scenario["id"] for scenario in scenarios}
+        if len(ids) != len(scenarios):
+            errors.append("scenarios: IDs must be unique")
+        if not REQUIRED_SCENARIOS.issubset(ids):
+            errors.append(f"scenarios: missing {sorted(REQUIRED_SCENARIOS - ids)}")
+        covered = {scenario["expectedSkill"] for scenario in scenarios}
+        if covered != EXPECTED_SKILLS:
+            errors.append(f"scenarios: skill coverage differs: {sorted(covered)}")
+        for scenario_id, assertions in SCENARIO_TEXT_ASSERTIONS.items():
+            if scenario_id not in ids:
+                continue
+            for relative, phrase in assertions:
+                if phrase not in (ROOT / relative).read_text(encoding="utf-8"):
+                    errors.append(f"scenario {scenario_id}: {relative} missing {phrase!r}")
+    except (OSError, KeyError, TypeError, json.JSONDecodeError) as error:
+        errors.append(f"scenarios: invalid fixture: {error}")
+
+
+def validate() -> list[str]:
+    errors: list[str] = []
+    validate_skills(errors)
+    validate_manifests(errors)
+    validate_config_and_scenarios(errors)
+
+    hard_gates = {
+        "skills/wave-autopilot/SKILL.md": ["Never merge a PR", "Never enable rollout"],
+        "skills/wave-experiment/SKILL.md": [
+            "Never enable a flag rollout",
+            "explicit human approval",
+        ],
+        "skills/wave-babysit/SKILL.md": ["Never merge"],
+    }
+    for relative, phrases in hard_gates.items():
+        text = (ROOT / relative).read_text(encoding="utf-8")
+        for phrase in phrases:
+            if phrase not in text:
+                errors.append(f"{relative}: missing hard gate {phrase!r}")
+    return errors
+
+
+def main() -> int:
+    errors = validate()
+    if errors:
+        print("Amplitude Wave plugin validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print(f"Amplitude Wave plugin validation passed ({len(EXPECTED_SKILLS)} skills).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/wave/skills/wave-autopilot/SKILL.md
+++ b/plugins/wave/skills/wave-autopilot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wave-autopilot
-description: Runs the Amplitude Wave opportunity loop autonomously within configured caps: reconcile work, evaluate against code, dispatch coding agents, shepherd PRs to review-ready, prepare experiments, close measurable outcomes, and report human gates. Use when users explicitly ask to run Wave autonomously, work the opportunity backlog end to end, or schedule a self-improving product loop.
+description: Orchestrates the Wave loop within caps: reconcile, evaluate, dispatch, babysit, optional experiment prep, and close-out. Use when the user explicitly asks to run Wave autonomously, work the Wave backlog end to end, or schedule the self-improving product loop. Not for ranking a morning queue or evaluating a single item.
 disable-model-invocation: true
 ---
 

--- a/plugins/wave/skills/wave-autopilot/SKILL.md
+++ b/plugins/wave/skills/wave-autopilot/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: wave-autopilot
+description: Runs the Amplitude Wave opportunity loop autonomously within configured caps: reconcile work, evaluate against code, dispatch coding agents, shepherd PRs to review-ready, prepare experiments, close measurable outcomes, and report human gates. Use when users explicitly ask to run Wave autonomously, work the opportunity backlog end to end, or schedule a self-improving product loop.
+disable-model-invocation: true
+---
+
+# Wave Autopilot
+
+Orchestrate the installed Wave skills. Do not duplicate their detailed procedures.
+
+Read:
+
+- [Wave pipeline contract](../../references/wave-pipeline-contract.md)
+- [Decision rubrics](../../references/decision-rubrics.md)
+- [Output contracts](../../references/output-contracts.md)
+
+## Hard boundaries
+
+- Never merge a PR.
+- Never enable rollout to real users or launch an experiment without explicit human
+  approval in the current run.
+- Never silently dismiss ambiguous opportunities.
+- Never exceed configured opportunity, idea, retry, or concurrency caps.
+- Never start new work before reconciling work already in progress.
+
+## Configuration
+
+Load `wave-config.json` from the workspace root or `.amplitude/`. If absent:
+
+- attended mode: ask for project ID and target-repo commands;
+- unattended mode: run read-only queue/reconcile, park missing setup, and stop.
+
+Hard gates remain on regardless of configuration.
+
+Supported scope inputs: `opportunityId`, `productAreaId`, tags, repository, and mode.
+Default interactive mode is `attended`; scheduled sessions use `unattended`.
+
+## Orchestration
+
+### 0. Reconcile
+
+Invoke `wave-queue` logic over bounded `IN_PROGRESS`, `FOR_REVIEW`, and `SHIPPED` work
+previously touched by this workflow.
+
+- Existing PR → `wave-babysit`.
+- Shipped and measurement-ready → `wave-close-out`.
+- Failed/interrupted agent with resumable branch → resume through
+  `wave-dispatch-handoff`.
+
+Complete reconciliation before selecting new work.
+
+### 1. Select
+
+Use `wave-queue` for `NEW`/`PLANNED` opportunities in scope. Honor
+`maxOpportunitiesPerRun`. Prefer resumable/high-impact/unblocked work and avoid parent
+epics as implementation units. Fetch the selected product area's description/metadata
+and recent approve, replan, dismiss, and outcome comments as a compact "team taste"
+brief; use it to rank and sharpen work without overriding fresh evidence.
+
+### 2. Investigate
+
+Run `wave-evaluate` for selected opportunities:
+
+- confirm current code state;
+- improve plan and acceptance criteria;
+- park ambiguity as `needs-human-review`;
+- propose dismissal only for conclusive obsolete/invalid problems, then park for human
+  confirmation rather than transitioning to `DISMISSED`.
+
+In unattended mode, do not wait for questions. Record the decision needed and continue.
+
+### 3. Experiment decision
+
+When the decision rubric recommends an experiment, invoke `wave-experiment` before the
+implementation starts so the coding handoff includes the flag, variants, and metrics.
+Prepare the disabled experiment and park live traffic at its human gate. Direct-ship work
+bypasses this stage.
+
+### 4. Dispatch and implement
+
+For each approved opportunity, invoke `wave-dispatch-handoff` subject to
+`maxConcurrentAgents`. Include the experiment setup in the handoff when applicable. Use
+isolated agents/worktrees when available. Resume existing work instead of duplicating it.
+
+### 5. Shepherd
+
+Invoke `wave-babysit` for returned/linked PRs. Drive deterministic CI and review work to a
+verified `FOR_REVIEW` state. Park at the merge gate.
+
+### 6. Learn
+
+Invoke `wave-close-out` for shipped work whose measurement window is ready. Persist
+outcome evidence and learnings. Do not force early measurement.
+
+### 7. Replenish
+
+Only when no workable backlog remains and `maxNewIdeasPerRun > 0`, invoke `wave-intake`
+with measured/product-area learnings. Semantic-search before submission. In unattended
+mode, submit only high-confidence, non-duplicate ideas; otherwise park proposals.
+
+### 8. Reflect
+
+After the configured minimum sample, invoke `wave-refine` read-only to identify workflow
+and skill improvements. It may propose a patch/PR; it must not silently rewrite the
+plugin.
+
+## Attended versus unattended
+
+**Attended**
+
+- Show evaluation batches before Wave writes.
+- Ask focused questions for genuine ambiguity.
+- Stop at merge and experiment-launch gates.
+
+**Unattended**
+
+- Never block on a prompt.
+- Park human decisions with a `wave_gate` comment.
+- Continue independent opportunities within caps.
+- Finish with a machine-readable `wave_run` summary.
+
+## Failure policy
+
+- Retry transient failures within `maxRetriesPerStage`.
+- Authentication/authorization denial: record once and stop affected work.
+- Agent/CI failure: preserve branch/session/PR state and mark resumable.
+- Tool schema mismatch: do not guess parameters; park and report the incompatibility.
+- Run timeout: stop launching work, persist resumable state, summarize.
+
+## Done
+
+The run reconciles existing work, advances bounded opportunities as far as safely
+possible, parks every human gate with evidence, and emits `wave_run`.
+
+## Gotchas
+
+- Autonomy means unattended orchestration, not removal of merge/traffic gates.
+- The host or automation starts the session; Wave MCP does not launch sessions itself.
+- Product-area metadata and Wave records are durable memory; local logs are operational.
+- Do not inline sibling skill bodies here—invoke their contracts.

--- a/plugins/wave/skills/wave-babysit/SKILL.md
+++ b/plugins/wave/skills/wave-babysit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wave-babysit
-description: Shepherds pull requests linked to Amplitude Wave opportunities through CI, review feedback, conflicts, acceptance-criteria verification, and a merge-ready human gate. Use when users ask to babysit Wave PRs, fix CI or review comments, resume opportunity implementation, or get Wave work ready for review. Never merges automatically.
+description: Shepherds an existing Wave-linked pull request through CI, review comments, conflicts, and verification to a merge-ready gate. Use when the user asks to babysit a Wave PR, fix CI on Wave work, or get a linked PR merge-ready. Never merges. Not for evaluating unapproved opportunities or launching new implementation.
 disable-model-invocation: true
 ---
 
@@ -40,12 +40,15 @@ For each active PR:
 5. Review the result against the current opportunity acceptance criteria—not merely the
    PR description.
 6. For frontend behavior, capture a screenshot or GIF. For backend work, attach a test
-   log, trace, or other concise proof. Use the exact upload sequence in the shared
-   contract and bind artifacts to one-based acceptance-criterion indexes.
+   log, trace, or other concise proof. Follow the contract upload sequence
+   (`prepare_upload` → execute the returned curl exactly → `finalize_upload`, or
+   `create_link` for a hosted URL) and bind artifacts to one-based acceptance-criterion
+   indexes. If proof cannot be captured or uploaded, leave the work `IN_PROGRESS` and
+   explain the gap.
 7. Ensure the idempotent `DELIVERED_VIA` relation exists with full PR URL.
 8. Add/update the `wave_pr_ready` comment. Use:
-   - `IN_PROGRESS` while checks or criteria are incomplete;
-   - `FOR_REVIEW` only when the PR is genuinely reviewable.
+   - `IN_PROGRESS` while checks or criteria are incomplete or unverified;
+   - `FOR_REVIEW` only when checks pass and required acceptance criteria have artifacts.
 9. Add `pr-ready` when all checks and criteria pass; remove stale failure/block tags.
 
 ## Human gate
@@ -78,4 +81,5 @@ verified shipped, or explicitly parked.
 - Never open a duplicate PR for an existing branch.
 - Do not resolve ambiguous review feedback by guessing.
 - Verification proves user-visible acceptance criteria, not just compilation.
+- Never mark `FOR_REVIEW` without the required screenshot/GIF or backend proof uploaded.
 - Never merge.

--- a/plugins/wave/skills/wave-babysit/SKILL.md
+++ b/plugins/wave/skills/wave-babysit/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: wave-babysit
+description: Shepherds pull requests linked to Amplitude Wave opportunities through CI, review feedback, conflicts, acceptance-criteria verification, and a merge-ready human gate. Use when users ask to babysit Wave PRs, fix CI or review comments, resume opportunity implementation, or get Wave work ready for review. Never merges automatically.
+disable-model-invocation: true
+---
+
+# Wave Babysit
+
+Drive linked implementation to a verified, merge-ready PR. Never merge.
+
+Read:
+
+- [Wave pipeline contract](../../references/wave-pipeline-contract.md)
+- [Output contracts](../../references/output-contracts.md)
+
+## Discover and reconcile
+
+1. Resolve the project.
+2. Query a bounded set of candidates across `IN_PROGRESS`, `FOR_REVIEW`,
+   `INVESTIGATING`, and `PLANNED`, or use supplied opportunity IDs.
+3. Call `get` and inspect relations in both directions.
+4. Discover PRs from:
+   - `DELIVERED_VIA` → `GITHUB_PR`;
+   - `IMPLEMENTED_BY` relation metadata;
+   - structured dispatch/PR-ready comments.
+5. Verify each PR's live state with the host's GitHub tooling. Status/tags/comments may
+   be stale.
+
+## Shepherd the PR
+
+For each active PR:
+
+1. Read the full diff, checks, review threads, and mergeability.
+2. Classify blockers:
+   - deterministic: CI, lint, tests, formatting, clear defect, simple conflict;
+   - ambiguous: product direction, security tradeoff, architecture change, scope dispute.
+3. Fix deterministic blockers on the existing branch. Route ambiguous blockers to a
+   human with one clear decision; add `pr-blocked` only when progress cannot continue.
+4. Re-run relevant checks after every substantive fix.
+5. Review the result against the current opportunity acceptance criteria—not merely the
+   PR description.
+6. For frontend behavior, capture a screenshot or GIF. For backend work, attach a test
+   log, trace, or other concise proof. Use the exact upload sequence in the shared
+   contract and bind artifacts to one-based acceptance-criterion indexes.
+7. Ensure the idempotent `DELIVERED_VIA` relation exists with full PR URL.
+8. Add/update the `wave_pr_ready` comment. Use:
+   - `IN_PROGRESS` while checks or criteria are incomplete;
+   - `FOR_REVIEW` only when the PR is genuinely reviewable.
+9. Add `pr-ready` when all checks and criteria pass; remove stale failure/block tags.
+
+## Human gate
+
+At merge-ready:
+
+- summarize change, checks, evidence, experiment state, and remaining risk;
+- produce a `wave_gate` block with `gate: merge`;
+- stop and request explicit human approval.
+
+Merge is never automatic. Approval must be explicit in the current run and the merge
+itself belongs outside this skill.
+
+## Already merged or closed
+
+- Merged PR: verify merge, add `pr-merged`, remove `pr-open`, transition to `SHIPPED`,
+  and route to `wave-close-out`.
+- Closed without merge: add `pr-closed`; transition to `IN_PROGRESS` only if resumable
+  implementation remains, otherwise add `needs-replan`.
+- Missing PR relation but known PR URL: create the relation after duplicate check.
+
+## Done
+
+Each candidate is merge-ready at a human gate, still in progress with concrete blockers,
+verified shipped, or explicitly parked.
+
+## Gotchas
+
+- `FOR_REVIEW` does not prove a PR exists.
+- Never open a duplicate PR for an existing branch.
+- Do not resolve ambiguous review feedback by guessing.
+- Verification proves user-visible acceptance criteria, not just compilation.
+- Never merge.

--- a/plugins/wave/skills/wave-close-out/SKILL.md
+++ b/plugins/wave/skills/wave-close-out/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: wave-close-out
-description: Measures shipped Amplitude Wave opportunities, links outcome evidence, records learnings, and moves ready work from SHIPPED to MEASURED. Use when users ask whether a Wave opportunity worked, request an outcome readout, want to close the product loop, or schedule post-ship measurement. Not for preparing or launching a new experiment.
-disable-model-invocation: true
+description: Measures a shipped Wave opportunity and records the outcome. Use when the user asks if a shipped Wave opportunity worked, wants a post-ship readout, or wants to move work to MEASURED. Not for preparing or launching experiments, and not for ranking new work.
 ---
 
 # Wave Close Out

--- a/plugins/wave/skills/wave-close-out/SKILL.md
+++ b/plugins/wave/skills/wave-close-out/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: wave-close-out
+description: Measures shipped Amplitude Wave opportunities, links outcome evidence, records learnings, and moves ready work from SHIPPED to MEASURED. Use when users ask whether a Wave opportunity worked, request an outcome readout, want to close the product loop, or schedule post-ship measurement. Not for preparing or launching a new experiment.
+disable-model-invocation: true
+---
+
+# Wave Close Out
+
+Read shipped outcomes and feed the learning back into Wave.
+
+Read:
+
+- [Wave pipeline contract](../../references/wave-pipeline-contract.md)
+- [Decision rubrics](../../references/decision-rubrics.md)
+- [Output contracts](../../references/output-contracts.md)
+
+## Workflow
+
+### 1. Find measurable work
+
+1. Resolve project context.
+2. Query a bounded `SHIPPED` set, narrowed by opportunity, product area, tags, or
+   configured measurement window.
+3. Call `get` and inspect incoming/outgoing relations for each candidate.
+4. Verify the delivery actually merged/shipped. Parent opportunities without a concrete
+   delivered child/PR are not measurement units.
+5. Resolve target metric, chart, experiment ID, ship date, and measurement window from
+   relations, metadata, and structured comments.
+
+### 2. Check readiness
+
+- Too early: leave `SHIPPED`; report the next valid measurement date.
+- Missing signal: add/retain `needs-instrumentation`; record an explicit fallback only
+  when the gap is real and no existing signal can answer the question.
+- Experiment still running or awaiting launch: leave `SHIPPED`; report its gate/state.
+
+### 3. Read outcome
+
+**Experiment-backed**
+
+1. Resolve experiment ID with `search_amp_entities` when needed.
+2. Call `use_amp_experiments` `analyze`; omit `metricIds` unless specific secondary
+   metrics were requested.
+3. Report primary decision, lift, guardrails, validity warnings, and Amplitude link.
+
+**Direct ship**
+
+1. Read linked saved charts with `get_amplitude_charts`.
+2. Use `query_amplitude_data` for a necessary ad-hoc pre/post query only after discovering
+   real events/properties through taxonomy tools.
+3. Compare equivalent pre/post windows; account for weekday and known seasonality.
+4. State correlation and caveats. Do not claim causality from a before/after comparison.
+
+### 4. Record and learn
+
+1. Attach a hosted chart with `manage_wave_verification_artifacts` `create_link`, or use
+   the documented prepare/upload/finalize sequence for a local before/after artifact.
+2. Add one idempotent `wave_outcome` comment.
+3. Patch durable metadata with measurement type, window, result, confidence, and learning.
+4. Ensure supported metric/chart relations exist.
+5. Remove stale measurement-gap tags and add `instrumented` when appropriate.
+6. Transition to `MEASURED` only when evidence or an explicit fallback is recorded.
+7. If the outcome warrants a follow-up, semantic-search existing opportunities first.
+   Invoke `wave-intake` only for a genuinely new, human-approved idea.
+8. Roll a concise learning into product-area metadata when the tool supports it.
+
+## Attended and scheduled behavior
+
+Attended mode shows proposed updates before writing. Unattended close-out may record
+outcome evidence and transition ready opportunities, but it parks ambiguous experiment
+decisions or attribution questions for a human.
+
+## Done
+
+Every candidate is measured with evidence and learning, too early with a recheck date, or
+not measurable with a precise instrumentation gap.
+
+## Gotchas
+
+- Never move to `MEASURED` just because enough days elapsed.
+- Experiment metrics are a replacement set when updated; this skill does not update them.
+- Do not invent a metric for close-out.
+- Direct-ship movement is not causal proof.

--- a/plugins/wave/skills/wave-dispatch-handoff/SKILL.md
+++ b/plugins/wave/skills/wave-dispatch-handoff/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: wave-dispatch-handoff
+description: Claims approved Amplitude Wave opportunities and launches or prepares isolated coding-agent sessions with a normalized implementation handoff. Use when users ask to dispatch agents, start coding approved Wave work, implement selected opportunities, or hand a Wave opportunity to a coding agent. Not for evaluating unapproved opportunities or shepherding an existing PR.
+disable-model-invocation: true
+---
+
+# Wave Dispatch Handoff
+
+Turn approved, codebase-validated opportunities into bounded coding-agent work.
+
+Read:
+
+- [Wave pipeline contract](../../references/wave-pipeline-contract.md)
+- [Decision rubrics](../../references/decision-rubrics.md)
+- [Output contracts](../../references/output-contracts.md)
+
+## Preconditions
+
+Dispatch only when all are true:
+
+- full opportunity was fetched;
+- verdict is approved and problem is codebase-confirmed;
+- structured `wave_handoff` exists;
+- target repository is available;
+- acceptance criteria are observable;
+- no fresh competing claim, implementation, or matching PR exists.
+
+If any precondition fails, route to `wave-evaluate` or `wave-babysit`; do not improvise.
+
+## Workflow
+
+1. Resolve project and re-fetch the opportunity plus incoming/outgoing relations.
+2. Detect current repository and match it to the approved handoff. For multi-repo work,
+   create one bounded handoff per repository and preserve dependency order.
+3. Apply the staleness rubric. Resume existing work when possible; never launch a
+   duplicate agent for an open/fresh PR.
+4. Determine execution shape:
+   - isolated local subagent/worktree when supported;
+   - cloud coding agent when explicitly requested and available;
+   - inline implementation only when the host lacks isolation and the user approved it.
+5. Create a branch name such as `wave/<short-opportunity-id>-<slug>`.
+6. Launch the coding agent with the `wave_dispatch` block plus:
+   - current codebase findings,
+   - exact acceptance criteria,
+   - target metric and experiment recommendation,
+   - repository test/lint/build commands,
+   - instruction to stop at a review-ready PR and never merge.
+7. When the host returns a stable agent/session ID, add an idempotent `IMPLEMENTED_BY`
+   relation. Use an `INVESTIGATED_BY` lease when supported, pass `leaseTtlSeconds`, then
+   re-read to detect a race. Never fabricate a session ID.
+8. Set `IN_PROGRESS` only after work actually started. Add the dispatch handoff comment
+   if an equivalent one is absent.
+
+## Coding-agent contract
+
+The launched agent must:
+
+- reconcile the opportunity before edits;
+- follow current repository conventions;
+- decide experiment gating before implementing the behavior;
+- keep changes scoped to acceptance criteria;
+- run configured checks;
+- create verification evidence;
+- open or update a PR;
+- return PR URL, commit, check results, and unresolved risks;
+- never merge or enable real-user experiment traffic.
+
+## Failure handling
+
+- Launch fails before work starts: leave status unchanged; add no implementation relation.
+- Agent starts but fails: preserve branch/session information, add `agent-failed`, and
+  leave `IN_PROGRESS` with a concise resume comment.
+- Retries exceed configured cap: add `retries-exhausted` and park for human review.
+- Another fresh claim wins: stop the launched work if safe, record the race, and defer.
+
+## Done
+
+Work is claimed and linked to a real coding-agent session/branch, or parked with a
+specific precondition/failure. The next skill is `wave-babysit`.
+
+## Gotchas
+
+- Never launch from a list/search result.
+- `sourceId` is the opportunity ID for relation writes; do not use `id`.
+- An agent relation without a stable ID is worse than an attribution comment.
+- Do not create a second branch/PR when resumable work exists.
+- This skill starts work; it does not shepherd CI/review or merge.

--- a/plugins/wave/skills/wave-dispatch-handoff/SKILL.md
+++ b/plugins/wave/skills/wave-dispatch-handoff/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: wave-dispatch-handoff
-description: Claims approved Amplitude Wave opportunities and launches or prepares isolated coding-agent sessions with a normalized implementation handoff. Use when users ask to dispatch agents, start coding approved Wave work, implement selected opportunities, or hand a Wave opportunity to a coding agent. Not for evaluating unapproved opportunities or shepherding an existing PR.
+description: Claims an approved Wave opportunity and launches isolated coding work with a normalized handoff. Use when the user asks to dispatch, implement, or hand an approved Wave opportunity to a coding agent. Not for evaluating unapproved items or babysitting an existing PR.
 disable-model-invocation: true
 ---
 
 # Wave Dispatch Handoff
 
-Turn approved, codebase-validated opportunities into bounded coding-agent work.
+Turn approved, codebase-validated opportunities into bounded coding-agent work. This
+skill launches work; it does not implement in the orchestrating session.
 
 Read:
 
@@ -30,40 +31,32 @@ If any precondition fails, route to `wave-evaluate` or `wave-babysit`; do not im
 ## Workflow
 
 1. Resolve project and re-fetch the opportunity plus incoming/outgoing relations.
-2. Detect current repository and match it to the approved handoff. For multi-repo work,
-   create one bounded handoff per repository and preserve dependency order.
+2. Match the current repository to the approved handoff. For multi-repo work, create one
+   bounded handoff per repository and preserve dependency order.
 3. Apply the staleness rubric. Resume existing work when possible; never launch a
    duplicate agent for an open/fresh PR.
-4. Determine execution shape:
-   - isolated local subagent/worktree when supported;
-   - cloud coding agent when explicitly requested and available;
-   - inline implementation only when the host lacks isolation and the user approved it.
-5. Create a branch name such as `wave/<short-opportunity-id>-<slug>`.
-6. Launch the coding agent with the `wave_dispatch` block plus:
-   - current codebase findings,
-   - exact acceptance criteria,
-   - target metric and experiment recommendation,
-   - repository test/lint/build commands,
-   - instruction to stop at a review-ready PR and never merge.
+4. Create branch `wave/<short-opportunity-id>-<slug>` in an isolated git worktree.
+5. Launch a **child** coding agent in that worktree with the `wave_dispatch` block plus
+   current codebase findings, acceptance criteria, metric/experiment recommendation,
+   repo test/lint/build commands, and "stop at a review-ready PR; never merge."
+   In Cursor, use an isolated subagent/worktree, or a cloud agent only if the user asked.
+6. Isolation rules:
+   - Unattended: if a worktree/child agent cannot be launched, park with `wave_gate`
+     and do not code inline.
+   - Attended: inline coding only if the user explicitly asks to implement here.
 7. When the host returns a stable agent/session ID, add an idempotent `IMPLEMENTED_BY`
    relation. Use an `INVESTIGATED_BY` lease when supported, pass `leaseTtlSeconds`, then
-   re-read to detect a race. Never fabricate a session ID.
+   re-read to detect a race. Never fabricate a session ID. If there is no stable ID,
+   write attribution in a comment and rely on the branch/PR.
 8. Set `IN_PROGRESS` only after work actually started. Add the dispatch handoff comment
    if an equivalent one is absent.
 
 ## Coding-agent contract
 
-The launched agent must:
-
-- reconcile the opportunity before edits;
-- follow current repository conventions;
-- decide experiment gating before implementing the behavior;
-- keep changes scoped to acceptance criteria;
-- run configured checks;
-- create verification evidence;
-- open or update a PR;
-- return PR URL, commit, check results, and unresolved risks;
-- never merge or enable real-user experiment traffic.
+The launched agent must: reconcile before edits; follow repo conventions; decide
+experiment gating before implementing; stay inside acceptance criteria; run configured
+checks; create verification evidence; open or update a PR; return PR URL, commit, checks,
+and risks; never merge or enable real-user experiment traffic.
 
 ## Failure handling
 

--- a/plugins/wave/skills/wave-evaluate/SKILL.md
+++ b/plugins/wave/skills/wave-evaluate/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: wave-evaluate
+description: Validates Amplitude Wave opportunities against the current codebase and fresh product evidence, then improves their execution plans and acceptance criteria. Use when users ask to evaluate, validate, review, sharpen, approve, or replan Wave opportunities. Dismisses only when the underlying problem is demonstrably obsolete or invalid; does not implement code.
+---
+
+# Wave Evaluate
+
+Confirm that the problem still exists, then make the plan implementable. Improving a real
+opportunity is the default success condition; clearing the queue is not.
+
+Read:
+
+- [Wave pipeline contract](../../references/wave-pipeline-contract.md)
+- [Decision rubrics](../../references/decision-rubrics.md)
+- [Output contracts](../../references/output-contracts.md)
+
+## Mode
+
+- `attended` (default): investigate read-only, present proposed verdicts, and obtain
+  confirmation before any Wave writes.
+- `unattended`: allowed only when explicitly invoked by `wave-autopilot`; write approvals
+  and replans, but park ambiguity as `needs-human-review`. A conclusive dismiss finding is
+  proposed and parked for human confirmation rather than applied silently.
+
+## Workflow
+
+### 1. Resolve and fetch
+
+1. Resolve project context with `get_amplitude_context`.
+2. Discover candidates with a bounded `query_wave_opportunities` `list` or `search`.
+3. For every candidate, call `get`; query relevant incoming and outgoing relations.
+4. Normalize tags, repositories, PRs, agents, parent/child state, and measurement links.
+
+### 2. Confirm current code state
+
+For each opportunity:
+
+1. Resolve the target repository from the full record; never infer from a snippet.
+2. Read referenced files and adjacent code paths.
+3. Check recent commits and linked/open PRs for an existing or in-flight fix.
+4. Reproduce or trace the described behavior when feasible.
+5. Separate:
+   - implementation truth: what current code does;
+   - product truth: whether the behavior matters to users/metrics.
+
+If the repository is unavailable, do not fabricate a verdict. Mark
+`NEEDS_HUMAN_REVIEW` with the missing repository/context.
+
+### 3. Corroborate evidence
+
+When the opportunity cites charts, metrics, feedback, experiments, or replays:
+
+- fetch the cited entities rather than guessing replacements;
+- use fresh data when practical;
+- discover event/property names through taxonomy tools before ad-hoc queries;
+- treat stale or missing product evidence as a confidence limitation, not automatic
+  dismissal when code confirms the problem.
+
+### 4. Improve the plan
+
+When the problem is real:
+
+- correct repository and file targeting;
+- replace a weak or risky solution with one aligned to current code conventions;
+- make steps concrete and minimal;
+- define observable acceptance criteria;
+- identify a target metric and experiment-vs-direct-ship recommendation;
+- capture risks, blockers, existing work, and verification needs.
+
+Use `metadataPatch` with `snake_case` keys for partial metadata changes. Emit the
+`wave_handoff` block from the output contract in an idempotent comment.
+
+### 5. Choose verdict
+
+- `APPROVE`: problem confirmed and improved plan is executable. Add `agent-approved`;
+  transition to `INVESTIGATING`.
+- `NEEDS_REPLAN`: problem confirmed but material implementation ambiguity remains. Add
+  `needs-replan`; keep it out of dispatch.
+- `NEEDS_HUMAN_REVIEW`: product/security/design judgment or missing context blocks a safe
+  plan. Add `needs-human-review`.
+- `DISMISS`: only when the underlying problem is conclusively obsolete or invalid. After
+  human confirmation, transition to `DISMISSED`, remove dispatch workflow tags, and add
+  the structured dismissal handoff/comment.
+
+Wrong repository, weak strategy, low RICE, oversized scope, or non-code work are routing
+and replan inputs—not dismissal reasons.
+
+### 6. Confirmation and writes
+
+In attended mode, show a compact verdict table and exact proposed writes. After
+confirmation:
+
+1. Re-fetch each opportunity.
+2. Apply `metadataPatch` and tag additions/removals.
+3. Add one structured handoff/verdict comment if an equivalent block is absent.
+4. Apply the status transition.
+
+Do not batch more than ten verdicts. Every dismissal requires explicit human confirmation.
+In unattended mode, leave the current status unchanged, add `needs-human-review`, and
+park the proposed `DISMISS` verdict at a human gate.
+
+## Done
+
+Each evaluated opportunity has a codebase-grounded verdict, improved plan, observable
+acceptance criteria, measurement direction, and structured handoff—or one clearly stated
+human decision needed.
+
+## Gotchas
+
+- Never decide from list/search snippets.
+- Never dismiss because the proposed solution is poor; fix the solution.
+- “Feature already shipped” requires code/PR evidence and, when relevant, product-state
+  confirmation.
+- Preserve non-workflow tags.
+- Do not implement code or launch agents from this skill.

--- a/plugins/wave/skills/wave-evaluate/SKILL.md
+++ b/plugins/wave/skills/wave-evaluate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wave-evaluate
-description: Validates Amplitude Wave opportunities against the current codebase and fresh product evidence, then improves their execution plans and acceptance criteria. Use when users ask to evaluate, validate, review, sharpen, approve, or replan Wave opportunities. Dismisses only when the underlying problem is demonstrably obsolete or invalid; does not implement code.
+description: Confirms a Wave opportunity still exists in the current codebase and rewrites its plan and acceptance criteria. Use when the user asks to evaluate, validate, sharpen, approve, or replan a Wave opportunity against code. Not for ranking the backlog, implementing, babysitting a PR, or dismissing work because the plan is weak.
 ---
 
 # Wave Evaluate

--- a/plugins/wave/skills/wave-experiment/SKILL.md
+++ b/plugins/wave/skills/wave-experiment/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: wave-experiment
-description: Designs, prepares, links, and monitors Amplitude experiments for validated Wave opportunities, including flags, variants, success metrics, guardrails, and outcome handoff. Use when users ask to A/B test a Wave opportunity, gate Wave work behind a flag, prepare an experiment, or review the experiment attached to an opportunity. Never launches traffic without explicit human approval.
+description: Prepares or monitors an Amplitude experiment tied to a validated Wave opportunity (flag, variants, metrics). Use when the user asks to A/B test a Wave opportunity, gate it behind a flag, or check the experiment already linked to one. Never launches traffic without explicit approval. Not for generic experiment analysis unrelated to a Wave opportunity.
 disable-model-invocation: true
 ---
 
 # Wave Experiment
 
-Make experiments a first-class Act/Learn path for Wave opportunities. Preparation and
-monitoring are allowed; live traffic launch is a hard human gate.
+Prepare and monitor experiments for Wave opportunities. Live traffic launch is a hard
+human gate.
 
 Read:
 
@@ -29,70 +29,98 @@ experiment can be bolted on. Replan or measure as a direct ship.
 ## Prepare
 
 1. Resolve project/product-area/opportunity IDs and fetch current relations/metadata.
-2. Search `search_amp_entities` for existing linked/equivalent flags, experiments, and
-   metrics. Reuse rather than duplicate.
-3. Select measurement:
-   - prefer an existing linked/official metric;
-   - discover metric/event/property definitions before use;
-   - create a metric with `use_amplitude_metrics` only after explicit approval;
-   - include one primary success metric and at least one guardrail.
+2. Search `search_amp_entities` (`entityTypes: ["FLAG"]`, `["EXPERIMENT"]`, `["METRIC"]`)
+   and reuse matches. Never guess IDs.
+3. Select measurement: existing linked/official metric first; discover events/properties
+   before use; create a metric with `use_amplitude_metrics` only after explicit approval.
+   One primary success metric and at least one guardrail.
 4. Resolve deployments with `use_amp_flags` `list_deployments`.
-5. Ensure code supports control/treatment via a flag. Create a new **disabled** flag with
-   `use_amp_flags` `create` only when no suitable flag exists.
-6. Create the experiment with `use_amp_experiments` `create`:
-   - clear key/name/description tied to the opportunity;
-   - control and treatment variants;
-   - project/deployment IDs;
-   - project metrics, with one recommendation metric;
-   - explicit MDE when sizing matters;
-   - `proxyExposureEvent` at the tested surface when an existing event is available;
-   - link back to the opportunity/PR when a stable URL exists.
+5. Create a **disabled** flag only when none exists. `use_amp_flags` `create` takes a
+   `flags` array, not a lone flag object. Do not set `percentage` or `rolloutWeights`:
+
+   ```yaml
+   action: create
+   flags:
+     - key: <flag-key>
+       name: <name>
+       description: <tied to opportunity>
+       enabled: false
+       deploymentIds: [<id>]
+   ```
+
+6. Create the experiment. `use_amp_experiments` `create` requires `projectIds` (array),
+   not `projectId`:
+
+   ```yaml
+   action: create
+   projectIds: ["<project-id>"]
+   key: <experiment-key>
+   name: <name>
+   description: <hypothesis>
+   variants:
+     - key: control
+     - key: treatment
+   deploymentIds: [<id>]
+   projectMetrics:
+     - metricId: <primary>
+       metricIndex: 0
+       recommendation: true
+       analysisParams:
+         metricGoalType: success
+         minDetectableEffect: <relative fraction, e.g. 0.05>
+     - metricId: <guardrail>
+       metricIndex: 1
+       analysisParams:
+         metricGoalType: guardrail
+   proxyExposureEvent:
+     eventType: <existing event at the tested surface>
+   links:
+     - url: <opportunity or PR URL>
+       title: Wave opportunity
+   ```
+
 7. Persist experiment ID, flag key, metric IDs, hypothesis, variants, and gate state via
    `metadataPatch`; add one idempotent comment.
-8. Add `TARGETS_METRIC`. Add direct flag/experiment relations only when current Wave tool
-   support is proven; otherwise use metadata/comment plus experiment links as specified
-   in the shared contract.
+8. Add `TARGETS_METRIC`. Add flag/experiment Wave relations only when the live tool
+   schema supports those target types; otherwise metadata/comment plus experiment links.
 9. Produce `wave_gate` with `gate: experiment_launch` and stop.
 
 ## Launch gate
 
 Never enable a flag rollout or launch traffic merely because the experiment is prepared.
-The user must explicitly approve launch in the current run after reviewing:
+After explicit approval in the current run, show this exact update before applying it:
 
-- hypothesis and variants,
-- targeting and exposure event,
-- primary metric, guardrails, and MDE,
-- estimated duration/traffic,
-- rollback plan.
+```yaml
+action: update
+flagId: <experiment-or-flag-id>
+flagConfig:
+  enabled: true
+```
 
-Even after approval, show the exact flag update before applying it. This skill must never
-combine experiment launch with PR merge. Use `use_amp_flags` `update` with the resolved
-experiment/flag `flagId` and only the intended update sections. Enabling a prepared
-experiment uses `flagConfig.enabled: true`; do not alter variants, testers, deployments,
-or links unless they were included in the approved launch plan. If the customer needs a
-rollout/targeting mutation that the current MCP schema cannot express, park at the gate
-and link them to the Amplitude UI instead of improvising another tool.
+Do not send `variants`, `testers`, `deployments`, `links`, or `percentage` unless they
+were in the approved launch plan. Never combine launch with PR merge. If the needed
+rollout cannot be expressed by this schema, park and link the Amplitude UI.
 
 ## Monitor
 
-For a linked experiment:
-
-1. Resolve the real experiment ID and fetch it.
+1. Resolve the real experiment ID and `get` it.
 2. Call `use_amp_experiments` `analyze`; omit secondary `metricIds` unless requested.
 3. Report decision readiness, primary lift, guardrails, validity issues, and Amplitude URL.
 4. Do not call a winner early or ignore validity warnings.
 5. Record a concise status comment only when the state materially changed.
-6. Once a decision is final, route to `wave-close-out` for durable outcome recording.
+6. Once a decision is final, route to `wave-close-out`.
 
 ## Done
 
-The opportunity has a deduplicated, disabled experiment setup at a human launch gate, or
-an existing experiment has a decision-quality monitoring readout.
+The opportunity has a deduplicated, disabled experiment at a human launch gate, or an
+existing experiment has a decision-quality monitoring readout.
 
 ## Gotchas
 
-- `use_amp_experiments` metric updates fully replace the metric set.
-- Experiments require flag-aware code before launch.
-- Without a proxy exposure event, planning can overstate duration using Any Active Event.
+- `use_amp_experiments` `create` uses `projectIds` (array). `update` metrics fully replace
+  the metric set.
+- Flag `create` uses `flags: [{ enabled: false }]`. `percentage` on a live flag is a
+  rollout; do not set it during prepare.
+- Without `proxyExposureEvent`, planning overstates duration via Any Active Event.
 - Never guess deployment, metric, event, flag, or experiment IDs.
-- Never launch real traffic without explicit approval.
+- Never enable a flag rollout without explicit human approval.

--- a/plugins/wave/skills/wave-experiment/SKILL.md
+++ b/plugins/wave/skills/wave-experiment/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: wave-experiment
+description: Designs, prepares, links, and monitors Amplitude experiments for validated Wave opportunities, including flags, variants, success metrics, guardrails, and outcome handoff. Use when users ask to A/B test a Wave opportunity, gate Wave work behind a flag, prepare an experiment, or review the experiment attached to an opportunity. Never launches traffic without explicit human approval.
+disable-model-invocation: true
+---
+
+# Wave Experiment
+
+Make experiments a first-class Act/Learn path for Wave opportunities. Preparation and
+monitoring are allowed; live traffic launch is a hard human gate.
+
+Read:
+
+- [Wave pipeline contract](../../references/wave-pipeline-contract.md)
+- [Decision rubrics](../../references/decision-rubrics.md)
+- [Output contracts](../../references/output-contracts.md)
+
+## Preconditions
+
+- Full opportunity and relations are fetched.
+- Problem is codebase-confirmed.
+- Experiment-vs-direct-ship rubric favors an experiment.
+- Treatment can be safely flag-gated in the implementation PR.
+- Human explicitly invoked this skill or approved experiment preparation.
+
+If the implementation is already merged without variant-aware behavior, do not pretend an
+experiment can be bolted on. Replan or measure as a direct ship.
+
+## Prepare
+
+1. Resolve project/product-area/opportunity IDs and fetch current relations/metadata.
+2. Search `search_amp_entities` for existing linked/equivalent flags, experiments, and
+   metrics. Reuse rather than duplicate.
+3. Select measurement:
+   - prefer an existing linked/official metric;
+   - discover metric/event/property definitions before use;
+   - create a metric with `use_amplitude_metrics` only after explicit approval;
+   - include one primary success metric and at least one guardrail.
+4. Resolve deployments with `use_amp_flags` `list_deployments`.
+5. Ensure code supports control/treatment via a flag. Create a new **disabled** flag with
+   `use_amp_flags` `create` only when no suitable flag exists.
+6. Create the experiment with `use_amp_experiments` `create`:
+   - clear key/name/description tied to the opportunity;
+   - control and treatment variants;
+   - project/deployment IDs;
+   - project metrics, with one recommendation metric;
+   - explicit MDE when sizing matters;
+   - `proxyExposureEvent` at the tested surface when an existing event is available;
+   - link back to the opportunity/PR when a stable URL exists.
+7. Persist experiment ID, flag key, metric IDs, hypothesis, variants, and gate state via
+   `metadataPatch`; add one idempotent comment.
+8. Add `TARGETS_METRIC`. Add direct flag/experiment relations only when current Wave tool
+   support is proven; otherwise use metadata/comment plus experiment links as specified
+   in the shared contract.
+9. Produce `wave_gate` with `gate: experiment_launch` and stop.
+
+## Launch gate
+
+Never enable a flag rollout or launch traffic merely because the experiment is prepared.
+The user must explicitly approve launch in the current run after reviewing:
+
+- hypothesis and variants,
+- targeting and exposure event,
+- primary metric, guardrails, and MDE,
+- estimated duration/traffic,
+- rollback plan.
+
+Even after approval, show the exact flag update before applying it. This skill must never
+combine experiment launch with PR merge. Use `use_amp_flags` `update` with the resolved
+experiment/flag `flagId` and only the intended update sections. Enabling a prepared
+experiment uses `flagConfig.enabled: true`; do not alter variants, testers, deployments,
+or links unless they were included in the approved launch plan. If the customer needs a
+rollout/targeting mutation that the current MCP schema cannot express, park at the gate
+and link them to the Amplitude UI instead of improvising another tool.
+
+## Monitor
+
+For a linked experiment:
+
+1. Resolve the real experiment ID and fetch it.
+2. Call `use_amp_experiments` `analyze`; omit secondary `metricIds` unless requested.
+3. Report decision readiness, primary lift, guardrails, validity issues, and Amplitude URL.
+4. Do not call a winner early or ignore validity warnings.
+5. Record a concise status comment only when the state materially changed.
+6. Once a decision is final, route to `wave-close-out` for durable outcome recording.
+
+## Done
+
+The opportunity has a deduplicated, disabled experiment setup at a human launch gate, or
+an existing experiment has a decision-quality monitoring readout.
+
+## Gotchas
+
+- `use_amp_experiments` metric updates fully replace the metric set.
+- Experiments require flag-aware code before launch.
+- Without a proxy exposure event, planning can overstate duration using Any Active Event.
+- Never guess deployment, metric, event, flag, or experiment IDs.
+- Never launch real traffic without explicit approval.

--- a/plugins/wave/skills/wave-intake/SKILL.md
+++ b/plugins/wave/skills/wave-intake/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wave-intake
-description: Creates or updates Amplitude Wave product areas and submits deduplicated product-improvement ideas for Wave AI investigation. Use when users ask to add an idea to Wave, submit a product opportunity, configure a Wave product area, or replenish an empty Wave backlog. Not for CRM opportunities or directly creating implementation-ready records.
+description: Creates Wave product areas and submits deduplicated ideas into Wave AI investigation. Use when the user asks to submit a Wave idea, add a product area, or replenish an empty Wave backlog. Not for Salesforce/CRM, not for discovering opportunities from analytics, and not for creating implementation-ready records.
 disable-model-invocation: true
 ---
 

--- a/plugins/wave/skills/wave-intake/SKILL.md
+++ b/plugins/wave/skills/wave-intake/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: wave-intake
+description: Creates or updates Amplitude Wave product areas and submits deduplicated product-improvement ideas for Wave AI investigation. Use when users ask to add an idea to Wave, submit a product opportunity, configure a Wave product area, or replenish an empty Wave backlog. Not for CRM opportunities or directly creating implementation-ready records.
+disable-model-invocation: true
+---
+
+# Wave Intake
+
+Submit a clear problem signal to the right Wave product area and start Wave's AI
+investigation. Do not bypass investigation by pretending an idea is implementation-ready.
+
+Read [Wave pipeline contract](../../references/wave-pipeline-contract.md).
+
+## Product-area setup
+
+1. Resolve the project through `get_amplitude_context`.
+2. Call `query_wave_product_areas` `list`.
+3. Reuse an existing area when its purpose fits.
+4. If none fits, propose title, description, owner, success metrics, product surface, and
+   repository context. Obtain confirmation before `manage_wave_product_areas` `create`.
+5. Before `update`, fetch the area and show the exact field changes. Preserve unrelated
+   metadata.
+
+Product-area descriptions should explain:
+
+- users and job-to-be-done,
+- product surfaces and relevant repositories,
+- outcome metrics and guardrails,
+- strategic constraints,
+- known team preferences or learnings.
+
+## Submit an idea
+
+1. Frame the input as a user/product problem, not a preselected solution.
+2. Semantic-search opportunities in the target product area with several concise problem
+   phrasings. Do not paginate the backlog.
+3. If a close match exists, fetch it and add new evidence/context only after user
+   confirmation. Do not submit a duplicate.
+4. For a new idea, propose:
+   - title,
+   - product-area ID,
+   - short problem/evidence description.
+5. Obtain confirmation, then call `manage_wave_opportunities` `submit_idea` with
+   `productAreaId` and title. This starts AI investigation.
+6. Fetch the created opportunity when an ID is returned. Add supporting context as one
+   idempotent comment if it was not captured by submission.
+
+## Backlog replenishment
+
+Automated replenishment is permitted only inside explicitly invoked `wave-autopilot`,
+when no workable opportunities remain and `maxNewIdeasPerRun` is positive:
+
+- search before every submission;
+- use accumulated measured learnings, not random ideation;
+- never exceed the configured cap;
+- unattended mode parks uncertain ideas instead of submitting them.
+
+## Done
+
+The idea is attached to a real product area and Wave investigation has started, or
+existing opportunity context was enriched without duplication.
+
+## Gotchas
+
+- This is never for Salesforce, CRM, or sales opportunities.
+- `submit_idea` is not generic CRUD; it starts AI investigation.
+- Product-area IDs must come from the current project.
+- Do not create a product area merely because terminology differs slightly.
+- Do not mass-submit an idea list.

--- a/plugins/wave/skills/wave-queue/SKILL.md
+++ b/plugins/wave/skills/wave-queue/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: wave-queue
-description: Reviews and ranks Amplitude Wave Opportunity Manager work by product area, status, evidence, and existing execution state. Use when users ask what Wave opportunity to work on, request a morning opportunity queue, want the top product improvements, or need to find an existing Wave opportunity. Not for evaluating code or starting implementation.
+description: Ranks existing Amplitude Wave Opportunity Manager records and names the next Wave skill for each. Use when the user asks what Wave work to do next, wants a morning Wave queue, or needs to find a Wave opportunity. Not for discovering new opportunities from analytics, evaluating code, implementing, measuring shipped outcomes, or mutating Wave records.
 ---
 
 # Wave Queue
 
-Produce a read-only, ranked Wave work queue. Do not change opportunity state.
+Produce a read-only, ranked Wave work queue. Do not change opportunity state. Name the
+next skill; do not start it unless the user asks to continue.
 
 Read:
 
@@ -17,7 +18,9 @@ Read:
 1. Call `get_amplitude_context` without a project ID. Resolve ambiguity with the user;
    never guess. Call it again with the selected numeric project ID for product context.
 2. Call `query_wave_product_areas` `list`. If the user named an area, match it to a real
-   product-area ID and fetch it with `get`.
+   product-area ID and fetch it with `get`. Use the area description plus recent
+   approve/replan/dismiss/outcome comments as a short "team taste" brief for ranking
+   only—never to override fresh code or product evidence.
 3. Query opportunities:
    - named topic → `search` with the topic and product-area scope when known;
    - morning queue → `list` with relevant statuses, product area, and a bounded limit;
@@ -30,8 +33,16 @@ Read:
    - resume active/review work before starting duplicates;
    - otherwise prefer high-impact, code-addressable, unblocked opportunities;
    - use RICE as a ranking signal, not as proof the problem is valid.
-7. Return no more than ten queue items using the queue-item output contract. Recommend
-   `wave-evaluate`, `wave-babysit`, or `wave-close-out` for each.
+7. Return no more than ten queue items. Set `recommendedNextSkill` with the first match:
+
+   | Condition | Next skill |
+   |---|---|
+   | Open/fresh linked PR, or `FOR_REVIEW` with a real PR | `wave-babysit` |
+   | `SHIPPED` and the measurement window is ready | `wave-close-out` |
+   | Approved, experiment recommended, no prepared experiment/flag | `wave-experiment` |
+   | Approved (`agent-approved` or `wave_handoff` verdict `APPROVE`), no fresh PR | `wave-dispatch-handoff` |
+   | `needs-human-review` or parked `wave_gate` | say the decision needed; do not dispatch |
+   | Anything else (`NEW`/`PLANNED`, weak/missing plan, `needs-replan`) | `wave-evaluate` |
 
 ## Done
 
@@ -40,12 +51,12 @@ The user receives:
 - product/project scope,
 - backlog count and filters,
 - ranked items with evidence and existing-work state,
-- one recommended next action per item,
-- a concise digest suitable for Cursor chat, Slack drafting, or an automation log.
+- one recommended next skill per item,
+- a concise digest suitable for Cursor chat or an automation log.
 
 ## Gotchas
 
-- Wave opportunities are not CRM or sales opportunities.
+- Wave opportunities are not CRM or sales opportunities, and not analytics-discovered ideas.
 - List/search descriptions are snippets; never rank a finalist without `get`.
 - Do not treat `FOR_REVIEW` as proof a PR exists—inspect relations.
-- Do not mutate, claim, dismiss, or submit ideas from this skill.
+- Do not mutate, claim, dismiss, implement, or submit ideas from this skill.

--- a/plugins/wave/skills/wave-queue/SKILL.md
+++ b/plugins/wave/skills/wave-queue/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: wave-queue
+description: Reviews and ranks Amplitude Wave Opportunity Manager work by product area, status, evidence, and existing execution state. Use when users ask what Wave opportunity to work on, request a morning opportunity queue, want the top product improvements, or need to find an existing Wave opportunity. Not for evaluating code or starting implementation.
+---
+
+# Wave Queue
+
+Produce a read-only, ranked Wave work queue. Do not change opportunity state.
+
+Read:
+
+- [Wave pipeline contract](../../references/wave-pipeline-contract.md)
+- [Output contracts](../../references/output-contracts.md)
+
+## Workflow
+
+1. Call `get_amplitude_context` without a project ID. Resolve ambiguity with the user;
+   never guess. Call it again with the selected numeric project ID for product context.
+2. Call `query_wave_product_areas` `list`. If the user named an area, match it to a real
+   product-area ID and fetch it with `get`.
+3. Query opportunities:
+   - named topic → `search` with the topic and product-area scope when known;
+   - morning queue → `list` with relevant statuses, product area, and a bounded limit;
+   - exact item → `get` by full ID or unique 8+ character prefix.
+4. Do not paginate the full backlog. Report first-page coverage and `totalCount`, then
+   narrow the query if needed.
+5. For likely candidates, call `get` for full detail and `get_relations` to detect PRs,
+   agents, blockers, parent/child work, charts, and metrics.
+6. Normalize records using the shared contract. Rank:
+   - resume active/review work before starting duplicates;
+   - otherwise prefer high-impact, code-addressable, unblocked opportunities;
+   - use RICE as a ranking signal, not as proof the problem is valid.
+7. Return no more than ten queue items using the queue-item output contract. Recommend
+   `wave-evaluate`, `wave-babysit`, or `wave-close-out` for each.
+
+## Done
+
+The user receives:
+
+- product/project scope,
+- backlog count and filters,
+- ranked items with evidence and existing-work state,
+- one recommended next action per item,
+- a concise digest suitable for Cursor chat, Slack drafting, or an automation log.
+
+## Gotchas
+
+- Wave opportunities are not CRM or sales opportunities.
+- List/search descriptions are snippets; never rank a finalist without `get`.
+- Do not treat `FOR_REVIEW` as proof a PR exists—inspect relations.
+- Do not mutate, claim, dismiss, or submit ideas from this skill.

--- a/plugins/wave/skills/wave-refine/SKILL.md
+++ b/plugins/wave/skills/wave-refine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wave-refine
-description: Audits the Amplitude Wave workflow across opportunity quality, plan improvements, agent/PR success, cycle time, experiment outcomes, measurement coverage, and skill drift. Use when users ask how the Wave pipeline is performing, want to improve Wave autonomy, review opportunity quality, or generate evidence-backed plugin changes. Produces recommendations; never silently self-edits.
+description: Audits Wave pipeline quality across plans, PRs, cycle time, measurement, and skill drift, then proposes reviewable patches. Use when the user asks how the Wave workflow is performing, wants autonomy metrics, or wants evidence-backed skill/contract changes. Not for evaluating one opportunity against code or ranking the morning queue.
 ---
 
 # Wave Refine

--- a/plugins/wave/skills/wave-refine/SKILL.md
+++ b/plugins/wave/skills/wave-refine/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: wave-refine
+description: Audits the Amplitude Wave workflow across opportunity quality, plan improvements, agent/PR success, cycle time, experiment outcomes, measurement coverage, and skill drift. Use when users ask how the Wave pipeline is performing, want to improve Wave autonomy, review opportunity quality, or generate evidence-backed plugin changes. Produces recommendations; never silently self-edits.
+---
+
+# Wave Refine
+
+Evaluate whether the end-to-end Wave loop is getting better. Use
+`minOpportunitiesForRefine` from customer config (default 20) or run monthly; smaller
+samples are directional and must be labeled as such.
+
+Read:
+
+- [Wave pipeline contract](../../references/wave-pipeline-contract.md)
+- [Output contracts](../../references/output-contracts.md)
+- [Skill design checklist](../../references/skill-design-checklist.md)
+
+## Gather
+
+1. Resolve project and product-area scope.
+2. Query bounded cohorts by status/tags and semantic searches; do not paginate the entire
+   backlog blindly.
+3. Fetch full records and relations for the sample.
+4. Extract structured `wave_handoff`, `wave_dispatch`, `wave_pr_ready`, `wave_gate`,
+   `wave_outcome`, and `wave_run` blocks.
+5. Validate live PR/experiment state for sampled records rather than trusting stale tags.
+
+## Measure
+
+Report by product area and overall:
+
+- trigger/routing precision when invocation logs exist;
+- approved, replanned, human-review, and dismissed rates;
+- dismiss reasons and later reversals;
+- opportunities where codebase validation materially improved the plan;
+- duplicate comment/relation/PR rate;
+- claim conflicts and stale-work takeovers;
+- coding-agent start, failure, retry, and PR-ready rates;
+- median time from planned → PR-ready → shipped → measured;
+- CI/review blocker distribution;
+- acceptance-criterion verification coverage;
+- experiment-prepared, launched, decided, and win/flat/regression rates;
+- shipped-to-measured rate and measurement fallbacks;
+- human overrides at evaluation, merge, and experiment gates.
+
+## Drift audit
+
+Flag:
+
+- legacy objective/tool names;
+- tag aliases or accidental tag replacement;
+- missing structured handoffs;
+- PRs hidden only in agent metadata;
+- statuses unsupported by real relations/PR state;
+- parent epics dispatched as implementation units;
+- `MEASURED` without evidence/fallback;
+- experiment/flag IDs stored nowhere durable;
+- duplicated writes from reruns;
+- skills over 500 lines, broken references, vague/overlapping descriptions;
+- any path that could merge or launch traffic without a human gate.
+
+## Recommend
+
+Prioritize no more than five changes by expected effect and confidence:
+
+```yaml
+wave_refinement:
+  observation: <measured problem>
+  evidence: []
+  root_cause: <skill|contract|tool|config|product-area context>
+  proposed_change:
+    files: []
+    summary: <specific patch>
+  expected_metric: <pipeline metric>
+  confidence: <high|medium|low>
+```
+
+Separate:
+
+- product-area memory/context updates;
+- workflow/config changes;
+- skill/contract patches;
+- upstream MCP capability gaps.
+
+## Self-improvement gate
+
+This skill is read-only by default. It may draft a patch or PR only after explicit user
+approval. It never edits its own skills, contract, configuration, or production Wave
+records silently.
+
+## Done
+
+The user gets a small, evidence-backed pipeline report and concrete reviewable
+improvements tied to success metrics.
+
+## Gotchas
+
+- Low dismissal rate is not automatically good; inspect validity and later reversals.
+- High PR throughput without measurement is an incomplete loop.
+- Do not infer causality between a skill change and outcomes without enough samples.
+- Never pad the report with weak findings.

--- a/plugins/wave/tests/scenarios.json
+++ b/plugins/wave/tests/scenarios.json
@@ -12,6 +12,20 @@
       ]
     },
     {
+      "id": "queue-routes-to-dispatch",
+      "prompt": "What should I do next with this approved Wave opportunity?",
+      "expectedSkill": "wave-queue",
+      "fixture": {
+        "status": "INVESTIGATING",
+        "agentApproved": true,
+        "freshPr": false
+      },
+      "expected": {
+        "recommendedNextSkill": "wave-dispatch-handoff",
+        "mutated": false
+      }
+    },
+    {
       "id": "real-problem-weak-plan",
       "prompt": "Evaluate this Wave opportunity against the current codebase.",
       "expectedSkill": "wave-evaluate",

--- a/plugins/wave/tests/scenarios.json
+++ b/plugins/wave/tests/scenarios.json
@@ -1,0 +1,206 @@
+{
+  "scenarios": [
+    {
+      "id": "queue-natural-language",
+      "prompt": "What Wave opportunities should I work on for onboarding?",
+      "expectedSkill": "wave-queue",
+      "invariants": [
+        "read_only",
+        "bounded_query",
+        "get_before_decide",
+        "product_area_scope"
+      ]
+    },
+    {
+      "id": "real-problem-weak-plan",
+      "prompt": "Evaluate this Wave opportunity against the current codebase.",
+      "expectedSkill": "wave-evaluate",
+      "fixture": {
+        "problemStillExists": true,
+        "planTargetsWrongRepository": true
+      },
+      "expected": {
+        "verdict": "NEEDS_REPLAN",
+        "dismissed": false,
+        "improvedPlanRequired": true
+      }
+    },
+    {
+      "id": "already-fixed-problem",
+      "prompt": "Evaluate this Wave opportunity.",
+      "expectedSkill": "wave-evaluate",
+      "fixture": {
+        "problemStillExists": false,
+        "mergedPrProvesFix": true,
+        "freshEvidenceConfirmsResolution": true
+      },
+      "expected": {
+        "verdict": "DISMISS",
+        "dismissalRequiresConfirmation": true
+      }
+    },
+    {
+      "id": "existing-in-flight-pr",
+      "prompt": "Dispatch this approved Wave opportunity.",
+      "expectedSkill": "wave-dispatch-handoff",
+      "fixture": {
+        "freshLinkedPr": true
+      },
+      "expected": {
+        "newAgentLaunched": false,
+        "newPrCreated": false,
+        "routeTo": "wave-babysit"
+      }
+    },
+    {
+      "id": "experiment-worthy-change",
+      "prompt": "Set up an experiment for this Wave opportunity.",
+      "expectedSkill": "wave-experiment",
+      "fixture": {
+        "behavioralBet": true,
+        "adequateTraffic": true,
+        "reversible": true
+      },
+      "expected": {
+        "disabledSetupPrepared": true,
+        "trafficLaunched": false,
+        "humanGate": "experiment_launch"
+      }
+    },
+    {
+      "id": "direct-ship-correctness",
+      "prompt": "Run Wave autopilot on this correctness bug.",
+      "expectedSkill": "wave-autopilot",
+      "fixture": {
+        "correctnessFix": true
+      },
+      "expected": {
+        "experimentRecommended": false,
+        "mergePerformed": false
+      }
+    },
+    {
+      "id": "interrupted-run-resume",
+      "prompt": "Resume Wave autopilot.",
+      "expectedSkill": "wave-autopilot",
+      "fixture": {
+        "status": "IN_PROGRESS",
+        "existingAgentSession": true,
+        "existingBranch": true
+      },
+      "expected": {
+        "reconciledFirst": true,
+        "newAgentLaunched": false,
+        "newBranchCreated": false
+      }
+    },
+    {
+      "id": "duplicate-write-prevention",
+      "prompt": "Run Wave autopilot again.",
+      "expectedSkill": "wave-autopilot",
+      "fixture": {
+        "existingStructuredComments": true,
+        "existingRelations": true,
+        "existingExperiment": true
+      },
+      "expected": {
+        "duplicateComments": 0,
+        "duplicateRelations": 0,
+        "duplicateExperiments": 0
+      }
+    },
+    {
+      "id": "frontend-verification",
+      "prompt": "Babysit this Wave frontend PR to review-ready.",
+      "expectedSkill": "wave-babysit",
+      "fixture": {
+        "frontendChange": true,
+        "acceptanceCriteriaCount": 2
+      },
+      "expected": {
+        "visualArtifactRequired": true,
+        "mergePerformed": false
+      }
+    },
+    {
+      "id": "intake-deduplication",
+      "prompt": "Submit this product-improvement idea to Wave.",
+      "expectedSkill": "wave-intake",
+      "fixture": {
+        "similarOpportunityExists": true
+      },
+      "expected": {
+        "newIdeaSubmitted": false,
+        "existingOpportunityFetched": true,
+        "contextWriteRequiresConfirmation": true
+      }
+    },
+    {
+      "id": "refine-read-only",
+      "prompt": "Review how the Wave pipeline is performing and improve the skills.",
+      "expectedSkill": "wave-refine",
+      "fixture": {
+        "processedOpportunities": 25
+      },
+      "expected": {
+        "reportProduced": true,
+        "skillFilesEdited": false,
+        "patchRequiresApproval": true
+      }
+    },
+    {
+      "id": "close-out-evidence-gate",
+      "prompt": "Measure this shipped Wave opportunity and close the loop.",
+      "expectedSkill": "wave-close-out",
+      "fixture": {
+        "measurementWindowElapsed": true,
+        "targetMetricAvailable": true,
+        "outcomeEvidenceAvailable": true
+      },
+      "expected": {
+        "status": "MEASURED",
+        "outcomeCommentRequired": true,
+        "artifactRequired": true
+      }
+    },
+    {
+      "id": "unattended-missing-config",
+      "prompt": "Run Wave autopilot unattended with no workspace config.",
+      "expectedSkill": "wave-autopilot",
+      "fixture": {
+        "configPresent": false
+      },
+      "expected": {
+        "readOnlyReconcile": true,
+        "newWorkStarted": false,
+        "setupGapParked": true
+      }
+    },
+    {
+      "id": "evaluate-repository-unavailable",
+      "prompt": "Evaluate this Wave opportunity, but its target repository is unavailable.",
+      "expectedSkill": "wave-evaluate",
+      "fixture": {
+        "repositoryAvailable": false
+      },
+      "expected": {
+        "verdict": "NEEDS_HUMAN_REVIEW",
+        "dismissed": false,
+        "codebaseVerdictFabricated": false
+      }
+    },
+    {
+      "id": "scheduled-human-decision",
+      "prompt": "Run Wave autopilot unattended.",
+      "expectedSkill": "wave-autopilot",
+      "fixture": {
+        "ambiguousProductDecision": true
+      },
+      "expected": {
+        "blocksOnPrompt": false,
+        "parkedAtHumanGate": true,
+        "dismissed": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a customer-installable `plugins/wave` package with nine focused skills spanning queueing, codebase validation, coding-agent handoff, PR shepherding, experiments, measurement, intake, autopilot, and workflow refinement
- define shared lifecycle, idempotency, structured handoff, verification, and decision contracts with hard human gates for PR merge, experiment launch, and dismissal
- register Wave in the Cursor, Claude, and Codex marketplaces and include generic customer config, documentation, scenario fixtures, and a dependency-free validator

## Test plan
- [x] `python3 plugins/wave/scripts/validate_plugin.py`
- [x] `git diff --check`
- [x] verify Cursor and Claude plugin/marketplace manifests normalize to identical JSON


Made with [Cursor](https://cursor.com)