### PR TITLE
MCP-679 [skills] refresh Amplitude skills for GA consolidated MCP tools

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -53,11 +53,7 @@
       "homepage": "https://github.com/amplitude/mcp-marketplace",
       "repository": "https://github.com/amplitude/mcp-marketplace",
       "license": "MIT",
-      "keywords": [
-        "analytics",
-        "amplitude",
-        "experimental"
-      ],
+      "keywords": ["analytics", "amplitude", "experimental"],
       "category": "analytics"
     }
   ]

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -53,11 +53,7 @@
       "homepage": "https://github.com/amplitude/mcp-marketplace",
       "repository": "https://github.com/amplitude/mcp-marketplace",
       "license": "MIT",
-      "keywords": [
-        "analytics",
-        "amplitude",
-        "experimental"
-      ],
+      "keywords": ["analytics", "amplitude", "experimental"],
       "category": "analytics"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -30,16 +30,17 @@ Install from the [Cursor Marketplace](https://cursor.com/marketplace) or add man
 ### Codex
 
 1. Add the marketplace:
-    ```bash
-    codex plugin marketplace add amplitude/mcp-marketplace
-    ```
+
+   ```bash
+   codex plugin marketplace add amplitude/mcp-marketplace
+   ```
 
 2. Install the plugin from inside Codex:
-    ```
-    codex
-    # Then run /plugins, select Amplitude, and install
-    /plugins
-    ```
+   ```
+   codex
+   # Then run /plugins, select Amplitude, and install
+   /plugins
+   ```
 
 ### Gemini CLI
 
@@ -64,8 +65,8 @@ Then run `/mcp` from inside Claude Code, select `plugin:amplitude:amplitude`, an
 
 ## What's Inside
 
-| Plugin | Description |
-| --- | --- |
+| Plugin                            | Description                                                                                                                                                               |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [amplitude](./plugins/amplitude/) | Reusable analysis and instrumentation skills covering charts, dashboards, experiments, session replays, reliability, AI agent analytics, and analytics tracking workflows |
 
 ---
@@ -76,66 +77,66 @@ The amplitude plugin turns your AI assistant into an expert product analyst and 
 
 ### Core Analytics
 
-| Skill | What it does |
-| --- | --- |
-| `create-chart` | Creates Amplitude charts from natural language descriptions |
-| `create-dashboard` | Builds dashboards from requirements, organizing charts into logical sections |
-| `analyze-chart` | Deep-dives a chart to explain trends, anomalies, and likely drivers |
+| Skill               | What it does                                                                 |
+| ------------------- | ---------------------------------------------------------------------------- |
+| `create-chart`      | Creates Amplitude charts from natural language descriptions                  |
+| `create-dashboard`  | Builds dashboards from requirements, organizing charts into logical sections |
+| `analyze-chart`     | Deep-dives a chart to explain trends, anomalies, and likely drivers          |
 | `analyze-dashboard` | Reviews a dashboard end-to-end, surfacing key takeaways and areas of concern |
 
 ### Product Insights
 
-| Skill | What it does |
-| --- | --- |
-| `analyze-experiment` | Designs A/B tests, monitors running experiments, and interprets results |
-| `monitor-experiments` | Triages all active and recently completed experiments by importance |
-| `analyze-feedback` | Synthesizes customer feedback into themes — feature requests, bugs, pain points, praise |
-| `analyze-account-health` | Summarizes B2B account health with usage patterns, risk signals, and expansion opportunities |
+| Skill                    | What it does                                                                                   |
+| ------------------------ | ---------------------------------------------------------------------------------------------- |
+| `analyze-experiment`     | Designs A/B tests, monitors running experiments, and interprets results                        |
+| `monitor-experiments`    | Triages all active and recently completed experiments by importance                            |
+| `analyze-feedback`       | Synthesizes customer feedback into themes — feature requests, bugs, pain points, praise        |
+| `analyze-account-health` | Summarizes B2B account health with usage patterns, risk signals, and expansion opportunities   |
 | `discover-opportunities` | Finds product opportunities by cross-referencing analytics, experiments, replays, and feedback |
-| `compare-user-journeys` | Compares two user groups side-by-side to surface behavioral differences |
+| `compare-user-journeys`  | Compares two user groups side-by-side to surface behavioral differences                        |
 
 ### Session Replay & Debugging
 
-| Skill | What it does |
-| --- | --- |
-| `debug-replay` | Turns bug reports into numbered reproduction steps by extracting the interaction timeline from Session Replay |
-| `replay-ux-audit` | Watches multiple session replays for a flow and synthesizes a ranked friction map |
-| `diagnose-errors` | Triages product issues across network failures, JS errors, and error clicks |
-| `monitor-reliability` | Proactive reliability report from auto-captured error data so issues surface before users complain |
+| Skill                 | What it does                                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `debug-replay`        | Turns bug reports into numbered reproduction steps by extracting the interaction timeline from Session Replay |
+| `replay-ux-audit`     | Watches multiple session replays for a flow and synthesizes a ranked friction map                             |
+| `diagnose-errors`     | Triages product issues across network failures, JS errors, and error clicks                                   |
+| `monitor-reliability` | Proactive reliability report from auto-captured error data so issues surface before users complain            |
 
 ### AI Agent Analytics
 
-| Skill | What it does |
-| --- | --- |
-| `analyze-ai-topics` | Analyzes what users ask AI agents about and how well each topic is served |
-| `investigate-ai-session` | Deep-dives specific AI agent sessions or failure patterns for root-cause analysis |
-| `monitor-ai-quality` | Delivers a proactive health report on AI agents covering quality, cost, performance, and errors |
-| `review-agent-insights` | Synthesizes recent results from Amplitude's AI agents into a unified, impact-ranked narrative |
+| Skill                    | What it does                                                                                    |
+| ------------------------ | ----------------------------------------------------------------------------------------------- |
+| `analyze-ai-topics`      | Analyzes what users ask AI agents about and how well each topic is served                       |
+| `investigate-ai-session` | Deep-dives specific AI agent sessions or failure patterns for root-cause analysis               |
+| `monitor-ai-quality`     | Delivers a proactive health report on AI agents covering quality, cost, performance, and errors |
+| `review-agent-insights`  | Synthesizes recent results from Amplitude's AI agents into a unified, impact-ranked narrative   |
 
 ### Analytics Instrumentation
 
-| Skill | What it does |
-| --- | --- |
-| `diff-intake` | Reads a PR or branch diff and outputs a structured `change_brief` YAML for downstream skills |
-| `discover-event-surfaces` | From a change brief, lists candidate analytics events for PM prioritization |
-| `discover-analytics-patterns` | Maps how analytics is already implemented in the repo (SDK calls, naming, imports) |
-| `instrument-events` | From prioritized event candidates, builds a concrete instrumentation plan and JSON tracking plan |
+| Skill                           | What it does                                                                                                  |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `diff-intake`                   | Reads a PR or branch diff and outputs a structured `change_brief` YAML for downstream skills                  |
+| `discover-event-surfaces`       | From a change brief, lists candidate analytics events for PM prioritization                                   |
+| `discover-analytics-patterns`   | Maps how analytics is already implemented in the repo (SDK calls, naming, imports)                            |
+| `instrument-events`             | From prioritized event candidates, builds a concrete instrumentation plan and JSON tracking plan              |
 | `add-analytics-instrumentation` | End-to-end workflow — reads code, decides what to track, and produces a full instrumentation plan in one pass |
-| `taxonomy` | Source of truth for event taxonomy generation, data auditing, and governance best practices |
+| `taxonomy`                      | Source of truth for event taxonomy generation, data auditing, and governance best practices                   |
 
 A typical flow: `diff-intake` → `discover-event-surfaces` → `instrument-events`, with `discover-analytics-patterns` ensuring new tracking matches existing conventions.
 
 ### Briefings
 
-| Skill | What it does |
-| --- | --- |
-| `daily-brief` | Morning briefing of the most important changes across your Amplitude instance |
+| Skill          | What it does                                                                  |
+| -------------- | ----------------------------------------------------------------------------- |
+| `daily-brief`  | Morning briefing of the most important changes across your Amplitude instance |
 | `weekly-brief` | Weekly recap of trends, wins, and risks to share with your team or leadership |
 
 ### Bonus
 
-| Skill | What it does |
-| --- | --- |
+| Skill                 | What it does                                                                                          |
+| --------------------- | ----------------------------------------------------------------------------------------------------- |
 | `what-would-lenny-do` | Answers product strategy questions by searching Lenny Rachitsky's archive (requires `lennysdata` MCP) |
 
 ---

--- a/plugins/amplitude-experimental/README.md
+++ b/plugins/amplitude-experimental/README.md
@@ -1,3 +1,3 @@
 # Amplitude Experimental Plugin
 
-This plugin contains skills that are still experimental. Use with caution. 
+This plugin contains skills that are still experimental. Use with caution.

--- a/plugins/amplitude-experimental/skills/event-description-generator/references/search-playbook.md
+++ b/plugins/amplitude-experimental/skills/event-description-generator/references/search-playbook.md
@@ -13,6 +13,7 @@ grep -r "purchase_completed" --include="*.{ts,tsx,js,jsx,py,java,kt,swift,go,rb}
 ```
 
 Search for both quoted and unquoted forms:
+
 - `"purchase_completed"` (double-quoted)
 - `'purchase_completed'` (single-quoted)
 - `` `purchase_completed` `` (template literal)
@@ -22,11 +23,11 @@ Search for both quoted and unquoted forms:
 
 Convert the event type to alternative casings:
 
-| Original              | PascalCase          | camelCase           | SCREAMING_SNAKE     |
-| --------------------- | ------------------- | ------------------- | ------------------- |
-| `purchase_completed`  | `PurchaseCompleted` | `purchaseCompleted` | `PURCHASE_COMPLETED`|
-| `Button Clicked`      | `ButtonClicked`     | `buttonClicked`     | `BUTTON_CLICKED`    |
-| `page.viewed`         | `PageViewed`        | `pageViewed`        | `PAGE_VIEWED`       |
+| Original             | PascalCase          | camelCase           | SCREAMING_SNAKE      |
+| -------------------- | ------------------- | ------------------- | -------------------- |
+| `purchase_completed` | `PurchaseCompleted` | `purchaseCompleted` | `PURCHASE_COMPLETED` |
+| `Button Clicked`     | `ButtonClicked`     | `buttonClicked`     | `BUTTON_CLICKED`     |
+| `page.viewed`        | `PageViewed`        | `pageViewed`        | `PAGE_VIEWED`        |
 
 ### 3. Constant/Enum Definitions
 
@@ -68,10 +69,10 @@ Exclude these from results to reduce noise:
 
 Most codebases separate event **definitions** (where the event string is declared) from event **call sites** (where the event is actually fired). Both are needed for good descriptions, but they serve different purposes:
 
-| Phase | What you find | Why it matters |
-|---|---|---|
-| Definition | The event string literal, class, or enum member | Confirms the event exists in code and gives you the class/constant name to search for next |
-| Call site | The `track()` / `ampli.` invocation in feature code | Tells you **when**, **where**, and **why** the event fires — this is what the description needs |
+| Phase      | What you find                                       | Why it matters                                                                                  |
+| ---------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Definition | The event string literal, class, or enum member     | Confirms the event exists in code and gives you the class/constant name to search for next      |
+| Call site  | The `track()` / `ampli.` invocation in feature code | Tells you **when**, **where**, and **why** the event fires — this is what the description needs |
 
 ### Phase A: Find the Definition
 
@@ -114,6 +115,7 @@ new EventClass(    ampli.eventName(
 ```
 
 When you find a call site, read ~20-30 lines of surrounding context to understand:
+
 - What triggers the event (user action, lifecycle, API response)
 - What properties are passed and what they represent
 - What component/feature owns it

--- a/plugins/amplitude/.codex-plugin/plugin.json
+++ b/plugins/amplitude/.codex-plugin/plugin.json
@@ -34,10 +34,7 @@
     "longDescription": "Bundle Amplitude analysis, experimentation, session replay, and instrumentation skills with the Amplitude MCP server configuration for use in Codex.",
     "developerName": "Amplitude",
     "category": "Productivity",
-    "capabilities": [
-      "Read",
-      "Write"
-    ],
+    "capabilities": ["Read", "Write"],
     "websiteURL": "https://amplitude.com",
     "privacyPolicyURL": "https://amplitude.com/privacy",
     "termsOfServiceURL": "https://amplitude.com/terms",

--- a/plugins/amplitude/README.md
+++ b/plugins/amplitude/README.md
@@ -9,6 +9,7 @@ Works with **Claude Code**, **Cursor**, and **Claude CLI**.
 ## Installation
 
 Claude Code: (CLI Application)
+
 ```bash
 # Add the Amplitude marketplace (one-time)
 /plugin marketplace add amplitude/mcp-marketplace
@@ -18,6 +19,7 @@ Claude Code: (CLI Application)
 ```
 
 Cursor:
+
 - Go to cursor settings
 - Click on Plugins
 - Look for the Amplitude Analytics plugin
@@ -27,38 +29,38 @@ Cursor:
 - You can add the MCP server to cursor by going to agent settings
 - Agent settings -> Tools & MCP -> Add a new MCP server
 - Add the following server to the config:
-    "amplitude-us": {
-        "command": "npx",
-        "args": [
-            "-y",
-            "mcp-remote",
-            "https://mcp-server.prod.us-west-2.amplitude.com/v1/mcp"
-        ]
-    }
+  "amplitude-us": {
+  "command": "npx",
+  "args": [
+  "-y",
+  "mcp-remote",
+  "https://mcp-server.prod.us-west-2.amplitude.com/v1/mcp"
+  ]
+  }
 - This should take you to the browser to complete the 0Auth flow
 
 ---
 
 ## What's Included
 
-| Skill | What it does |
-| ----- | ------------ |
-| **analyze-account-health** | Summarize B2B account health – usage patterns, engagement trends, risk signals, expansion opportunities |
-| **analyze-chart** | Deep dive into a specific chart to explain trends, anomalies, and likely drivers |
-| **analyze-dashboard** | Synthesize dashboards into talking points, surface concerns, connect quant to qual |
-| **analyze-experiment** | Design A/B tests, analyze running or completed experiments, interpret results with statistical rigor |
-| **analyze-feedback** | Synthesize customer feedback into themes (requests, bugs, pain points, praise) |
-| **create-chart** | Create Amplitude charts from natural language – event discovery, filters, groupings, visualization |
-| **create-dashboard** | Build dashboards from requirements or goals – organize charts into logical sections with layouts |
-| **daily-brief** | Deliver a concise daily briefing – metric anomalies, experiment updates, feedback, and deployment context from the last 1-2 days |
-| **diff-intake** | Read a PR, branch, or file diff and produce a compact change brief for downstream analytics instrumentation planning |
-| **discover-analytics-patterns** | Inspect the codebase for existing tracking wrappers, naming conventions, and analytics patterns before adding new events |
-| **discover-event-surfaces** | Turn a change brief into concrete event candidates, priorities, and likely instrumentation points |
-| **weekly-brief** | Deliver a weekly summary – week-over-week trends, wins, risks, inflection points, and strategic recommendations |
-| **discover-opportunities** | Discover product opportunities by mining analytics, experiments, replays, and feedback — synthesized into RICE-scored, actionable recommendations |
-| **instrument-events** | Convert priority events into a detailed, line-by-line instrumentation plan grounded in the target code |
-| **add-analytics-instrumentation** | Run the full end-to-end instrumentation workflow for a PR, branch, file, or feature request |
-| **monitor-experiments** | Monitor active and recently completed experiments, triage by importance, and deep-dive on the most impactful ones |
+| Skill                             | What it does                                                                                                                                      |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **analyze-account-health**        | Summarize B2B account health – usage patterns, engagement trends, risk signals, expansion opportunities                                           |
+| **analyze-chart**                 | Deep dive into a specific chart to explain trends, anomalies, and likely drivers                                                                  |
+| **analyze-dashboard**             | Synthesize dashboards into talking points, surface concerns, connect quant to qual                                                                |
+| **analyze-experiment**            | Design A/B tests, analyze running or completed experiments, interpret results with statistical rigor                                              |
+| **analyze-feedback**              | Synthesize customer feedback into themes (requests, bugs, pain points, praise)                                                                    |
+| **create-chart**                  | Create Amplitude charts from natural language – event discovery, filters, groupings, visualization                                                |
+| **create-dashboard**              | Build dashboards from requirements or goals – organize charts into logical sections with layouts                                                  |
+| **daily-brief**                   | Deliver a concise daily briefing – metric anomalies, experiment updates, feedback, and deployment context from the last 1-2 days                  |
+| **diff-intake**                   | Read a PR, branch, or file diff and produce a compact change brief for downstream analytics instrumentation planning                              |
+| **discover-analytics-patterns**   | Inspect the codebase for existing tracking wrappers, naming conventions, and analytics patterns before adding new events                          |
+| **discover-event-surfaces**       | Turn a change brief into concrete event candidates, priorities, and likely instrumentation points                                                 |
+| **weekly-brief**                  | Deliver a weekly summary – week-over-week trends, wins, risks, inflection points, and strategic recommendations                                   |
+| **discover-opportunities**        | Discover product opportunities by mining analytics, experiments, replays, and feedback — synthesized into RICE-scored, actionable recommendations |
+| **instrument-events**             | Convert priority events into a detailed, line-by-line instrumentation plan grounded in the target code                                            |
+| **add-analytics-instrumentation** | Run the full end-to-end instrumentation workflow for a PR, branch, file, or feature request                                                       |
+| **monitor-experiments**           | Monitor active and recently completed experiments, triage by importance, and deep-dive on the most impactful ones                                 |
 
 ---
 

--- a/plugins/amplitude/skills/add-analytics-instrumentation/SKILL.md
+++ b/plugins/amplitude/skills/add-analytics-instrumentation/SKILL.md
@@ -37,6 +37,7 @@ the conversation. Only ask if it's genuinely ambiguous.
 | **Feature**          | A natural-language description of functionality, not a specific code reference | `instrument the onboarding flow`, `add tracking to the checkout experience` |
 
 **Inference rules:**
+
 - If the user provided a URL or `#number` → **PR**
 - If the user provided something that looks like a branch name (contains `/`, no file extension, matches a git branch) → **Branch**
 - If the user provided a path that exists on disk (file or directory) → **File / Directory**
@@ -46,6 +47,7 @@ the conversation. Only ask if it's genuinely ambiguous.
 **If ambiguous**, ask the user:
 
 > What would you like to instrument?
+>
 > 1. A specific file or directory
 > 2. A PR
 > 3. A branch

--- a/plugins/amplitude/skills/analyze-account-health/SKILL.md
+++ b/plugins/amplitude/skills/analyze-account-health/SKILL.md
@@ -12,6 +12,7 @@ Deep-dive into a B2B account's product usage to prepare for QBRs, assess renewal
 ### Step 0: Identify Account & Discover Context
 
 **Get the account identifier:**
+
 - Company name, org ID, account ID, or group property value
 - Ask user if not provided
 
@@ -25,20 +26,24 @@ Use `Amplitude:search` to find existing dashboards, charts, or notebooks for thi
 Use `Amplitude:query_dataset` to run these queries in parallel:
 
 **Usage Trend:**
+
 - Event: `_active`, Metric: `uniques`, Group by: account property
 - Time: Last 60 days, daily interval
 - **Shows:** Activity increasing or decreasing?
 
 **Engagement Quality:**
+
 - Calculate DAU and MAU for account
 - Get DAU/MAU ratio (stickiness)
 - **Shows:** How engaged are active users?
 
 **User Momentum:**
+
 - Active user count week-over-week
 - **Shows:** Team growing or shrinking?
 
 **Classify Health:**
+
 - **Healthy**: Growing MAU, DAU/MAU >40%, positive WoW
 - **At-Risk**: Flat/declining MAU, DAU/MAU 20-40%, negative WoW
 - **Critical**: Steep decline, DAU/MAU <20%, sustained negative WoW
@@ -50,12 +55,15 @@ Use `Amplitude:query_dataset` to run these queries in parallel:
 Use `Amplitude:query_dataset` with user-level groupBy:
 
 **Power Users:**
+
 - Top 3-5 users by event volume (champions to leverage)
 
 **Churned Users:**
+
 - Users active in previous period but not current (retention risks)
 
 **License Utilization:**
+
 - Active users in last 30 days vs total seats
 
 ---
@@ -65,14 +73,17 @@ Use `Amplitude:query_dataset` with user-level groupBy:
 Use `Amplitude:query_dataset` grouped by events/features:
 
 **Feature Breadth:**
+
 - Which core features are being used (ask user for 5-10 key features)
 - Adoption rate per feature
 
 **Feature Trends:**
+
 - Usage over last 90 days per feature
 - Identify growing vs declining features
 
 **Focus based on health:**
+
 - **If At-Risk/Critical:** Find abandoned features (used 60-90 days ago, not in last 30)
 - **If Healthy:** Find expansion opportunities (premium features not yet tried)
 
@@ -85,6 +96,7 @@ Use `Amplitude:get_feedback_sources` to see what's available.
 
 **Get feedback insights:**
 Use `Amplitude:get_feedback_insights` filtered by:
+
 - ampId for each user in the account
 - dateStart/dateEnd: Last 90 days
 - types: `bug`, `painPoint`, `complaint`, `request`, `lovedFeature`
@@ -93,6 +105,7 @@ Use `Amplitude:get_feedback_insights` filtered by:
 For top 3-5 insights, use `Amplitude:get_feedback_mentions` to get quotes.
 
 **Correlate with behavior:**
+
 - Complaint about Feature X? Query their usage of Feature X
 - Request for Feature Y? Check if they hit limits Y would solve
 - Praise for Feature Z? Validate they're heavy users of Z
@@ -106,29 +119,34 @@ Structure output as follows:
 # Account Health Report: [Account Name]
 
 ## Executive Summary
+
 [2-3 sentences: Health score, key trend, primary recommendation]
 
 ## Health Score: [🟢 Healthy | 🟡 At-Risk | 🔴 Critical]
+
 [One sentence rationale with key metric]
 
 ---
 
 ## Key Metrics
-| Metric | Current | Trend | Status |
-|--------|---------|-------|--------|
-| MAU | X | ↑↓→ Y% | 🟢🟡🔴 |
-| DAU/MAU | X% | ↑↓→ Y% | 🟢🟡🔴 |
-| License Utilization | X% | ↑↓→ | 🟢🟡🔴 |
-| Features Adopted | X/Y | ↑↓→ | 🟢🟡🔴 |
+
+| Metric              | Current | Trend  | Status |
+| ------------------- | ------- | ------ | ------ |
+| MAU                 | X       | ↑↓→ Y% | 🟢🟡🔴 |
+| DAU/MAU             | X%      | ↑↓→ Y% | 🟢🟡🔴 |
+| License Utilization | X%      | ↑↓→    | 🟢🟡🔴 |
+| Features Adopted    | X/Y     | ↑↓→    | 🟢🟡🔴 |
 
 ---
 
 ## 🚨 Risk Factors (if any)
+
 1. **[Issue]** - [Impact]
    - Usage data: [metric/trend]
    - Customer feedback: [theme with X mentions] - [representative quote]
 
 ## ✅ Positive Signals
+
 1. **[What's working]** - [Evidence from usage + feedback]
 
 ---
@@ -136,12 +154,15 @@ Structure output as follows:
 ## 👥 User Intelligence
 
 ### Champions (Leverage)
-- **[User ID/Name]**: [Activity summary] - *Action: [Specific CS recommendation]*
+
+- **[User ID/Name]**: [Activity summary] - _Action: [Specific CS recommendation]_
 
 ### At Risk (Engage)
-- **[User ID/Name]**: [Last active date / declining pattern] - *Action: [Check-in recommendation]*
+
+- **[User ID/Name]**: [Last active date / declining pattern] - _Action: [Check-in recommendation]_
 
 ### Inactive (>30 days)
+
 - [Count] users ([X]% of licenses)
 
 ---
@@ -149,18 +170,21 @@ Structure output as follows:
 ## 💡 Top Pain Points & Requests
 
 ### Pain Points
+
 1. **[Theme]** (X mentions)
    - [Concise description]
    - Evidence: [Behavioral data] + "[Quote]" - [Source, Date]
-   - *Action: [What to do]*
+   - _Action: [What to do]_
 
 ### Feature Requests
+
 1. **[Theme]** (X mentions)
    - [What they want]
    - Evidence: "[Quote]" - [Source, Date]
-   - *Roadmap status: [On roadmap/Not planned/Considering]*
+   - _Roadmap status: [On roadmap/Not planned/Considering]_
 
 ### What They Love ❤️
+
 1. **[Feature]**: "[Quote]"
 
 ---
@@ -168,7 +192,7 @@ Structure output as follows:
 ## 📊 Feature Adoption
 
 **High Usage:** [Feature] - [X users] (↑Y%)
-**Declining:** [Feature] - [X users] (↓Y%) - *Investigate*
+**Declining:** [Feature] - [X users] (↓Y%) - _Investigate_
 **Untapped (Upsell):** [Premium feature] - Could solve [pain point]
 
 ---
@@ -176,17 +200,21 @@ Structure output as follows:
 ## 🎯 Recommendations
 
 ### 🔥 This Week
+
 1. [Specific action with user/contact name]
 
 ### 📅 This Month
+
 1. [Strategic action with context]
 
 ### 💰 Expansion Opportunities
+
 1. [Upsell signal with evidence]
 
 ---
 
 ## 📎 Details
+
 - **Analysis Date:** [Date]
 - **Timeframe:** [Last X days]
 - **Confidence:** [High/Medium/Low based on data volume]
@@ -205,11 +233,13 @@ Structure output as follows:
 ## Common Patterns
 
 **Churn Risks:**
+
 - Champion churned + declining overall usage
 - Multiple complaints about same issue + behavioral evidence of friction
 - License utilization declining + negative feedback
 
 **Expansion Signals:**
+
 - Hitting plan limits (users, API, storage)
 - Requests for premium features + high engagement
 - New users being added + positive feedback

--- a/plugins/amplitude/skills/analyze-ai-topics/SKILL.md
+++ b/plugins/amplitude/skills/analyze-ai-topics/SKILL.md
@@ -32,14 +32,15 @@ Run these in parallel:
 
 Score each topic on a 2x2 of **volume x quality**:
 
-| | High Quality (>0.7) | Low Quality (<0.7) |
-|---|---|---|
-| **High Volume** | Well-served (maintain) | **Underserved (fix now)** |
-| **Low Volume** | Niche but working (monitor) | **Gap or emerging (investigate)** |
+|                 | High Quality (>0.7)         | Low Quality (<0.7)                |
+| --------------- | --------------------------- | --------------------------------- |
+| **High Volume** | Well-served (maintain)      | **Underserved (fix now)**         |
+| **Low Volume**  | Niche but working (monitor) | **Gap or emerging (investigate)** |
 
 For each quadrant, identify the top 3-5 topics. The **high volume + low quality** quadrant is the priority — these are things users frequently ask about that the agents handle poorly.
 
 Also flag:
+
 - **Growing topics:** Topics with increasing volume over the time window. These may need better coverage soon even if quality is currently acceptable.
 - **Sentiment outliers:** Topics where sentiment is notably lower than quality score. This means the agent technically completes the task but users aren't happy with the experience.
 - **Agent routing issues:** Topics where one agent handles them well but another handles them poorly — suggesting a routing improvement.
@@ -92,6 +93,7 @@ Sort by priority: Fix items first, then Monitor, then Good. Limit to top 15-20 t
 8. **Follow-on prompt**: "Want me to deep-dive into a specific topic, investigate the failing sessions for [top underserved topic], or build a monitoring dashboard for AI topic quality?"
 
 **Writing standards:**
+
 - Lead with the user impact, not the data
 - Use conversation excerpts to make abstract topics concrete
 - Quantify everything — "340 sessions/week" not "many sessions"
@@ -105,6 +107,7 @@ Sort by priority: Fix items first, then Monitor, then Good. Limit to top 15-20 t
 User says: "What are people asking our AI about?"
 
 Actions:
+
 1. Get context and AI schema
 2. Query topic breakdown, agent-by-topic matrix, volume trends, and failures by topic (4 parallel calls)
 3. Score topics on the volume x quality matrix
@@ -116,6 +119,7 @@ Actions:
 User says: "Where is our AI falling short?"
 
 Actions:
+
 1. Get context and schema
 2. Query topics and failures — focus on low quality and high failure rate topics
 3. For each underserved topic, search conversations to understand the failure mode
@@ -126,6 +130,7 @@ Actions:
 User says: "What topics does the Chart Agent handle, and how well?"
 
 Actions:
+
 1. Get context, then query sessions grouped by topic for that agent specifically
 2. Compare the agent's topic quality scores against the fleet average
 3. Deep-dive into the agent's worst topics
@@ -134,10 +139,13 @@ Actions:
 ## Troubleshooting
 
 ### No topic enrichment data
+
 Topics require session enrichment to be enabled. If topics are empty, fall back to `search_agent_analytics_conversations` with broad keyword searches to manually categorize common themes. Note the limitation and suggest enabling enrichment.
 
 ### Too many topics (>50)
+
 Group similar topics and present the top 20 by volume. Offer to drill into specific clusters on request.
 
 ### Topics are too generic
+
 If topic labels are broad (e.g., "data question", "help request"), the enrichment model may need tuning. Note this and use conversation search to identify more specific sub-topics manually.

--- a/plugins/amplitude/skills/analyze-chart/SKILL.md
+++ b/plugins/amplitude/skills/analyze-chart/SKILL.md
@@ -31,6 +31,7 @@ x-amp-exclude-when-flags: [mcp-consolidate-charts]
   - Ask the user to correct the chart or provide a valid chart
 
 Capture and restate:
+
 - Metric being measured
 - Time range and granularity
 - Chart type (e.g. time series, funnel, retention)
@@ -48,6 +49,7 @@ Use **Analyzing chart** to characterize what’s happening:
 - **Anomaly**: Deviation from recent baseline or historical behavior
 
 Explicitly identify:
+
 - The **window of change** (start/end)
 - Direction and magnitude of the change
 - Baseline period used for comparison (default: previous equal-length period)
@@ -96,7 +98,7 @@ Present a structured, decision-ready analysis:
 3. **Primary Hypothesis**  
    Most likely explanation based on chart data and contextual signals
 
-4. **Supporting Evidence**  
+4. **Supporting Evidence**
    - Key metrics
    - Segment contributions
    - Relevant experiments, deployments, or annotations
@@ -111,6 +113,7 @@ Present a structured, decision-ready analysis:
    One clear follow-up action (e.g. deeper segment, experiment review, instrumentation check)
 
 Always include:
+
 - Chart name
 - Chart ID
 - Link back to the chart

--- a/plugins/amplitude/skills/analyze-dashboard/SKILL.md
+++ b/plugins/amplitude/skills/analyze-dashboard/SKILL.md
@@ -34,14 +34,15 @@ Use `Amplitude:query_charts` to fetch data for up to 3 charts at a time. Priorit
 ### Step 3: Analyze Patterns
 
 When analyzing charts, focus on the most decision-relevant signals for each type:
-  - KPI tiles: Context (timeframe, user type) and % change if shown.
-  - Line / Time series: Trends, slope changes, or notable events (not right-edge noise).
-  - Funnel: Major drop-off steps or unexpected retention. Use conversion framing (solid bars), not dropoff framing, unless explicitly relevant.
-  - Bar / Categorical: Concentrations, gaps, or surprising distributions.
-  - Stacked area: Total volume shifts and changing composition over time.
-  - Retention by interval: Compare segments at key intervals (Day 1, Day 7, Day 30).
-  - Retention over time: Recent cohorts may show incomplete periods (dotted lines) because they haven't completed the retention window yet—this does NOT mean retention is declining.
-  - Tables: Top contributors, dominant players, distribution imbalances.
+
+- KPI tiles: Context (timeframe, user type) and % change if shown.
+- Line / Time series: Trends, slope changes, or notable events (not right-edge noise).
+- Funnel: Major drop-off steps or unexpected retention. Use conversion framing (solid bars), not dropoff framing, unless explicitly relevant.
+- Bar / Categorical: Concentrations, gaps, or surprising distributions.
+- Stacked area: Total volume shifts and changing composition over time.
+- Retention by interval: Compare segments at key intervals (Day 1, Day 7, Day 30).
+- Retention over time: Recent cohorts may show incomplete periods (dotted lines) because they haven't completed the retention window yet—this does NOT mean retention is declining.
+- Tables: Top contributors, dominant players, distribution imbalances.
 
 ### Step 4: Contextualize with User Feedback (Optional)
 
@@ -60,6 +61,7 @@ If significant changes or anomalies are detected, check if user feedback can exp
 3. If a relevant insight is found, use `Amplitude:get_feedback_mentions` with the `insightId` to pull specific user quotes that illustrate the pattern.
 
 **Skip this step if:**
+
 - No feedback sources are configured for the project
 - No insights match the time period or observed changes
 - The dashboard changes are minor or expected
@@ -72,7 +74,6 @@ Present a structured summary:
 2. **Areas of Concern 🚩**: Top 1-3 urgent issues worth investigating or negative metric trends. If no issues are urgent, it's great to concisely acknolwedge there's no urgent areas of concern so that the reader has less noise to sift through.
 3. **Key Takeaways 💡**: Top 1-3 most important or surprising insights from the analysis not included in the areas of concern.
 4. **Recommendations**: Very concise section recapping up to the top 3 specific actionable recommendations (unless prompted otherwise) to follow-up on. Include [p0],[p1],[p2],[p3] in front of each title to help size priority with p0 being most urgent and p3 being least.
-
 
 ## Best Practices
 

--- a/plugins/amplitude/skills/analyze-experiment-consolidated/SKILL.md
+++ b/plugins/amplitude/skills/analyze-experiment-consolidated/SKILL.md
@@ -20,6 +20,7 @@ Perform comprehensive, detailed deep-dive analysis of experiments to make data-d
 ## Analysis Philosophy
 
 **Be comprehensive, not brief:**
+
 - Include specific numbers, percentages, and data points
 - Explain statistical meaning AND business implications in plain language
 - Cover all metrics (primary, secondary, guardrails) with actual values
@@ -32,16 +33,19 @@ Perform comprehensive, detailed deep-dive analysis of experiments to make data-d
 ### Step 0: Identify Experiment
 
 **If user provides a specific experiment:**
+
 - Accept experiment **URL or experiment ID**
 - If URL: use `Amplitude:get_from_url` to extract details
 - If ID: proceed to Step 1
 
 **If user asks about experiments generally:**
+
 - Use `Amplitude:search` with `entityTypes: ["EXPERIMENT"]` and relevant query terms
 - Present top 3-5 matches with names, IDs, and states
 - Ask user which experiment to analyze
 
 **If no experiment specified:**
+
 - Ask explicitly for experiment URL, ID, or search terms and stop
 
 ---
@@ -57,6 +61,7 @@ Use `Amplitude:use_amp_experiments` with experiment ID to capture:
 - Bucketing strategy
 
 **Get metric names:**
+
 - Extract metric IDs from the experiment response (e.g., "c4pn8fkv")
 - **CRITICAL: Amplitude MCP cannot retrieve metric names by ID directly**
 - Workaround options:
@@ -69,6 +74,7 @@ Use `Amplitude:use_amp_experiments` with experiment ID to capture:
   - Include metric IDs so users can look them up in Amplitude UI
 
 **Validation:**
+
 - Is experiment running or completed? (not draft)
 - Has it run for 1+ weeks?
 - Are variants and metrics clearly defined?
@@ -96,6 +102,7 @@ funnels, custom slices, cross-checks against another warehouse):
 Use `Amplitude:use_amp_experiments` (primary metric only) to assess:
 
 **Traffic Balance (SRM Check):**
+
 - Report actual traffic split per variant (e.g., 48.2% control, 51.8% treatment)
 - **Use `srmDetected` field from API:** Flag if `srmDetected: true`
 - SRM (Sample Ratio Mismatch) indicates the observed traffic split deviates significantly from the expected allocation
@@ -105,12 +112,14 @@ Use `Amplitude:use_amp_experiments` (primary metric only) to assess:
 **Sample Size Analysis:**
 
 **A. Current Sample Assessment:**
+
 - Report total users per variant with specific numbers
 - **Flag if <100 users per variant** (insufficient for any conclusion)
 - **Flag if 100-1000 users** (directional signals only, not confident decision)
 - Need 1000+ per variant for confident decisions
 
 **B. Statistical Power Analysis:**
+
 - **Target effect size:** What minimum lift would be meaningful for the business? (typically 2-5% for conversion metrics)
 - **Achieved power:** Given current sample size and observed variance, what's the probability of detecting the target effect if it exists?
 - **Power interpretation:**
@@ -122,6 +131,7 @@ Use `Amplitude:use_amp_experiments` (primary metric only) to assess:
 - **Recommendation:** If power <70% and results are inconclusive, extend duration rather than making premature decision
 
 **C. Precision Analysis (Confidence Interval Width):**
+
 - **CI width for primary metric:** Report the width of the 95% confidence interval as percentage of baseline
 - **Precision assessment:**
   - CI width >10% of baseline: Low precision - effect size uncertainty too high for confident decisions
@@ -172,6 +182,7 @@ The `Amplitude:use_amp_experiments` API returns multiple boolean flags that asse
    - Impact: Critical - cannot analyze if mean is invalid
 
 **For each flag that fails (returns false or true for suspicious uplift), document:**
+
 - Which flag failed
 - What it means in plain language
 - Specific impact on result reliability
@@ -180,6 +191,7 @@ The `Amplitude:use_amp_experiments` API returns multiple boolean flags that asse
 **If all flags pass:** Note this explicitly as strong data quality signal
 
 **Temporal Stability:**
+
 - Check if primary metric is stable day-over-day
 - Note ramp period (first 24-48hrs) or day-of-week effects
 
@@ -194,6 +206,7 @@ Use `Amplitude:use_amp_experiments` **without metricIds** to get primary metric 
 **Use metric name from Step 1** - Report using the human-readable metric name, not the metric ID.
 
 Extract and report:
+
 - **Control baseline:** metric value and sample size
 - **Treatment performance:** metric value and sample size
 - **Absolute lift:** treatment - control
@@ -202,11 +215,13 @@ Extract and report:
 - **Confidence interval:** report 95% CI bounds
 
 **Interpret:**
+
 - ✅ **Statistically significant:** p < 0.05 and CI doesn't include 0
 - ⚠️ **Trending:** 0.05 < p < 0.15 (suggestive but inconclusive)
 - ❌ **No effect:** p ≥ 0.15 or CI includes 0
 
 **Practical significance:**
+
 - Is the lift magnitude meaningful for the business?
 - Small lifts (<2-3%) may not be worth complexity even if significant
 - Consider metric's business impact (revenue vs. low-value engagement)
@@ -220,11 +235,13 @@ Use `Amplitude:use_amp_experiments` **with metricIds** for all metrics.
 **Use metric names from Step 1** - Report using human-readable metric names, not metric IDs.
 
 **For each secondary metric:**
+
 - Report metric name (from Step 1 mapping), variant performance, and statistical significance
 - Note which moved and which didn't (with specific numbers)
 - **Identify unintended consequences:** Flag any negative impacts with specific values
 
 **For each guardrail:**
+
 - ✅ No regression: neutral or positive (p > 0.05)
 - ⚠️ Marginal concern: small negative lift (1-5%) with p < 0.10
 - 🚩 **Significant regression:** negative lift with p < 0.05 - report actual numbers
@@ -240,6 +257,7 @@ Use `Amplitude:use_amp_experiments` **with metricIds** for all metrics.
 Use `Amplitude:use_amp_experiments` with `groupBy` parameter (one at a time).
 
 Test 3-4 high-signal segments:
+
 1. **Platform** (iOS, Android, Web)
 2. **User tenure** (new vs. established users)
 3. **Plan type** (free vs. paid)
@@ -250,17 +268,19 @@ Test 3-4 high-signal segments:
 For each segment analysis, present results in this exact format:
 
 | Segment | Control Rate | Control Exposures | Control % of Total | Treatment Rate | Treatment Exposures | Treatment % of Total | Relative Lift | Significant? |
-|---------|--------------|-------------------|-------------------|----------------|---------------------|---------------------|---------------|--------------|
-| iOS | 48.7% | 1,234 | 45.2% | 55.4% | 1,456 | 54.8% | **+13.6%** | Yes (p=0.02) |
-| Android | 63.9% | 567 | 20.8% | 65.1% | 589 | 22.2% | +1.9% | No (p=0.45) |
-| Web | 51.2% | 928 | 34.0% | 50.8% | 611 | 23.0% | -0.8% | No (p=0.89) |
+| ------- | ------------ | ----------------- | ------------------ | -------------- | ------------------- | -------------------- | ------------- | ------------ |
+| iOS     | 48.7%        | 1,234             | 45.2%              | 55.4%          | 1,456               | 54.8%                | **+13.6%**    | Yes (p=0.02) |
+| Android | 63.9%        | 567               | 20.8%              | 65.1%          | 589                 | 22.2%                | +1.9%         | No (p=0.45)  |
+| Web     | 51.2%        | 928               | 34.0%              | 50.8%          | 611                 | 23.0%                | -0.8%         | No (p=0.89)  |
 
 **Calculate % of Total:**
+
 - Sum all exposures across segments to get total
 - Show each segment's share: (segment exposures / total exposures) × 100%
 - This reveals which segments drive overall results
 
 **Key insights:**
+
 - Identify segments where treatment performs **best** (targeted rollout opportunity)
 - Identify segments where treatment **hurts** (consider exclusions)
 - Explain why different segments show different performance
@@ -276,18 +296,21 @@ Use `groupByLimit: 10` to avoid overwhelming output.
 Based on the power and precision analysis from Step 2, evaluate if the experiment has run long enough:
 
 **Runtime factors:**
+
 - **Minimum duration:** Has experiment run at least 1-2 weeks to capture full user lifecycle?
 - **Learning effects:** For feature changes, have users had time to adapt? (typically 3-7 days)
 - **Weekly seasonality:** Has experiment captured at least one complete week to account for day-of-week patterns?
 - **Business cycles:** For B2B products, has it run through full business week patterns?
 
 **Integration with Step 2 power analysis:**
+
 - **If Step 2 showed adequate power (>80%) AND p < 0.05:** Experiment has sufficient data, duration is adequate
 - **If Step 2 showed low power (<70%) AND p > 0.05:** Inconclusive due to insufficient data, extend duration
 - **If Step 2 showed adequate power (>80%) AND p > 0.15:** Sufficient data to accept null result (no effect)
 - **If Step 2 showed adequate power but CI width too wide:** Need more data for precision, extend duration
 
 **Velocity projection (only if extending recommended):**
+
 - **Current daily enrollment:** Calculate users per day per variant
 - **Days to target sample:** Based on Step 2 power calculation, how many more days needed?
 - **Days to target precision:** Based on Step 2 CI width calculation, how many more days to reach desired precision?
@@ -302,12 +325,14 @@ Based on the power and precision analysis from Step 2, evaluate if the experimen
 **For significant results (positive or negative):**
 
 Use `Amplitude:get_feedback_insights`:
+
 - Filter by experiment date range
 - For wins: look for `["lovedFeature", "mentionedFeature"]`
 - For losses: look for `["bug", "complaint", "painPoint"]`
 - Check if themes align with experiment hypothesis
 
 **Connect quantitative to qualitative:**
+
 - Explain the lift with user quotes or feedback themes
 - Present 2-3 representative examples with specific details
 
@@ -316,6 +341,7 @@ Use `Amplitude:get_feedback_insights`:
 ### Step 8: Synthesize Findings and Make Recommendation
 
 **Before finalizing, verify you have included:**
+
 - ✓ All primary metric data (lift, CI, p-value, interpretation)
 - ✓ All data quality findings (SRM, sample size, power, precision, all 7 validity flags with actual values)
 - ✓ All secondary metrics and guardrails (with actual values and significance)
@@ -330,6 +356,7 @@ Present structured analysis:
 ## Experiment Analysis: [Experiment Name]
 
 **Overview:**
+
 - **Hypothesis:** [What was tested and expected impact]
 - **Duration:** [Start] to [End] ([X days])
 - **Sample Size:** Control: [N] | Treatment: [N]
@@ -340,10 +367,12 @@ Present structured analysis:
 **Data Quality Assessment:**
 
 **Traffic & SRM:**
+
 - **Traffic Balance:** Control [X%] | Treatment [Y%] (Expected: [X%] | [Y%])
 - **SRM Detected:** [Yes/No] [If yes, explain deviation severity]
 
 **Sample Size & Power:**
+
 - **Sample Size:** Control: [N] | Treatment: [N]
 - **Sample Adequacy:** [Adequate (>1000) / Moderate (100-1000) / Low (<100)]
 - **Statistical Power:** [X%] to detect [Y%] lift (Target: 80%+)
@@ -351,6 +380,7 @@ Present structured analysis:
 
 **Statistical Validity Flags:**
 [Only include flags that failed - if all pass, state "All statistical validity checks passed"]
+
 - ❌ **statsAssumptionsMetForWholeExperiment:** Statistical assumptions not met - [brief impact]
 - ❌ **hasSuspiciousUplift:** Unusually large effect detected - [brief recommendation]
 - ❌ **isVariancePositive:** Invalid variance - [critical issue description]
@@ -360,6 +390,7 @@ Present structured analysis:
 - ❌ **isMeanValid:** Invalid mean value - [data quality issue]
 
 **Duration:**
+
 - **Runtime:** [X days] (Started: [date])
 - **Sufficiency:** [Adequate - captured full user lifecycle / Need more time - [reason]]
 - **Recommendation:** [Continue running for X more days / Sufficient data to conclude]
@@ -371,10 +402,10 @@ Present structured analysis:
 
 **Primary Metric: [Metric Name]**
 
-| Variant | Value | Lift | 95% CI | P-value | Status |
-|---------|-------|------|--------|---------|--------|
-| Control | [X] | — | — | — | — |
-| Treatment | [Y] | **[+Z%]** | [[A, B]] | [P] | ✅ Significant |
+| Variant   | Value | Lift      | 95% CI   | P-value | Status         |
+| --------- | ----- | --------- | -------- | ------- | -------------- |
+| Control   | [X]   | —         | —        | —       | —              |
+| Treatment | [Y]   | **[+Z%]** | [[A, B]] | [P]     | ✅ Significant |
 
 **Interpretation:** [1-2 sentences on statistical AND practical significance]
 
@@ -383,11 +414,13 @@ Present structured analysis:
 **Secondary Metrics & Guardrails:**
 
 **Guardrails:**
+
 - ✅ **Revenue per user:** No regression ([+X%], p=[P])
 - ✅ **Retention D7:** Slight positive ([+X%], p=[P])
 - 🚩 **Bounce rate:** Regression detected ([+X%], p=[P]) ⚠️
 
 **Secondary Metrics:**
+
 - **[Metric]:** [+X% lift, p=[P]] - [brief interpretation]
 - **[Metric]:** No significant change (p=[P])
 
@@ -410,6 +443,7 @@ Present structured analysis:
 ---
 
 **Statistical Power:**
+
 - **Current Power:** [X%] - [Adequate/Underpowered]
 - **Required Sample:** Need [X] more users per variant for 80% power
 - **Estimated Duration:** [X] more days at current traffic to reach significance
@@ -417,6 +451,7 @@ Present structured analysis:
 ---
 
 **Why This Result:**
+
 - **[Feedback theme]** ([X mentions])
   - "[Quote]" - [Source] ([Date])
 
@@ -425,6 +460,7 @@ Present structured analysis:
 **Recommendation: ✅ SHIP** / **⚠️ ITERATE** / **❌ ABANDON** / **🔄 NEED MORE DATA**
 
 **Rationale:**
+
 1. [Primary metric result with statistical and practical significance]
 2. [Guardrail status and any unintended consequences]
 3. [Segment insights - opportunities or concerns]
@@ -432,16 +468,19 @@ Present structured analysis:
 5. [Qualitative validation]
 
 **Known Risks:**
+
 - [Risk 1 with mitigation if shipping]
 - [Risk 2 with mitigation if shipping]
 
 **Next Steps:**
+
 1. [Specific action based on recommendation]
 2. [Follow-up or monitoring action]
 
 ---
 
 **Key Takeaways (3-5 actionable insights):**
+
 1. [Most important finding]
 2. [Second most important finding]
 3. [Third most important finding]
@@ -456,11 +495,13 @@ Present structured analysis:
 ### Inconclusive Results (p > 0.05)
 
 **Diagnose:**
+
 - Check statistical power: Is sample size adequate? Report current power percentage
 - Check confidence interval: Very wide = high variance, need more data
 - Check segments: Effect may exist in specific subgroup
 
 **Action:**
+
 - If power <60%: Extend duration or increase traffic allocation
 - If power >80% but p >0.15: Accept null result (no effect detected)
 - Check segment tables: Look for subgroups with significant effects
@@ -470,11 +511,13 @@ Present structured analysis:
 ### Guardrail Regressed
 
 **Diagnose:**
+
 - Quantify trade-off with specific numbers: +10% conversion but -2% retention
 - Which segments drove the regression? Check segment tables
 - Is regression statistically significant or just noise?
 
 **Action:**
+
 - Small regression + large primary win + not significant = ship with monitoring
 - Significant regression on critical metric = iterate to fix or abandon
 - Segment-specific regression = consider targeted rollout excluding affected segments
@@ -484,10 +527,12 @@ Present structured analysis:
 ### Segment Tables Show Opposite Effects
 
 **Simpson's Paradox detected:**
+
 - Overall result may be misleading if segments show opposite directions
 - Example: Overall +5% lift, but iOS -10%, Android +15%
 
 **Action:**
+
 - Report the paradox clearly with specific segment numbers
 - Consider targeted rollout to segments that benefit
 - Exclude or iterate for segments that are harmed
@@ -497,6 +542,7 @@ Present structured analysis:
 ## Best Practices
 
 **Comprehensive analysis:**
+
 - ✅ Include ALL data from tool calls with specific numbers
 - ✅ Format segment analysis as breakdown tables with % of total
 - ✅ Check statistical power and duration adequacy
@@ -504,12 +550,14 @@ Present structured analysis:
 - ✅ Connect quantitative results to qualitative insights
 
 **Statistical rigor:**
+
 - ✅ Report confidence intervals, not just p-values
 - ✅ Distinguish statistical vs. practical significance
 - ✅ Apply multiple testing correction for 5+ metrics
 - ✅ Check for Simpson's Paradox in segment analysis
 
 **Avoid:**
+
 - ❌ Don't provide brief summaries - be comprehensive
 - ❌ Don't omit data quality issues or negative secondary metrics
 - ❌ Don't ignore segments - they reveal critical insights

--- a/plugins/amplitude/skills/analyze-experiment/SKILL.md
+++ b/plugins/amplitude/skills/analyze-experiment/SKILL.md
@@ -20,6 +20,7 @@ Perform comprehensive, detailed deep-dive analysis of experiments to make data-d
 ## Analysis Philosophy
 
 **Be comprehensive, not brief:**
+
 - Include specific numbers, percentages, and data points
 - Explain statistical meaning AND business implications in plain language
 - Cover all metrics (primary, secondary, guardrails) with actual values
@@ -32,16 +33,19 @@ Perform comprehensive, detailed deep-dive analysis of experiments to make data-d
 ### Step 0: Identify Experiment
 
 **If user provides a specific experiment:**
+
 - Accept experiment **URL or experiment ID**
 - If URL: use `Amplitude:get_from_url` to extract details
 - If ID: proceed to Step 1
 
 **If user asks about experiments generally:**
+
 - Use `Amplitude:search` with `entityTypes: ["EXPERIMENT"]` and relevant query terms
 - Present top 3-5 matches with names, IDs, and states
 - Ask user which experiment to analyze
 
 **If no experiment specified:**
+
 - Ask explicitly for experiment URL, ID, or search terms and stop
 
 ---
@@ -57,6 +61,7 @@ Use `Amplitude:get_experiments` with experiment ID to capture:
 - Bucketing strategy
 
 **Get metric names:**
+
 - Extract metric IDs from the experiment response (e.g., "c4pn8fkv")
 - **CRITICAL: Amplitude MCP cannot retrieve metric names by ID directly**
 - Workaround options:
@@ -69,6 +74,7 @@ Use `Amplitude:get_experiments` with experiment ID to capture:
   - Include metric IDs so users can look them up in Amplitude UI
 
 **Validation:**
+
 - Is experiment running or completed? (not draft)
 - Has it run for 1+ weeks?
 - Are variants and metrics clearly defined?
@@ -82,6 +88,7 @@ If incomplete, explain what's missing and stop.
 Use `Amplitude:query_experiment` (primary metric only) to assess:
 
 **Traffic Balance (SRM Check):**
+
 - Report actual traffic split per variant (e.g., 48.2% control, 51.8% treatment)
 - **Use `srmDetected` field from API:** Flag if `srmDetected: true`
 - SRM (Sample Ratio Mismatch) indicates the observed traffic split deviates significantly from the expected allocation
@@ -91,12 +98,14 @@ Use `Amplitude:query_experiment` (primary metric only) to assess:
 **Sample Size Analysis:**
 
 **A. Current Sample Assessment:**
+
 - Report total users per variant with specific numbers
 - **Flag if <100 users per variant** (insufficient for any conclusion)
 - **Flag if 100-1000 users** (directional signals only, not confident decision)
 - Need 1000+ per variant for confident decisions
 
 **B. Statistical Power Analysis:**
+
 - **Target effect size:** What minimum lift would be meaningful for the business? (typically 2-5% for conversion metrics)
 - **Achieved power:** Given current sample size and observed variance, what's the probability of detecting the target effect if it exists?
 - **Power interpretation:**
@@ -108,6 +117,7 @@ Use `Amplitude:query_experiment` (primary metric only) to assess:
 - **Recommendation:** If power <70% and results are inconclusive, extend duration rather than making premature decision
 
 **C. Precision Analysis (Confidence Interval Width):**
+
 - **CI width for primary metric:** Report the width of the 95% confidence interval as percentage of baseline
 - **Precision assessment:**
   - CI width >10% of baseline: Low precision - effect size uncertainty too high for confident decisions
@@ -158,6 +168,7 @@ The `Amplitude:query_experiment` API returns multiple boolean flags that assess 
    - Impact: Critical - cannot analyze if mean is invalid
 
 **For each flag that fails (returns false or true for suspicious uplift), document:**
+
 - Which flag failed
 - What it means in plain language
 - Specific impact on result reliability
@@ -166,6 +177,7 @@ The `Amplitude:query_experiment` API returns multiple boolean flags that assess 
 **If all flags pass:** Note this explicitly as strong data quality signal
 
 **Temporal Stability:**
+
 - Check if primary metric is stable day-over-day
 - Note ramp period (first 24-48hrs) or day-of-week effects
 
@@ -180,6 +192,7 @@ Use `Amplitude:query_experiment` **without metricIds** to get primary metric onl
 **Use metric name from Step 1** - Report using the human-readable metric name, not the metric ID.
 
 Extract and report:
+
 - **Control baseline:** metric value and sample size
 - **Treatment performance:** metric value and sample size
 - **Absolute lift:** treatment - control
@@ -188,11 +201,13 @@ Extract and report:
 - **Confidence interval:** report 95% CI bounds
 
 **Interpret:**
+
 - ✅ **Statistically significant:** p < 0.05 and CI doesn't include 0
 - ⚠️ **Trending:** 0.05 < p < 0.15 (suggestive but inconclusive)
 - ❌ **No effect:** p ≥ 0.15 or CI includes 0
 
 **Practical significance:**
+
 - Is the lift magnitude meaningful for the business?
 - Small lifts (<2-3%) may not be worth complexity even if significant
 - Consider metric's business impact (revenue vs. low-value engagement)
@@ -206,11 +221,13 @@ Use `Amplitude:query_experiment` **with metricIds** for all metrics.
 **Use metric names from Step 1** - Report using human-readable metric names, not metric IDs.
 
 **For each secondary metric:**
+
 - Report metric name (from Step 1 mapping), variant performance, and statistical significance
 - Note which moved and which didn't (with specific numbers)
 - **Identify unintended consequences:** Flag any negative impacts with specific values
 
 **For each guardrail:**
+
 - ✅ No regression: neutral or positive (p > 0.05)
 - ⚠️ Marginal concern: small negative lift (1-5%) with p < 0.10
 - 🚩 **Significant regression:** negative lift with p < 0.05 - report actual numbers
@@ -226,6 +243,7 @@ Use `Amplitude:query_experiment` **with metricIds** for all metrics.
 Use `Amplitude:query_experiment` with `groupBy` parameter (one at a time).
 
 Test 3-4 high-signal segments:
+
 1. **Platform** (iOS, Android, Web)
 2. **User tenure** (new vs. established users)
 3. **Plan type** (free vs. paid)
@@ -236,17 +254,19 @@ Test 3-4 high-signal segments:
 For each segment analysis, present results in this exact format:
 
 | Segment | Control Rate | Control Exposures | Control % of Total | Treatment Rate | Treatment Exposures | Treatment % of Total | Relative Lift | Significant? |
-|---------|--------------|-------------------|-------------------|----------------|---------------------|---------------------|---------------|--------------|
-| iOS | 48.7% | 1,234 | 45.2% | 55.4% | 1,456 | 54.8% | **+13.6%** | Yes (p=0.02) |
-| Android | 63.9% | 567 | 20.8% | 65.1% | 589 | 22.2% | +1.9% | No (p=0.45) |
-| Web | 51.2% | 928 | 34.0% | 50.8% | 611 | 23.0% | -0.8% | No (p=0.89) |
+| ------- | ------------ | ----------------- | ------------------ | -------------- | ------------------- | -------------------- | ------------- | ------------ |
+| iOS     | 48.7%        | 1,234             | 45.2%              | 55.4%          | 1,456               | 54.8%                | **+13.6%**    | Yes (p=0.02) |
+| Android | 63.9%        | 567               | 20.8%              | 65.1%          | 589                 | 22.2%                | +1.9%         | No (p=0.45)  |
+| Web     | 51.2%        | 928               | 34.0%              | 50.8%          | 611                 | 23.0%                | -0.8%         | No (p=0.89)  |
 
 **Calculate % of Total:**
+
 - Sum all exposures across segments to get total
 - Show each segment's share: (segment exposures / total exposures) × 100%
 - This reveals which segments drive overall results
 
 **Key insights:**
+
 - Identify segments where treatment performs **best** (targeted rollout opportunity)
 - Identify segments where treatment **hurts** (consider exclusions)
 - Explain why different segments show different performance
@@ -262,18 +282,21 @@ Use `groupByLimit: 10` to avoid overwhelming output.
 Based on the power and precision analysis from Step 2, evaluate if the experiment has run long enough:
 
 **Runtime factors:**
+
 - **Minimum duration:** Has experiment run at least 1-2 weeks to capture full user lifecycle?
 - **Learning effects:** For feature changes, have users had time to adapt? (typically 3-7 days)
 - **Weekly seasonality:** Has experiment captured at least one complete week to account for day-of-week patterns?
 - **Business cycles:** For B2B products, has it run through full business week patterns?
 
 **Integration with Step 2 power analysis:**
+
 - **If Step 2 showed adequate power (>80%) AND p < 0.05:** Experiment has sufficient data, duration is adequate
 - **If Step 2 showed low power (<70%) AND p > 0.05:** Inconclusive due to insufficient data, extend duration
 - **If Step 2 showed adequate power (>80%) AND p > 0.15:** Sufficient data to accept null result (no effect)
 - **If Step 2 showed adequate power but CI width too wide:** Need more data for precision, extend duration
 
 **Velocity projection (only if extending recommended):**
+
 - **Current daily enrollment:** Calculate users per day per variant
 - **Days to target sample:** Based on Step 2 power calculation, how many more days needed?
 - **Days to target precision:** Based on Step 2 CI width calculation, how many more days to reach desired precision?
@@ -288,12 +311,14 @@ Based on the power and precision analysis from Step 2, evaluate if the experimen
 **For significant results (positive or negative):**
 
 Use `Amplitude:get_feedback_insights`:
+
 - Filter by experiment date range
 - For wins: look for `["lovedFeature", "mentionedFeature"]`
 - For losses: look for `["bug", "complaint", "painPoint"]`
 - Check if themes align with experiment hypothesis
 
 **Connect quantitative to qualitative:**
+
 - Explain the lift with user quotes or feedback themes
 - Present 2-3 representative examples with specific details
 
@@ -302,6 +327,7 @@ Use `Amplitude:get_feedback_insights`:
 ### Step 8: Synthesize Findings and Make Recommendation
 
 **Before finalizing, verify you have included:**
+
 - ✓ All primary metric data (lift, CI, p-value, interpretation)
 - ✓ All data quality findings (SRM, sample size, power, precision, all 7 validity flags with actual values)
 - ✓ All secondary metrics and guardrails (with actual values and significance)
@@ -316,6 +342,7 @@ Present structured analysis:
 ## Experiment Analysis: [Experiment Name]
 
 **Overview:**
+
 - **Hypothesis:** [What was tested and expected impact]
 - **Duration:** [Start] to [End] ([X days])
 - **Sample Size:** Control: [N] | Treatment: [N]
@@ -326,10 +353,12 @@ Present structured analysis:
 **Data Quality Assessment:**
 
 **Traffic & SRM:**
+
 - **Traffic Balance:** Control [X%] | Treatment [Y%] (Expected: [X%] | [Y%])
 - **SRM Detected:** [Yes/No] [If yes, explain deviation severity]
 
 **Sample Size & Power:**
+
 - **Sample Size:** Control: [N] | Treatment: [N]
 - **Sample Adequacy:** [Adequate (>1000) / Moderate (100-1000) / Low (<100)]
 - **Statistical Power:** [X%] to detect [Y%] lift (Target: 80%+)
@@ -337,6 +366,7 @@ Present structured analysis:
 
 **Statistical Validity Flags:**
 [Only include flags that failed - if all pass, state "All statistical validity checks passed"]
+
 - ❌ **statsAssumptionsMetForWholeExperiment:** Statistical assumptions not met - [brief impact]
 - ❌ **hasSuspiciousUplift:** Unusually large effect detected - [brief recommendation]
 - ❌ **isVariancePositive:** Invalid variance - [critical issue description]
@@ -346,6 +376,7 @@ Present structured analysis:
 - ❌ **isMeanValid:** Invalid mean value - [data quality issue]
 
 **Duration:**
+
 - **Runtime:** [X days] (Started: [date])
 - **Sufficiency:** [Adequate - captured full user lifecycle / Need more time - [reason]]
 - **Recommendation:** [Continue running for X more days / Sufficient data to conclude]
@@ -357,10 +388,10 @@ Present structured analysis:
 
 **Primary Metric: [Metric Name]**
 
-| Variant | Value | Lift | 95% CI | P-value | Status |
-|---------|-------|------|--------|---------|--------|
-| Control | [X] | — | — | — | — |
-| Treatment | [Y] | **[+Z%]** | [[A, B]] | [P] | ✅ Significant |
+| Variant   | Value | Lift      | 95% CI   | P-value | Status         |
+| --------- | ----- | --------- | -------- | ------- | -------------- |
+| Control   | [X]   | —         | —        | —       | —              |
+| Treatment | [Y]   | **[+Z%]** | [[A, B]] | [P]     | ✅ Significant |
 
 **Interpretation:** [1-2 sentences on statistical AND practical significance]
 
@@ -369,11 +400,13 @@ Present structured analysis:
 **Secondary Metrics & Guardrails:**
 
 **Guardrails:**
+
 - ✅ **Revenue per user:** No regression ([+X%], p=[P])
 - ✅ **Retention D7:** Slight positive ([+X%], p=[P])
 - 🚩 **Bounce rate:** Regression detected ([+X%], p=[P]) ⚠️
 
 **Secondary Metrics:**
+
 - **[Metric]:** [+X% lift, p=[P]] - [brief interpretation]
 - **[Metric]:** No significant change (p=[P])
 
@@ -396,6 +429,7 @@ Present structured analysis:
 ---
 
 **Statistical Power:**
+
 - **Current Power:** [X%] - [Adequate/Underpowered]
 - **Required Sample:** Need [X] more users per variant for 80% power
 - **Estimated Duration:** [X] more days at current traffic to reach significance
@@ -403,6 +437,7 @@ Present structured analysis:
 ---
 
 **Why This Result:**
+
 - **[Feedback theme]** ([X mentions])
   - "[Quote]" - [Source] ([Date])
 
@@ -411,6 +446,7 @@ Present structured analysis:
 **Recommendation: ✅ SHIP** / **⚠️ ITERATE** / **❌ ABANDON** / **🔄 NEED MORE DATA**
 
 **Rationale:**
+
 1. [Primary metric result with statistical and practical significance]
 2. [Guardrail status and any unintended consequences]
 3. [Segment insights - opportunities or concerns]
@@ -418,16 +454,19 @@ Present structured analysis:
 5. [Qualitative validation]
 
 **Known Risks:**
+
 - [Risk 1 with mitigation if shipping]
 - [Risk 2 with mitigation if shipping]
 
 **Next Steps:**
+
 1. [Specific action based on recommendation]
 2. [Follow-up or monitoring action]
 
 ---
 
 **Key Takeaways (3-5 actionable insights):**
+
 1. [Most important finding]
 2. [Second most important finding]
 3. [Third most important finding]
@@ -442,11 +481,13 @@ Present structured analysis:
 ### Inconclusive Results (p > 0.05)
 
 **Diagnose:**
+
 - Check statistical power: Is sample size adequate? Report current power percentage
 - Check confidence interval: Very wide = high variance, need more data
 - Check segments: Effect may exist in specific subgroup
 
 **Action:**
+
 - If power <60%: Extend duration or increase traffic allocation
 - If power >80% but p >0.15: Accept null result (no effect detected)
 - Check segment tables: Look for subgroups with significant effects
@@ -456,11 +497,13 @@ Present structured analysis:
 ### Guardrail Regressed
 
 **Diagnose:**
+
 - Quantify trade-off with specific numbers: +10% conversion but -2% retention
 - Which segments drove the regression? Check segment tables
 - Is regression statistically significant or just noise?
 
 **Action:**
+
 - Small regression + large primary win + not significant = ship with monitoring
 - Significant regression on critical metric = iterate to fix or abandon
 - Segment-specific regression = consider targeted rollout excluding affected segments
@@ -470,10 +513,12 @@ Present structured analysis:
 ### Segment Tables Show Opposite Effects
 
 **Simpson's Paradox detected:**
+
 - Overall result may be misleading if segments show opposite directions
 - Example: Overall +5% lift, but iOS -10%, Android +15%
 
 **Action:**
+
 - Report the paradox clearly with specific segment numbers
 - Consider targeted rollout to segments that benefit
 - Exclude or iterate for segments that are harmed
@@ -483,6 +528,7 @@ Present structured analysis:
 ## Best Practices
 
 **Comprehensive analysis:**
+
 - ✅ Include ALL data from tool calls with specific numbers
 - ✅ Format segment analysis as breakdown tables with % of total
 - ✅ Check statistical power and duration adequacy
@@ -490,12 +536,14 @@ Present structured analysis:
 - ✅ Connect quantitative results to qualitative insights
 
 **Statistical rigor:**
+
 - ✅ Report confidence intervals, not just p-values
 - ✅ Distinguish statistical vs. practical significance
 - ✅ Apply multiple testing correction for 5+ metrics
 - ✅ Check for Simpson's Paradox in segment analysis
 
 **Avoid:**
+
 - ❌ Don't provide brief summaries - be comprehensive
 - ❌ Don't omit data quality issues or negative secondary metrics
 - ❌ Don't ignore segments - they reveal critical insights

--- a/plugins/amplitude/skills/analyze-feedback/SKILL.md
+++ b/plugins/amplitude/skills/analyze-feedback/SKILL.md
@@ -45,15 +45,16 @@ Structure as:
 6. **Prioritized Recommendations**: Very concise section recapping the top 3-7 specific actionable recommendations (unless prompted otherwise) to follow-up on. Inlcude [p0],[p1],[p2],[p3] in front of each title to help size priority with p0 being most urgent and p3 being least.
 
 ## Best Practices
-- Be comprehensive in your investigation and analysis but concise and actionable in your response. 
+
+- Be comprehensive in your investigation and analysis but concise and actionable in your response.
 - Do not repeat duplicate sections or the same takeaway multiple times.
 - Include 1-2 representative quotes for each theme. Prioritize the best quotes that explains the theme. Include when it was received and what source it came from. If the quote is long, only quote the relevant section tied to the theme.
 - When describing a theme, include the mention volumes, key sources, and recency in a concise manner.
 - Each theme should have consistent formatting like:
-    Concise But Descriptive Theme Name (X mentions)
-    Actionable one-line description or multiple concise bullet-points explaining what the specific issue or request or praise is, what time period the feedback was relevant for, and key sources the theme came from
-    - "Customer quote backing the theme" - Source name (Received date)
-    - "Customer quote backing the theme" - Source name (Received date)
+  Concise But Descriptive Theme Name (X mentions)
+  Actionable one-line description or multiple concise bullet-points explaining what the specific issue or request or praise is, what time period the feedback was relevant for, and key sources the theme came from
+  - "Customer quote backing the theme" - Source name (Received date)
+  - "Customer quote backing the theme" - Source name (Received date)
 - For the Prioritized Recommendations section, each recommendation should just be 1 concise but actionable bullet-point instead of a long theme overview.
 - Do not recap what you did at the very end and just end after the concise prioritized recommendations.
 - Connect feedback to behavioral data when possible.

--- a/plugins/amplitude/skills/build-charts-with-typed-params/SKILL.md
+++ b/plugins/amplitude/skills/build-charts-with-typed-params/SKILL.md
@@ -79,9 +79,23 @@ counts) or `COMPARISON_EVENT` (members compared), plus `members[]`.
 
 ```jsonc
 {
-  "where": [{ "property": "country", "op": "is", "values": ["United States"], "scope": "user" }],
-  "performed": [{ "event": "Purchase", "op": ">=", "count": 1,
-                  "time_type": "rolling", "time_value": 30 }]
+  "where": [
+    {
+      "property": "country",
+      "op": "is",
+      "values": ["United States"],
+      "scope": "user",
+    },
+  ],
+  "performed": [
+    {
+      "event": "Purchase",
+      "op": ">=",
+      "count": 1,
+      "time_type": "rolling",
+      "time_value": 30,
+    },
+  ],
 }
 ```
 
@@ -181,16 +195,35 @@ by plan:
 {
   "kind": "segmentation",
   "name": "iOS signups by plan",
-  "events": [{ "event": "Sign Up", "where": [
-    { "property": "platform", "op": "is", "values": ["iOS"], "scope": "event" }
-  ]}],
+  "events": [
+    {
+      "event": "Sign Up",
+      "where": [
+        {
+          "property": "platform",
+          "op": "is",
+          "values": ["iOS"],
+          "scope": "event",
+        },
+      ],
+    },
+  ],
   "measured_as": { "as": "unique_users" },
   "group_by": [{ "property": "plan", "scope": "user" }],
-  "segments": [{ "where": [
-    { "property": "country", "op": "is", "values": ["United States"], "scope": "user" }
-  ]}],
+  "segments": [
+    {
+      "where": [
+        {
+          "property": "country",
+          "op": "is",
+          "values": ["United States"],
+          "scope": "user",
+        },
+      ],
+    },
+  ],
   "date_range": { "relative": "Last 12 Weeks" },
-  "interval": "week"
+  "interval": "week",
 }
 ```
 
@@ -201,7 +234,7 @@ fix-oriented hint — read the hint, fix that one field, and retry. Do not
 rebuild the whole chart. The three seen most in production:
 
 1. **Range/interval unit mismatch** — `Invalid range format: Last 3 Years …
-   Match the relative range's unit to the interval`. Re-denominate the range
+Match the relative range's unit to the interval`. Re-denominate the range
    in the interval's unit (`Last 30 Days` at weekly interval → `Last 4 Weeks`).
 2. **Missing funnel window field** — `conversion_window.unit: Field required`.
    Pass both `value` and `unit`.

--- a/plugins/amplitude/skills/compare-user-journeys/SKILL.md
+++ b/plugins/amplitude/skills/compare-user-journeys/SKILL.md
@@ -13,10 +13,12 @@ Investigate what distinguishes two user groups by pulling session replays and me
 ## CRITICAL: Tool Reference
 
 **Primary tools:**
+
 - **`Amplitude:get_session_replays`** — Find sessions for each user group using event count filters and user property filters. Run this twice — once per group.
 - **`Amplitude:get_session_replay_events`** — Decode replays into interaction timelines. Run this for sessions from both groups.
 
 **Supporting tools:**
+
 - **`Amplitude:search`** — Search for existing charts, funnels, dashboards, events, and cohorts relevant to the comparison. Always check for existing analysis before building from scratch.
 - **`Amplitude:get_cohorts`** — Discover existing cohorts that define the groups (e.g., "power users", "churned", "converted").
 - **`Amplitude:get_events`** — Discover valid event names. Never guess event names.
@@ -32,16 +34,17 @@ Investigate what distinguishes two user groups by pulling session replays and me
 
 Parse the user's request to identify Group A and Group B. Common comparison patterns:
 
-| Comparison | Group A | Group B |
-|---|---|---|
-| Conversion | Users who completed the goal | Users who didn't |
-| Engagement | Power users / high-frequency | Casual / low-frequency |
-| Retention | Retained users | Churned users |
-| Plan tier | Enterprise / paid | Free / trial |
-| Outcome | Successful (e.g., activated) | Failed (e.g., dropped off) |
-| A/B test | Variant A | Variant B |
+| Comparison | Group A                      | Group B                    |
+| ---------- | ---------------------------- | -------------------------- |
+| Conversion | Users who completed the goal | Users who didn't           |
+| Engagement | Power users / high-frequency | Casual / low-frequency     |
+| Retention  | Retained users               | Churned users              |
+| Plan tier  | Enterprise / paid            | Free / trial               |
+| Outcome    | Successful (e.g., activated) | Failed (e.g., dropped off) |
+| A/B test   | Variant A                    | Variant B                  |
 
 For each group, determine:
+
 - **Defining criteria**: What makes a user belong to this group? (cohort, event, property)
 - **Labels**: Clear names for the report (e.g., "Converters" vs. "Drop-offs", not "Group A" vs "Group B")
 
@@ -67,6 +70,7 @@ Use `Amplitude:query_charts` or `Amplitude:query_charts` to compare the two grou
 3. **Feature usage differences**: Which events does Group A fire significantly more than Group B? Use event totals or unique user counts segmented by group.
 
 **What to look for:**
+
 - Large percentage differences in specific event frequencies
 - Features used exclusively or predominantly by one group
 - Timing differences (Group A does X on day 1, Group B waits until day 7)
@@ -85,10 +89,12 @@ Run `Amplitude:get_session_replays` **twice** — once for each group. Request `
 If groups are defined by a **cohort**, filter on the cohort's defining user property or event.
 
 If groups are defined by an **event outcome** (e.g., completed checkout vs. didn't):
+
 - **Group A (converters)**: Filter for sessions containing the conversion event (use `eventCountFilters` with `operator: "greater or equal"`, `count: "1"`).
 - **Group B (drop-offs)**: Filter for sessions containing the entry event but NOT the conversion event. Since `get_session_replays` doesn't support "did not do" filters directly, filter for the entry event only, then when watching replays in Step 5, check the interaction timeline for absence of the conversion event. Discard sessions where the user actually converted and replace with additional sessions until you have 4-6 confirmed drop-offs.
 
 If groups are defined by a **user property** (plan, segment):
+
 - Use user property filters with `event_type: "_all"`.
 
 ### Step 5: Watch Sessions — Extract Interaction Timelines
@@ -98,19 +104,20 @@ For each group, call `Amplitude:get_session_replay_events` for 4-6 sessions. Use
 **Budget: 8-12 total sessions (4-6 per group).**
 
 **Rate limiting and large responses:**
+
 - Call `get_session_replay_events` in batches of 3-4 at a time, not all at once. The Session Replay API enforces concurrency limits and will return 429 errors if overwhelmed. If you hit a 429, wait briefly and retry.
 - Some sessions have extremely high interaction counts (100K+ raw events). If a response is too large and gets saved to a file, read the key portions from the saved file path. For sessions with very high `total_raw_events`, consider using a lower `event_limit` (e.g., 150) to stay within response size limits.
 
 **While analyzing, track these behavioral dimensions for each session:**
 
-| Dimension | What to capture |
-|---|---|
-| **Navigation path** | Sequence of pages visited. Note the order and any pages unique to this session. |
-| **Feature engagement** | Which features/areas the user interacted with. Note depth (quick glance vs. extended use). |
-| **Pace & hesitation** | Fast and confident vs. slow with pauses. Note long gaps between actions. |
-| **Exploration vs. focus** | Did the user go straight to their goal or browse around? |
-| **Friction encountered** | Errors, rage clicks, back-navigation, abandoned inputs. |
-| **Session outcome** | Did they accomplish something? What was the last action before leaving? |
+| Dimension                 | What to capture                                                                            |
+| ------------------------- | ------------------------------------------------------------------------------------------ |
+| **Navigation path**       | Sequence of pages visited. Note the order and any pages unique to this session.            |
+| **Feature engagement**    | Which features/areas the user interacted with. Note depth (quick glance vs. extended use). |
+| **Pace & hesitation**     | Fast and confident vs. slow with pauses. Note long gaps between actions.                   |
+| **Exploration vs. focus** | Did the user go straight to their goal or browse around?                                   |
+| **Friction encountered**  | Errors, rage clicks, back-navigation, abandoned inputs.                                    |
+| **Session outcome**       | Did they accomplish something? What was the last action before leaving?                    |
 
 For each session, write a 2-3 sentence behavioral summary capturing the overall pattern.
 
@@ -203,6 +210,7 @@ For each differentiating behavior:
 User says: "What do users who complete onboarding do differently from those who drop off?"
 
 Actions:
+
 1. Get context, discover onboarding events (signup, each onboarding step, activation event)
 2. Query onboarding funnel conversion rate and identify the biggest drop-off step
 3. Find sessions: Group A = completed activation event; Group B = started onboarding but didn't activate
@@ -215,6 +223,7 @@ Actions:
 User says: "How do our most active users use the product differently?"
 
 Actions:
+
 1. Get context, check for existing "power user" cohort
 2. Define groups: top 10% by session frequency vs. bottom 50%
 3. Query feature usage segmented by group — which features show the biggest usage gap
@@ -227,6 +236,7 @@ Actions:
 User says: "Why are some users churning after the first week?"
 
 Actions:
+
 1. Get context, define groups: users active in week 2+ vs. users who never returned after week 1
 2. Query retention curve and week-1 engagement metrics by group
 3. Find sessions from each group's first week

--- a/plugins/amplitude/skills/create-chart/SKILL.md
+++ b/plugins/amplitude/skills/create-chart/SKILL.md
@@ -13,6 +13,7 @@ Create charts from natural language by discovering events, building chart defini
 Before any tool calls, decompose the request:
 
 **1. Identify chart components:**
+
 - Chart type and metric (what's being measured)
 - Time range (default: Last 30 Days if not specified)
 - Primary event (the action being counted)
@@ -21,11 +22,13 @@ Before any tool calls, decompose the request:
 - Funnel steps (if conversion analysis)
 
 **2. Plan event searches:**
+
 - ONE search per distinct event concept
 - Never combine multiple concepts in one search
 - Example: "purchase" and "signup" need separate searches
 
 **3. Plan parallel tool calls:**
+
 - Get context, search events, find cohorts can run together
 - Wait for results before building definition
 
@@ -34,21 +37,25 @@ Before any tool calls, decompose the request:
 **IMPORTANT: Cast a wide net before narrowing down**
 
 When the user's request is ambiguous or could map to multiple events:
+
 1. Search BROADLY first to discover relevant options
 2. Review relevant results - look for related events, custom events, meta events
 3. Present options to user OR explain your selection rationale
 4. Try not to assume a single event is the only answer without exploration
 
 **Search for events:**
+
 ```
 Amplitude:search with entity_types=['EVENT', 'CUSTOM_EVENT']
 ```
+
 - Search ONE concept at a time
 - Use broad search terms first (e.g., "AI" not just "AI chat")
 - ✓ Good: "user completes purchase"
 - ✗ Bad: "signup or purchase events"
 
 **Make informed decisions, then explain:**
+
 1. Search broadly to discover all options
 2. Review results and identify the most comprehensive/accurate approach
 3. Make your best judgment call (prefer aggregated custom events over single events)
@@ -56,27 +63,32 @@ Amplitude:search with entity_types=['EVENT', 'CUSTOM_EVENT']
 5. User can correct if your assumption was wrong
 
 **Decision criteria:**
+
 - Prefer custom events that aggregate related activity (e.g., "[2026] Activation Metric [AI events only]")
 - If no aggregated event exists, choose the primary interaction event
 - Consider what "active user" typically means for that product area
 - Default to broader scope unless user specifies narrow focus
 
 **Examples:**
+
 - ❌ BAD: User asks "weekly AI users" → immediately pick "ai-chat: send message" without exploring, no explanation
 - ✅ GOOD: User asks "weekly AI users" → search "AI", find Ask AI, Agents, Visibility, custom aggregated event. Respond: "I found AI activity across Ask AI, Agents, and Visibility. I'm using the '[2026] Activation Metric [AI events only]' custom event which includes all AI product interactions. This gives you total AI users across all features. Let me know if you want to focus on a specific AI product instead."
 
 **Verify before use:**
+
 - Get existing charts using the event via search
 - Check event has actual volume (not zero/stale)
 - Look for custom events that aggregate related activity
 - If zero results, search for alternatives
 
 **Get properties:**
+
 ```
 Amplitude:get_properties for exact property names/values
 ```
 
 **Find cohorts:**
+
 ```
 Amplitude:search with entity_types=['COHORT']
 Amplitude:get_cohorts to get full definitions
@@ -84,29 +96,32 @@ Amplitude:get_cohorts to get full definitions
 
 ## Chart Type Selection
 
-| Chart Type | Use When |
-|------------|----------|
-| `eventsSegmentation` | Counting events/users over time, trends, comparisons, KPIs, distributions, property analytics |
-| `funnels` | Multi-step conversion analysis with a **known sequence**, drop-off analysis, time between specific events, time-to-convert metrics |
-| `retention` | User return behavior, cohort retention curves, churn analysis |
-| `dataTableV2` | Tabular comparisons, rankings, multi-dimensional breakdowns |
-| `customerJourney` | Path exploration, discovering **unknown paths** users take, comparing converted vs dropped-off paths |
-| `sessions` | Session duration, session frequency, time spent per user, session length distributions |
+| Chart Type           | Use When                                                                                                                           |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `eventsSegmentation` | Counting events/users over time, trends, comparisons, KPIs, distributions, property analytics                                      |
+| `funnels`            | Multi-step conversion analysis with a **known sequence**, drop-off analysis, time between specific events, time-to-convert metrics |
+| `retention`          | User return behavior, cohort retention curves, churn analysis                                                                      |
+| `dataTableV2`        | Tabular comparisons, rankings, multi-dimensional breakdowns                                                                        |
+| `customerJourney`    | Path exploration, discovering **unknown paths** users take, comparing converted vs dropped-off paths                               |
+| `sessions`           | Session duration, session frequency, time spent per user, session length distributions                                             |
 
 ### Quick Reference
 
 **eventsSegmentation** - Most versatile. Use for:
+
 - User counts (DAU, WAU, MAU) with `uniques` metric
 - Event totals, averages, sums of properties
 - Percentiles, distributions, formulas
 - Time series with rolling windows
 
 **Aggregation Scope (eventsSegmentation):**
+
 - `PROPSUM(A)` / `metric: "sums"` = Global sum across ALL events
 - `metric: "frequency"` = Distribution of per-user event counts (how many users did it 1x, 2x, 3x)
 - For "distribution of property sum per user": Amplitude does not support this directly. Use `metric: "frequency"` for event count distributions, or use dataTableV2 grouped by user_id with PROPSUM, then export for external analysis.
 
 **funnels** - Conversion analysis with **predefined steps**. Use for:
+
 - Step-by-step conversion rates when you know the expected sequence
 - Ordered or unordered sequences
 - Time-to-convert (median time between events)
@@ -115,15 +130,18 @@ Amplitude:get_cohorts to get full definitions
 - Note: If you want to **discover** what paths users take, use `customerJourney` instead
 
 **retention** - Return behavior. Use for:
+
 - N-day or rolling retention curves
 - Cohort analysis (new vs returning users)
 - Start event → Return event patterns
 
 **dataTableV2** - Tabular data. Use for:
+
 - Breakdowns by dimensions (country, platform, etc.)
 - Multi-metric comparisons in table format
 
 **customerJourney** - Path exploration and discovery. Use for:
+
 - Understanding the actual paths users take (vs. expected paths in funnels)
 - Analyzing paths starting with, ending with, or between two specific events
 - Comparing converted vs dropped-off user paths side by side
@@ -132,6 +150,7 @@ Amplitude:get_cohorts to get full definitions
 - Bridging the gap between ideal customer journeys and actual user behavior
 
 **sessions** - Session-based engagement metrics. Use for:
+
 - Session duration analysis (average length, time spent, distributions)
 - Session frequency (average sessions per user, total sessions)
 - Time spent per user over time
@@ -139,12 +158,14 @@ Amplitude:get_cohorts to get full definitions
 - Comparing session behavior across user segments
 
 **Special metrics:**
+
 - User counts: `metric: "uniques"`
 - Event counts: `metric: "totals"`
 - Property sums: `metric: "sums"` with property in `group_by`
 - Rates/percentages: Use when comparing groups of different sizes
 
 **Meta events:**
+
 - `_active`: Any active event (DAU, MAU)
 - `_new`: New users (first-time event)
 - `_any_revenue_event`: Revenue events
@@ -152,6 +173,7 @@ Amplitude:get_cohorts to get full definitions
 ## Chart Definition Structure
 
 **Core parameters (all chart types):**
+
 ```json
 {
   "name": "Descriptive Chart Title",
@@ -161,26 +183,30 @@ Amplitude:get_cohorts to get full definitions
     "type": "eventsSegmentation",
     "params": {
       "range": "Last 30 Days",
-      "events": [{
-        "event_type": "Purchase Completed",
-        "filters": [],
-        "group_by": []
-      }],
+      "events": [
+        {
+          "event_type": "Purchase Completed",
+          "filters": [],
+          "group_by": []
+        }
+      ],
       "metric": "uniques",
       "countGroup": "User",
       "interval": 1,
-      "segments": [{"conditions": []}]
+      "segments": [{ "conditions": [] }]
     }
   }
 }
 ```
 
 **Key parameters:**
+
 - `countGroup`: "User" (unique users) or "Event" (event occurrences)
 - `interval`: 1 (daily), 7 (weekly), 30 (monthly)
 - `segments`: User filters/groups (empty array = all users)
 
 **Event filters (inline OR logic):**
+
 ```json
 "filters": [{
   "group_type": "User",
@@ -192,6 +218,7 @@ Amplitude:get_cohorts to get full definitions
 ```
 
 **User segments (conditions AND logic):**
+
 ```json
 "segments": [{
   "name": "Active Users",
@@ -208,6 +235,7 @@ Amplitude:get_cohorts to get full definitions
 
 **Cohort segments:**
 Search for cohort, get ID, then:
+
 ```json
 "segments": [{
   "name": "My Cohort",
@@ -223,11 +251,13 @@ Search for cohort, get ID, then:
 ## Workflow: Create Chart
 
 1. **Get context:**
+
 ```
 Amplitude:get_amplitude_context (for projectId)
 ```
 
 2. **Discover events** (BROAD search first):
+
 ```
 Amplitude:search for each distinct concept
 - Use broad search terms initially
@@ -236,25 +266,30 @@ Amplitude:search for each distinct concept
 ```
 
 3. **Evaluate and decide:**
+
 - Review all discovered events and custom events
 - Make informed decision (prefer aggregated events)
 - Prepare clear explanation of what you found and your choice
 
 4. **Find similar charts** (see examples):
+
 ```
 Amplitude:search entity_types=['CHART'] query="similar concept"
 Amplitude:get_charts to see definition structure
 ```
 
 5. **Get properties if needed:**
+
 ```
 Amplitude:get_properties
 ```
 
 6. **Build definition** using discovered names
+
 - Explain event selection rationale in response
 
 7. **Create chart:**
+
 ```
 Amplitude:query_dataset with full definition
 ```
@@ -262,6 +297,7 @@ Amplitude:query_dataset with full definition
 8. **Verify results** - check data makes sense
 
 9. **Save chart:**
+
 ```
 Amplitude:save_chart_edits with editId from query_dataset
 ```
@@ -269,12 +305,14 @@ Amplitude:save_chart_edits with editId from query_dataset
 ## Error Handling
 
 **If query_dataset fails:**
+
 - Read error message carefully
 - Common issues: incorrect event names, invalid filters, wrong parameter types
 - Fix definition and retry
 - Verify events exist via search first
 
 **If zero results:**
+
 - Check filters aren't too restrictive
 - Verify event has data (search for charts using it)
 - Try broader time range
@@ -283,28 +321,30 @@ Amplitude:save_chart_edits with editId from query_dataset
 ## Best Practices
 
 **Naming:**
+
 - Include metric + time context: "Weekly Active Users Last 90 Days"
 - Not: "WAU" or "Users"
 
 **Time ranges:**
+
 - Default to "Last 30 Days"
 - Use inclusive ranges for specific periods
 - State interpreted range explicitly
 
 **Verification:**
+
 - Always verify event exists before using
 - Check similar charts to understand event usage
 - Confirm properties with get_properties
 
 **Comparisons:**
+
 - Use segments for comparing user groups on same chart
 - Use rates/percentages for different-sized groups
 
 **Always include:**
+
 - Chart URL in response
 - What the chart shows
 - Key insights from initial data
 - Methodology used
-
-
-

--- a/plugins/amplitude/skills/create-dashboard/SKILL.md
+++ b/plugins/amplitude/skills/create-dashboard/SKILL.md
@@ -12,6 +12,7 @@ Create new team or initiative dashboards, organize scattered charts, build execu
 ### Step 0: Discovery (if unfamiliar with the feature)
 
 Before building, understand what you're tracking:
+
 - Search for existing dashboards/charts related to the topic
 - Search for relevant events: `Amplitude:search` with entityTypes: ["EVENT", "CUSTOM_EVENT"]
 - Use `get_properties` to understand available properties for segmentation
@@ -29,17 +30,20 @@ Clarify:
 ### Step 2: Gather or Create Charts
 
 **If existing charts found (>5 relevant):**
+
 - Use `Amplitude:search` to find relevant existing charts
 - Use `Amplitude:get_charts` to retrieve their definitions
 - Identify gaps that need new charts
 
 **If few/no charts exist (<5 relevant):**
+
 - Switch to "greenfield build" mode
 - Use `Amplitude:query_dataset` to create needed charts
 - Save all charts with `Amplitude:save_chart_edits` before building dashboard
 - Consider searching for relevant events first with entityTypes: ["EVENT", "CUSTOM_EVENT"]
 
 **Creating new charts:**
+
 - Prototype with `query_dataset` to verify data
 - Save in batches using `save_chart_edits` (more efficient)
 - Collect all chart IDs before creating dashboard
@@ -79,7 +83,7 @@ Include rich text blocks for:
 ## Layout Guidelines
 
 | Content Type     | Suggested Width | Suggested Height |
-|------------------|-----------------|------------------|
+| ---------------- | --------------- | ---------------- |
 | Headline metric  | 3-4 columns     | 375px            |
 | Trend chart      | 6-12 columns    | 500px            |
 | Comparison chart | 6 columns       | 500px            |
@@ -98,14 +102,13 @@ Include rich text blocks for:
 ## Common Issues
 
 **Query errors (500/400):**
+
 - Simplify: remove complex groupBy, reduce date ranges, avoid nested properties
 - Verify events/properties exist using search first
 - Use eventsSegmentation with groupBy instead of dataTableV2 for top N lists
 
 **No data returned:**
+
 - Check event names are exact matches (case-sensitive)
 - Verify date range covers when events were tracked
 - Confirm user segments aren't too restrictive
-
-
-

--- a/plugins/amplitude/skills/daily-brief/SKILL.md
+++ b/plugins/amplitude/skills/daily-brief/SKILL.md
@@ -31,7 +31,7 @@ Before scanning data, build context about who you're talking to and what they ca
 
 Gather data with a tight recency focus. The primary time window is **today (so far) and yesterday**. Use the trailing 7 days only as a comparison baseline to contextualize whether today's numbers are normal or unusual.
 
-**Important: Cast a wide net across the platform.** Don't limit yourself to the user's most-viewed dashboards. Use the official/top-viewed content discovered in Phase 1 to surface things the user *wouldn't* have seen on their own. But be efficient — batch calls and avoid redundant fetches.
+**Important: Cast a wide net across the platform.** Don't limit yourself to the user's most-viewed dashboards. Use the official/top-viewed content discovered in Phase 1 to surface things the user _wouldn't_ have seen on their own. But be efficient — batch calls and avoid redundant fetches.
 
 Run these in parallel where possible:
 
@@ -79,13 +79,13 @@ Transform your analysis into a concise, narrative briefing the user could forwar
 
 **Persona calibration:**
 
-| Persona     | Language Style                                         | Lead With                    |
-|-------------|--------------------------------------------------------|------------------------------|
-| Executive   | Strategic (revenue, competitive position, market share) | Business outcomes            |
-| PM          | Feature-oriented (conversion, activation, adoption)    | Experiment results, funnels  |
-| Analyst     | Methodological (p-values, significance, confidence)    | Statistical rigor, drill-downs |
-| Growth      | Channel-focused (LTV, retention cohort, acquisition)   | Acquisition and retention    |
-| Engineering | Technical (error rate, p95 latency, crash-free rate)   | Deployments, error spikes    |
+| Persona     | Language Style                                          | Lead With                      |
+| ----------- | ------------------------------------------------------- | ------------------------------ |
+| Executive   | Strategic (revenue, competitive position, market share) | Business outcomes              |
+| PM          | Feature-oriented (conversion, activation, adoption)     | Experiment results, funnels    |
+| Analyst     | Methodological (p-values, significance, confidence)     | Statistical rigor, drill-downs |
+| Growth      | Channel-focused (LTV, retention cohort, acquisition)    | Acquisition and retention      |
+| Engineering | Technical (error rate, p95 latency, crash-free rate)    | Deployments, error spikes      |
 
 **Writing standards:**
 
@@ -119,6 +119,7 @@ Before delivering, verify your work. Prefer reviewing data you already have over
 User says: "Give me my daily download"
 
 Actions:
+
 1. Detect persona from context (executive based on dashboard usage patterns)
 2. Discover official dashboards, top-viewed charts across the org, and recently modified content
 3. Query all discovered charts at daily granularity, rank by day-over-day magnitude of change
@@ -136,6 +137,7 @@ Example output (showing the narrative finding format):
 > **Enterprise trials jumped ~22% — the new landing page is converting.** Marketing's refreshed enterprise landing page went live Wednesday and trial starts hit ~480 yesterday, up from the ~390 trailing average. This is your strongest self-serve acquisition signal this quarter. Share with leadership and ask marketing to increase paid spend on this page while momentum holds. [chart](https://app.amplitude.com/...)
 >
 > **Today's priorities**
+>
 > 1. Break down the EMEA activation drop by device type and OS version to isolate whether the v4.2 onboarding regression is browser-specific or platform-wide.
 > 2. Set up an A/B test comparing the current v4.2 onboarding flow against a variant that removes the extra email verification step, targeting EMEA mobile users, with activation rate as the primary metric.
 >
@@ -146,6 +148,7 @@ Example output (showing the narrative finding format):
 User says: "Anything I should know about my product metrics today?"
 
 Actions:
+
 1. Identify PM persona and their key feature areas
 2. Scan org-wide charts and official dashboards alongside the user's own dashboards
 3. Query experiment results for changes in the last 48 hours
@@ -161,6 +164,7 @@ Example output (showing the narrative finding format):
 > **Search adoption stalled — the empty state is losing users.** Daily active search users dropped ~15% yesterday vs. the 5-day average, and the empty state page has a 60% bounce rate. Users who get zero results abandon the feature entirely. Add a fallback suggestions tooltip to the empty state this sprint. [chart](https://app.amplitude.com/...)
 >
 > **Today's priorities**
+>
 > 1. Ship Variant B of the checkout redesign to 100% — end the experiment and coordinate with eng to remove the feature flag.
 > 2. Build a cohort of users who hit zero search results this week and compare their 7-day retention against users who got results — quantify the business impact of the empty state before prioritizing the fix.
 >
@@ -171,6 +175,7 @@ Example output (showing the narrative finding format):
 User says: "How's the new onboarding flow performing?"
 
 Actions:
+
 1. Narrow the scan to onboarding-related metrics from the last 1-2 days
 2. Pull yesterday's activation funnel completion rates and compare to the prior 5 days
 3. Check feedback from the last 48 hours for onboarding-related themes
@@ -184,6 +189,7 @@ Example output:
 > **Onboarding completion slipped to 62% — email verification is the bottleneck.** Yesterday's completion rate dropped from the 68% trailing average, and today is pacing at ~60% through the first 6 hours. Step 3 (email verification) saw 18% abandonment vs. the 12% baseline — three user feedback submissions in the last 24 hours mention verification emails arriving late. Investigate the email delivery pipeline with eng today and consider adding a "resend" prompt at the 30-second mark. [chart](https://app.amplitude.com/...)
 >
 > **Today's priorities**
+>
 > 1. Segment the step 3 abandonment by email provider (Gmail, Outlook, corporate domains) to determine if verification delays are concentrated in a specific delivery path.
 > 2. Check if a recent deployment correlates with the timing of the drop — pull the deployment log from the last 72 hours and overlay it against the hourly abandonment rate at step 3.
 >
@@ -192,17 +198,21 @@ Example output:
 ## Troubleshooting
 
 ### Error: No dashboards found
+
 Cause: User may not have created dashboards, or the project has limited setup.
 Solution: Fall back to searching for any charts or events. Use `search` broadly and build context from whatever is available. Let the user know their setup is limited and suggest creating a key metrics dashboard.
 
 ### Error: Feedback API returns 400
+
 Cause: Called `get_feedback_insights` without first calling `get_feedback_sources`, or passed multiple values in the `types` array.
 Solution: ALWAYS call `get_feedback_sources` first. Only pass a single type value per call, or omit the types parameter entirely.
 
 ### Error: Metrics look flat / nothing interesting
+
 Cause: Yesterday and today look similar to the prior days — stability is a finding.
 Solution: Frame it positively: "Yesterday's metrics were in line with the prior 5 days — no fires to fight. Here's what shifted slightly that may be worth watching tomorrow..."
 
 ### Error: Too many findings, report is overwhelming
+
 Cause: Broad gathering surfaced too much signal.
 Solution: Ruthlessly prioritize. Cap at 5 findings maximum. Use severity scoring (impact × confidence × urgency) to rank. Demote lower-priority items to a "Background Context" appendix.

--- a/plugins/amplitude/skills/debug-replay/SKILL.md
+++ b/plugins/amplitude/skills/debug-replay/SKILL.md
@@ -19,6 +19,7 @@ This skill operates on three Amplitude Session Replay tools. Use them in this or
 3. **`Amplitude:get_session_replay_events`** — Decode a specific replay into an interaction timeline: navigations, clicks, inputs, scrolls. Requires `replay_id` from the tools above.
 
 Supporting tools used in this skill:
+
 - **`Amplitude:get_users`** — Look up users by email, user ID, or other identifiers.
 - **`Amplitude:get_events`** — Discover valid event names before filtering. Never guess event names.
 - **`Amplitude:get_properties`** — Discover properties available on an event for filtering.
@@ -53,6 +54,7 @@ If the report is vague (e.g., "something is broken in checkout"), ask one clarif
 Use `Amplitude:get_session_replays` to find sessions where the error occurred. Build filters based on what you know:
 
 **If you have a specific user:**
+
 ```json
 {
   "eventCountFilters": [
@@ -61,14 +63,26 @@ Use `Amplitude:get_session_replays` to find sessions where the error occurred. B
       "operator": "greater or equal",
       "event": {
         "event_type": "_all",
-        "filters": [{"group_type": "User", "subprop_key": "gp:email", "subprop_op": "is", "subprop_type": "user", "subprop_value": ["user@example.com"]}],
+        "filters": [
+          {
+            "group_type": "User",
+            "subprop_key": "gp:email",
+            "subprop_op": "is",
+            "subprop_type": "user",
+            "subprop_value": ["user@example.com"]
+          }
+        ],
         "group_by": []
       }
     },
     {
       "count": "1",
       "operator": "greater or equal",
-      "event": {"event_type": "[Amplitude] Error Logged", "filters": [], "group_by": []}
+      "event": {
+        "event_type": "[Amplitude] Error Logged",
+        "filters": [],
+        "group_by": []
+      }
     }
   ],
   "limit": 5
@@ -76,6 +90,7 @@ Use `Amplitude:get_session_replays` to find sessions where the error occurred. B
 ```
 
 **If you have an error message but no specific user:**
+
 ```json
 {
   "eventCountFilters": [
@@ -84,7 +99,15 @@ Use `Amplitude:get_session_replays` to find sessions where the error occurred. B
       "operator": "greater or equal",
       "event": {
         "event_type": "[Amplitude] Error Logged",
-        "filters": [{"group_type": "User", "subprop_key": "Error Message", "subprop_op": "contains", "subprop_type": "event", "subprop_value": ["TypeError"]}],
+        "filters": [
+          {
+            "group_type": "User",
+            "subprop_key": "Error Message",
+            "subprop_op": "contains",
+            "subprop_type": "event",
+            "subprop_value": ["TypeError"]
+          }
+        ],
         "group_by": []
       }
     }
@@ -103,6 +126,7 @@ For each session found in Step 3, call `Amplitude:get_session_replay_events` wit
 - Use `event_limit: 200` if analyzing 4+ sessions (to manage context)
 
 **What to capture from each timeline:**
+
 - Page navigations (URLs visited)
 - Clicks and inputs leading up to the error point
 - Any unusual patterns: rapid repeated clicks (rage clicks), long pauses, back-and-forth navigation
@@ -182,6 +206,7 @@ Structure the output as an engineering-ready bug report.
 User says: "Customer jane@acme.com says the export button doesn't work"
 
 Actions:
+
 1. Get context and confirm project
 2. Look up jane@acme.com via `get_users`
 3. Find her recent sessions with `get_session_replays` filtered to her email + any error events
@@ -194,6 +219,7 @@ Actions:
 User says: "TypeError errors doubled yesterday, can you get repro steps?"
 
 Actions:
+
 1. Get context, confirm `[Amplitude] Error Logged` exists
 2. Find sessions with TypeError in the last 48 hours via `get_session_replays`
 3. Extract timelines from 3-5 sessions
@@ -206,6 +232,7 @@ Actions:
 User says: "Users are having trouble with checkout"
 
 Actions:
+
 1. Ask one clarifying question: "Do you have a specific error event or user in mind, or should I look for any errors on checkout pages?"
 2. Search for error events on checkout-related pages
 3. Find sessions, extract timelines, identify friction patterns

--- a/plugins/amplitude/skills/diagnose-errors/SKILL.md
+++ b/plugins/amplitude/skills/diagnose-errors/SKILL.md
@@ -127,12 +127,12 @@ Structure the output as a triage report. Lead with what's most broken and action
 
 **Severity classification:**
 
-| Severity | Criteria |
-|----------|----------|
+| Severity     | Criteria                                                                                          |
+| ------------ | ------------------------------------------------------------------------------------------------- |
 | **Critical** | >5% of users affected, full causal chain (network → error → frustration), or blocking a core flow |
-| **High** | 1-5% of users, JS errors on key pages, or a clear regression from a deploy |
-| **Medium** | <1% of users, chronic errors, or errors on non-critical pages |
-| **Low** | Silent errors with no user-facing impact, or errors isolated to a single edge-case segment |
+| **High**     | 1-5% of users, JS errors on key pages, or a clear regression from a deploy                        |
+| **Medium**   | <1% of users, chronic errors, or errors on non-critical pages                                     |
+| **Low**      | Silent errors with no user-facing impact, or errors isolated to a single edge-case segment        |
 
 ---
 
@@ -152,6 +152,7 @@ Structure the output as a triage report. Lead with what's most broken and action
 User says: "What's broken right now?"
 
 Actions:
+
 1. Get context and project
 2. Query all three error events for the last 7 days — volume, trend, top sources
 3. Cross-reference by page to find causal chains
@@ -164,6 +165,7 @@ Actions:
 User says: "Errors seem up since yesterday's deploy"
 
 Actions:
+
 1. Get context and check `get_deployments` for what shipped
 2. Query `[Amplitude] Error Logged` comparing pre-deploy (7d before) vs post-deploy (last 24h)
 3. Identify new error messages that didn't exist before the deploy
@@ -176,6 +178,7 @@ Actions:
 User says: "We're seeing a lot of TypeErrors in the chart builder"
 
 Actions:
+
 1. Filter `[Amplitude] Error Logged` to `Error Type = TypeError` and `[Amplitude] Page Path` containing the chart builder
 2. Group by `Error Message` and `File Name` to find the specific errors
 3. Check `[Amplitude] Network Request` on the same pages for failing API calls

--- a/plugins/amplitude/skills/diff-intake/SKILL.md
+++ b/plugins/amplitude/skills/diff-intake/SKILL.md
@@ -23,16 +23,19 @@ precise — no prose around the YAML block.
 Fetch the list of changed files from the source, then categorize each one.
 
 ### Fetching changes
+
 - **PR URL**
-`gh pr view <number-or-url>`
-`gh pr view <pr-number> --json files --jq '.files[] | "\(.path)\t+\(.additions) -\(.deletions)\t"'`
+  `gh pr view <number-or-url>`
+  `gh pr view <pr-number> --json files --jq '.files[] | "\(.path)\t+\(.additions) -\(.deletions)\t"'`
 - **Branch comparison**
-`git log <main|master>..<branch>`
-`git diff --stat <main|master>..<branch>`
+  `git log <main|master>..<branch>`
+  `git diff --stat <main|master>..<branch>`
 - **Ambiguous mention** (PR number, branch name): infer the right form and fetch without asking unless auth fails.
 
 ### Categorize files
+
 Assign each file to a category based on its path:
+
 - **Core Logic**: application source (e.g. src/auth/login.py, database/models.ts)
 - **Generated**: anything with `generated` in its path
 - **Testing**: test files
@@ -43,18 +46,21 @@ Assign each file to a category based on its path:
 For each file, record: path, category, change type (Added / Modified / Deleted), and analytics likelihood (1–5).
 
 ## Step 2: Build the file summary map
+
 Read every single **Core Logic** file and create the file summary map.
 Only process and include **Core Logic** files.
 
 ### Fetching detailed diffs
+
 - **PR**
-`gh pr view <number-or-url> --json baseRefOid,headRefOid`
-Using the response, get a detailed diff
-`git diff <baseRefOid>...<headRefOid> -- <file1> <file2> <file_n>`
+  `gh pr view <number-or-url> --json baseRefOid,headRefOid`
+  Using the response, get a detailed diff
+  `git diff <baseRefOid>...<headRefOid> -- <file1> <file2> <file_n>`
 - **Branch comparison**
-`git diff main..feature/foo  -- <file1> <file2> <file_n>`
+  `git diff main..feature/foo  -- <file1> <file2> <file_n>`
 
 ### For each file, record
+
 - `summary` — 2-line summary of what changed
 - `stack` — frontend, backend, or shared
 
@@ -71,6 +77,7 @@ signals that downstream event discovery needs:
   likely instrumentation points over low-level helpers.
 
 For each surface, record:
+
 - `name` — component, route, page, hook, or surface name
 - `file` — repo-relative path
 - `change` — `added`, `modified`, or `deleted`
@@ -92,6 +99,7 @@ Infer the change type and analytics scope:
 | style / docs / test / build / ci / chore | None — skip analytics analysis                    |
 
 `analytics_scope` = highest implication present:
+
 - `none` — only no-impact types
 - `low` — only perf/refactor
 - `medium` — fix
@@ -100,29 +108,30 @@ Infer the change type and analytics scope:
 If `analytics_scope` is `none`, emit the brief and note that downstream skills are not needed.
 
 ## Step 4: Emit the YAML brief
+
 Output only the YAML block — no prose before or after. Follow the format exactly.
 List each file individually in file_summary_map (no globs).
 
 ```yaml
 change_brief:
   classification:
-    primary: feat           # dominant conventional commit type
-    types: [feat, fix]      # all types detected
-    analytics_scope: high   # none | low | medium | high
-    stack: frontend         # frontend | backend | fullstack
-  summary: "One sentence describing the overall change"
+    primary: feat # dominant conventional commit type
+    types: [feat, fix] # all types detected
+    analytics_scope: high # none | low | medium | high
+    stack: frontend # frontend | backend | fullstack
+  summary: 'One sentence describing the overall change'
   user_facing_changes:
-    - "Users can now upload an avatar with drag-and-drop and preview it before saving."
+    - 'Users can now upload an avatar with drag-and-drop and preview it before saving.'
   surfaces:
     components:
-      - name: "AvatarUpload"
-        file: "src/components/AvatarUpload.tsx"
+      - name: 'AvatarUpload'
+        file: 'src/components/AvatarUpload.tsx'
         change: modified
-  file_summary_map:         # each entry includes a layer field
-    - file: "src/components/AvatarUpload.tsx"
-      summary: "New component for avatar upload with drag-and-drop and preview"
-      layer: frontend       # frontend | backend | shared
-    - file: "src/api/upload.ts"
-      summary: "Upload endpoint handler, validates file type and persists to S3"
+  file_summary_map: # each entry includes a layer field
+    - file: 'src/components/AvatarUpload.tsx'
+      summary: 'New component for avatar upload with drag-and-drop and preview'
+      layer: frontend # frontend | backend | shared
+    - file: 'src/api/upload.ts'
+      summary: 'Upload endpoint handler, validates file type and persists to S3'
       layer: backend
 ```

--- a/plugins/amplitude/skills/discover-analytics-patterns/SKILL.md
+++ b/plugins/amplitude/skills/discover-analytics-patterns/SKILL.md
@@ -23,6 +23,7 @@ rest of the codebase. It should also tell downstream skills how event names and
 property names are typically written in code here.
 
 When determining naming conventions in this skill, use the following sources in strict order of preference:
+
 1. Customer directives in `.amplitude/instrumentation-agent-context.md` (and any files it references), if present — explicit conventions the customer wants followed, so they override everything below.
 2. Events and properties observed from the Amplitude MCP server
 3. Real tracking call sites in the codebase
@@ -85,35 +86,38 @@ raw SDK in a utility like `trackEvent()`, `track()`, or a React hook like
 that call into Amplitude internally. **Treat each wrapper as its own pattern,
 separate from the underlying SDK call**, even if it ultimately calls
 `amplitude.track()` underneath. Engineers who encounter the wrapper will use
-*it*, not the raw SDK — so it's the more important pattern to document.
+_it_, not the raw SDK — so it's the more important pattern to document.
 
 To find wrappers: search for files that import the Amplitude SDK, then check
 whether any of those files export a function or hook that other parts of the
 codebase import and use for tracking.
 
 Exclude test files (`.test.`, `.spec.`, `__tests__`) and mock files unless they
-are the *only* place a pattern appears.
+are the _only_ place a pattern appears.
 
 ---
 
 ## Step 2: Group by pattern
 
 Two call sites use the **same pattern** if they share the same:
+
 - Library/SDK/function being called
 - Method name
 - Argument structure (even if the event name or properties differ)
 
 For example, these are the **same** pattern:
+
 ```ts
-amplitude.track('Page Viewed', { page: '/home' })
-amplitude.track('Button Clicked', { label: 'signup' })
+amplitude.track('Page Viewed', { page: '/home' });
+amplitude.track('Button Clicked', { label: 'signup' });
 ```
 
 But these are **different** patterns — always keep them separate:
+
 ```ts
-amplitude.track('Page Viewed', { page: '/home' })   // direct SDK — one pattern
-ampli.pageViewed({ page: '/home' })                  // Ampli typed method — different pattern
-trackEvent('Page Viewed', { page: '/home' })         // custom wrapper — also a separate pattern
+amplitude.track('Page Viewed', { page: '/home' }); // direct SDK — one pattern
+ampli.pageViewed({ page: '/home' }); // Ampli typed method — different pattern
+trackEvent('Page Viewed', { page: '/home' }); // custom wrapper — also a separate pattern
 ```
 
 A custom wrapper is always its own pattern, even if it delegates to the SDK
@@ -175,6 +179,7 @@ Then, for each unique pattern, output a section in this format:
 codebase (e.g., "Used throughout the React frontend for user action tracking").
 
 **Example** (generalized):
+
 ```<language>
 // show the import(s) needed
 import { amplitude } from '@/lib/analytics'
@@ -187,6 +192,7 @@ amplitude.track('Event Name', {
 ```
 
 **Relevant paths**:
+
 - `src/path/to/file.ts`
 - `src/another/file.tsx`
 

--- a/plugins/amplitude/skills/discover-event-surfaces/SKILL.md
+++ b/plugins/amplitude/skills/discover-event-surfaces/SKILL.md
@@ -124,7 +124,7 @@ Start from the funnel hypothesis. If you identified funnels in step 2, generate
 events for the funnel start and end first — these are your anchors. Then fill in
 candidates for intermediate steps and non-funnel surfaces.
 
-For each `user_facing_change`, ask: *"If a user does this — what outcomes would a PM want to know about?"*
+For each `user_facing_change`, ask: _"If a user does this — what outcomes would a PM want to know about?"_
 
 Generate from four categories (ordered by priority):
 
@@ -157,7 +157,7 @@ If you drop a candidate because it already exists, note it in a
 Every candidate must pass all three:
 
 1. **Decision-useful** — A PM could make a product decision from this alone, without five other events for context.
-2. **Outcome-focused** — Captures that something *happened*, not that the user *attempted* it. `Property Extracted` > `Extract Button Clicked`. Prefer confirmed outcomes; form submissions are acceptable when no server confirmation exists.
+2. **Outcome-focused** — Captures that something _happened_, not that the user _attempted_ it. `Property Extracted` > `Extract Button Clicked`. Prefer confirmed outcomes; form submissions are acceptable when no server confirmation exists.
 3. **Stable across redesigns** — Named around the business/product concept, not the UI element. If renaming a modal would make the event name stale, it's too coupled.
 
 **Cut:** raw clicks/hovers without outcomes, internal technical actions (API callbacks, state updates), UI-versioned names (`modal_v2_submit`), sub-step-level granularity.
@@ -187,20 +187,20 @@ names (PropertyItem, ActionStore).
 For each candidate, use `file_summary_map` and `surfaces.components` to identify:
 
 - **`file`** — the source file where the tracking call belongs. Prefer the file closest to where the outcome is confirmed (not where the user initiates the action). Usually a component file from `surfaces.components` or a hook where an async operation resolves.
-- **`instrumentation`** — 1-2 sentences: *when* it fires (after what condition/callback/state transition) and *how* it's wired (which function/handler to place it in). Reference actual function names from file summaries so an engineer can find the right line.
+- **`instrumentation`** — 1-2 sentences: _when_ it fires (after what condition/callback/state transition) and _how_ it's wired (which function/handler to place it in). Reference actual function names from file summaries so an engineer can find the right line.
 
 ## 8. Deepen understanding, then prioritize
 
 For each candidate, first work through these two fields — they force you to think concretely about the event's value before scoring it:
 
-- **`analysis_recipe`** — Describe the specific chart, funnel, or query an analyst would build with this event. Be concrete: mention the visualization type, segmentation dimensions, and any other events to combine with. e.g., *"Weekly funnel: Panel Opened → Extract Type Selected → Property Extracted, segmented by extractType. Alert if completion rate drops below 50%."*
-- **`stakeholder_narrative`** — Write a sentence that a PM could drop into a quarterly review or board deck, using this event's data. Imagine the metric already exists and write the story it tells. e.g., *"68% of users who try extraction complete it on the first attempt, up from 45% last quarter."* If you can't imagine a compelling slide sentence, the event probably isn't worth instrumenting.
+- **`analysis_recipe`** — Describe the specific chart, funnel, or query an analyst would build with this event. Be concrete: mention the visualization type, segmentation dimensions, and any other events to combine with. e.g., _"Weekly funnel: Panel Opened → Extract Type Selected → Property Extracted, segmented by extractType. Alert if completion rate drops below 50%."_
+- **`stakeholder_narrative`** — Write a sentence that a PM could drop into a quarterly review or board deck, using this event's data. Imagine the metric already exists and write the story it tells. e.g., _"68% of users who try extraction complete it on the first attempt, up from 45% last quarter."_ If you can't imagine a compelling slide sentence, the event probably isn't worth instrumenting.
 
 Now, with that context fresh, assign a **priority**:
 
 | Priority         | Meaning                                                                                                            | Guidance                                                                                                                         |
 | ---------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| **3** (critical) | You would block a release if this event were missing. It answers a question the team *will* ask in the first week. | Reserve for events that directly measure whether the feature succeeded or failed. Most changes produce only 1-2 critical events. |
+| **3** (critical) | You would block a release if this event were missing. It answers a question the team _will_ ask in the first week. | Reserve for events that directly measure whether the feature succeeded or failed. Most changes produce only 1-2 critical events. |
 | **2** (useful)   | Adds real analytical value but the feature can ship without it. Worth adding if instrumentation cost is low.       | Segmentation dimensions, secondary workflows, configuration choices.                                                             |
 | **1** (optional) | Nice-to-have. Only instrument if the team has bandwidth and a specific hypothesis to test.                         | Edge-case failures, exploratory engagement signals, discoverability metrics.                                                     |
 
@@ -208,7 +208,7 @@ Now, with that context fresh, assign a **priority**:
 
 **Funnel start and funnel end events are always critical (priority 3).** Without the bookends, you can't measure conversion rate — the single most important metric for any funnel. These two events are non-negotiable regardless of funnel length or complexity.
 
-To decide how many *intermediate* funnel events to mark critical, gauge the length and complexity of the funnel:
+To decide how many _intermediate_ funnel events to mark critical, gauge the length and complexity of the funnel:
 
 - **Short process (2-3 steps, single page):** The start and end events are enough. Don't instrument every micro-step in a simple flow.
 - **Medium process (3-5 steps, possibly spanning pages):** Add one intermediate event at the most likely drop-off point — typically where the user commits effort (fills a form, makes a key selection, uploads a file).
@@ -224,54 +224,54 @@ Output only the YAML block — no surrounding prose.
 
 ```yaml
 event_candidates:
-  source_summary: "<from change_brief.summary>"
-  analytics_scope: "<from change_brief.classification.analytics_scope>"
-  event_naming_convention: "<from MCP if clear, otherwise codebase instrumentation, otherwise taxonomy skill>"
-  property_naming_convention: "<from MCP if clear, otherwise codebase instrumentation, otherwise taxonomy skill>"
+  source_summary: '<from change_brief.summary>'
+  analytics_scope: '<from change_brief.classification.analytics_scope>'
+  event_naming_convention: '<from MCP if clear, otherwise codebase instrumentation, otherwise taxonomy skill>'
+  property_naming_convention: '<from MCP if clear, otherwise codebase instrumentation, otherwise taxonomy skill>'
 
-  already_tracked:                         # omit if no duplicates found
-    - existing_event: "Subscription Upgraded"
-      candidate_dropped: "Plan Upgraded"
-      reason: "Same action — existing event already tracks plan/subscription upgrades."
+  already_tracked: # omit if no duplicates found
+    - existing_event: 'Subscription Upgraded'
+      candidate_dropped: 'Plan Upgraded'
+      reason: 'Same action — existing event already tracks plan/subscription upgrades.'
 
-  funnels:                                 # omit if no multi-step flows found
-    - name: "Descriptive funnel name"
+  funnels: # omit if no multi-step flows found
+    - name: 'Descriptive funnel name'
       steps:
-        - step: "Step description"
-          file: "src/components/Foo.tsx"
-          function: "handleOpen"
-          role: start                      # start | intermediate | end
-        - step: "Next step"
-          file: "src/components/Bar.tsx"
-          function: "onSubmit"
+        - step: 'Step description'
+          file: 'src/components/Foo.tsx'
+          function: 'handleOpen'
+          role: start # start | intermediate | end
+        - step: 'Next step'
+          file: 'src/components/Bar.tsx'
+          function: 'onSubmit'
           role: intermediate
-        - step: "Final step"
-          file: "src/hooks/useSave.ts"
-          function: "onSuccess"
+        - step: 'Final step'
+          file: 'src/hooks/useSave.ts'
+          function: 'onSuccess'
           role: end
 
   candidates:
-    - name: "Event Name Here"
-      category: feature_success          # business_outcome | user_journey | feature_success | friction_failure
-      rationale: "What PM question this answers."
-      analysis_recipe: "Weekly trend of completions; funnel from Panel Opened → Extract Type Selected → Event Name, segmented by extract type."
-      stakeholder_narrative: "Feature X adoption reached 40% of active users within two weeks of launch, exceeding our 25% target."
-      priority: 3                        # 3 = critical, 2 = useful, 1 = optional
-      funnel: "Funnel name"             # which funnel this belongs to, if any
-      funnel_role: start                 # start | intermediate | end — omit if not part of a funnel
-      surface: "ComponentName"           # from surfaces.components
-      file: "src/components/Foo/Bar.tsx"
-      instrumentation: "Fire after the async save resolves, inside onSuccess of useExtract(). Pass result status."
+    - name: 'Event Name Here'
+      category: feature_success # business_outcome | user_journey | feature_success | friction_failure
+      rationale: 'What PM question this answers.'
+      analysis_recipe: 'Weekly trend of completions; funnel from Panel Opened → Extract Type Selected → Event Name, segmented by extract type.'
+      stakeholder_narrative: 'Feature X adoption reached 40% of active users within two weeks of launch, exceeding our 25% target.'
+      priority: 3 # 3 = critical, 2 = useful, 1 = optional
+      funnel: 'Funnel name' # which funnel this belongs to, if any
+      funnel_role: start # start | intermediate | end — omit if not part of a funnel
+      surface: 'ComponentName' # from surfaces.components
+      file: 'src/components/Foo/Bar.tsx'
+      instrumentation: 'Fire after the async save resolves, inside onSuccess of useExtract(). Pass result status.'
 
-    - name: "Another Event"
+    - name: 'Another Event'
       category: user_journey
-      rationale: "..."
-      analysis_recipe: "..."
-      stakeholder_narrative: "..."
+      rationale: '...'
+      analysis_recipe: '...'
+      stakeholder_narrative: '...'
       priority: 2
-      surface: "..."
-      file: "..."
-      instrumentation: "..."
+      surface: '...'
+      file: '...'
+      instrumentation: '...'
 ```
 
 Order: higher categories first, most impactful within each category first.
@@ -281,9 +281,10 @@ Order: higher categories first, most impactful within each category first.
 ## Example
 
 **Input excerpt:**
+
 ```yaml
 user_facing_changes:
-  - "Users can now select Extract Type (Text or Attribute) in the PropertyItem panel"
+  - 'Users can now select Extract Type (Text or Attribute) in the PropertyItem panel'
 surfaces:
   components:
     - name: PropertyItem
@@ -291,36 +292,37 @@ surfaces:
 ```
 
 **Good candidates:**
+
 ```yaml
-- name: "Property Extracted"
+- name: 'Property Extracted'
   category: feature_success
-  rationale: "Core adoption signal — tells PMs whether the extract workflow completes."
-  analysis_recipe: "Weekly funnel: Panel Opened → Extract Type Selected → Property Extracted, segmented by extractType. Alert if completion rate drops below 50%."
-  stakeholder_narrative: "72% of users who open a property panel complete an extraction, up from 0% before this release — validating the new extract workflow."
+  rationale: 'Core adoption signal — tells PMs whether the extract workflow completes.'
+  analysis_recipe: 'Weekly funnel: Panel Opened → Extract Type Selected → Property Extracted, segmented by extractType. Alert if completion rate drops below 50%.'
+  stakeholder_narrative: '72% of users who open a property panel complete an extraction, up from 0% before this release — validating the new extract workflow.'
   priority: 3
-  surface: "PropertyItem"
-  file: "src/components/PropertiesPanel/PropertyItem.tsx"
-  instrumentation: "Fire after extract resolves successfully in onSuccess handler. Include extractType (TEXT or ATTRIBUTE)."
+  surface: 'PropertyItem'
+  file: 'src/components/PropertiesPanel/PropertyItem.tsx'
+  instrumentation: 'Fire after extract resolves successfully in onSuccess handler. Include extractType (TEXT or ATTRIBUTE).'
 
-- name: "Extract Type Selected"
+- name: 'Extract Type Selected'
   category: feature_success
-  rationale: "Shows which mode users prefer — informs investment in Attribute mode."
-  analysis_recipe: "Pie chart of Text vs Attribute selections over 30 days. Combine with Property Extracted to get per-mode completion rate."
-  stakeholder_narrative: "85% of extractions use Text mode vs 15% Attribute — we should double down on Text UX before expanding Attribute capabilities."
+  rationale: 'Shows which mode users prefer — informs investment in Attribute mode.'
+  analysis_recipe: 'Pie chart of Text vs Attribute selections over 30 days. Combine with Property Extracted to get per-mode completion rate.'
+  stakeholder_narrative: '85% of extractions use Text mode vs 15% Attribute — we should double down on Text UX before expanding Attribute capabilities.'
   priority: 2
-  surface: "PropertyItem"
-  file: "src/components/PropertiesPanel/PropertyItem.tsx"
-  instrumentation: "Fire in onChange of Extract Type select, passing new value."
+  surface: 'PropertyItem'
+  file: 'src/components/PropertiesPanel/PropertyItem.tsx'
+  instrumentation: 'Fire in onChange of Extract Type select, passing new value.'
 
-- name: "Property Extraction Failed"
+- name: 'Property Extraction Failed'
   category: friction_failure
-  rationale: "Surfaces where the extract workflow breaks for reliability prioritization."
-  analysis_recipe: "Error rate chart: Property Extraction Failed / (Property Extracted + Property Extraction Failed), grouped by error reason. Alert on spikes."
-  stakeholder_narrative: "Extraction failure rate dropped from 12% to 3% after the v2 error-handling patch — users are hitting fewer dead ends."
+  rationale: 'Surfaces where the extract workflow breaks for reliability prioritization.'
+  analysis_recipe: 'Error rate chart: Property Extraction Failed / (Property Extracted + Property Extraction Failed), grouped by error reason. Alert on spikes.'
+  stakeholder_narrative: 'Extraction failure rate dropped from 12% to 3% after the v2 error-handling patch — users are hitting fewer dead ends.'
   priority: 2
-  surface: "PropertyItem"
-  file: "src/components/PropertiesPanel/PropertyItem.tsx"
-  instrumentation: "Fire in catch/onError of extract call. Include error reason if available."
+  surface: 'PropertyItem'
+  file: 'src/components/PropertiesPanel/PropertyItem.tsx'
+  instrumentation: 'Fire in catch/onError of extract call. Include error reason if available.'
 ```
 
 **Do NOT include:** `Extract Type Dropdown Opened` (click, no outcome), `PropertyItem State Updated` (internal), `Attribute Input Focused` (too granular).

--- a/plugins/amplitude/skills/discover-opportunities/SKILL.md
+++ b/plugins/amplitude/skills/discover-opportunities/SKILL.md
@@ -44,6 +44,7 @@ Run these in parallel where possible. Budget: 10-15 tool calls total for this ph
 #### 2b. Funnel Analysis
 
 For each funnel chart discovered, examine:
+
 - Overall conversion rate and trend
 - The step with the largest absolute drop-off
 - Whether drop-off is getting worse or better over time
@@ -70,6 +71,7 @@ If no funnel charts exist but the user mentioned a flow, use `query_dataset` to 
 #### 2e. Session Replays
 
 If investigating a specific flow or drop-off:
+
 1. Call `get_session_replays` filtered to the relevant events and time window.
 2. Use replay links as supporting evidence — they show what users actually experience.
 
@@ -115,21 +117,23 @@ enhancement → before vs. after; new feature → user journey.
 
 #### RICE Scoring
 
-| Dimension      | Definition                                              | Scale          |
-|----------------|---------------------------------------------------------|----------------|
-| **Reach**      | Number of users/events affected per quarter             | Absolute count |
-| **Impact**     | Expected effect per user on the target metric           | 0.25–3         |
-| **Confidence** | How confident you are in the estimates                  | 0–100%         |
-| **Effort**     | Implementation effort                                   | Person-months  |
+| Dimension      | Definition                                    | Scale          |
+| -------------- | --------------------------------------------- | -------------- |
+| **Reach**      | Number of users/events affected per quarter   | Absolute count |
+| **Impact**     | Expected effect per user on the target metric | 0.25–3         |
+| **Confidence** | How confident you are in the estimates        | 0–100%         |
+| **Effort**     | Implementation effort                         | Person-months  |
 
 **Score = (Reach x Impact x Confidence%) / Effort** — higher = better ROI.
 
 Reach guidelines:
+
 - Estimate the number of users or events affected per quarter.
 - Use analytics data to ground this: DAU/WAU/MAU counts, funnel volumes, segment sizes from existing cohorts.
 - State the source: "~12,000 users/quarter hit this flow based on [chart]."
 
 Impact anchors (expected effect per user):
+
 - 0.25 (Minimal): Cosmetic polish, barely noticeable change
 - 0.5 (Low): Minor friction reduction, small quality-of-life improvement
 - 1 (Medium): Measurable lift on a key metric
@@ -137,12 +141,14 @@ Impact anchors (expected effect per user):
 - 3 (Massive): Removes a blocking failure, unlocks a workflow entirely
 
 Confidence anchors:
+
 - 100%: Strong multi-source evidence — quantified funnel data, A/B results, corroborating feedback
 - 80%: Analytics + feedback + replays all pointing the same direction
 - 50%: Analytics OR validated feedback, not both — reasonable hypothesis
 - 20%: Anecdotal signal only — gut feel backed by a few data points
 
 Effort guidelines:
+
 - Estimate in person-months, accounting for coding agents handling implementation.
   Agents compress pure coding time but don't eliminate review, testing, rollout,
   or cross-team coordination. Discount the coding portion, keep the rest.
@@ -182,6 +188,7 @@ Structure the final output as:
 6. **Follow-on prompt**: End with a question about what to dig into next.
 
 **Writing standards:**
+
 - Narrative over structure. Write like a product memo, not a database record.
 - Numbers are evidence, not the story. Lead with the insight.
 - Approximate: "~42%" not "42.37%".
@@ -197,6 +204,7 @@ Structure the final output as:
 User says: "Find me the biggest product opportunities right now"
 
 Actions:
+
 1. Get context and discover the org's most important dashboards, charts, and experiments
 2. Query all discovered charts at daily granularity over 30 days, rank by trend magnitude
 3. Analyze funnels for conversion drop-offs
@@ -209,6 +217,7 @@ Actions:
 User says: "Where are we losing users in onboarding?"
 
 Actions:
+
 1. Search for onboarding-related charts, dashboards, and cohorts
 2. Query the onboarding funnel and break down by segment (platform, plan, new vs. returning)
 3. Pull feedback filtered to onboarding-related complaints and pain points
@@ -221,6 +230,7 @@ Actions:
 User says: "We launched feature X last week — what opportunities do you see?"
 
 Actions:
+
 1. Search for charts and dashboards tracking feature X
 2. Query adoption metrics (daily active users, activation rate, retention)
 3. Compare pre-launch vs. post-launch baselines
@@ -231,13 +241,17 @@ Actions:
 ## Troubleshooting
 
 ### No dashboards or charts found
+
 Fall back to `search` with broad queries related to the user's product area. Use `query_dataset` to build ad-hoc charts from raw events. Suggest the user create a key metrics dashboard.
 
 ### Feedback API returns errors
+
 Always call `get_feedback_sources` before `get_feedback_insights`. If no sources are configured, skip feedback and note it as a gap in the report — recommend the user connect a feedback source.
 
 ### Everything looks healthy — no anomalies
+
 Stability is a finding. Focus on: stalled experiments that need decisions, features with flat adoption that could grow, feedback themes that haven't been addressed, and conversion rates that are "fine" but benchmarkably low.
 
 ### Too many findings
+
 Cap at 7 full opportunities. Rank by RICE score and demote everything below the cutoff to "Emerging Signals." Merge findings that share a root cause.

--- a/plugins/amplitude/skills/instrument-events/SKILL.md
+++ b/plugins/amplitude/skills/instrument-events/SKILL.md
@@ -73,9 +73,13 @@ and what it's for, so they can improve this and future runs:
 >
 > ```markdown
 > # Instrumentation context
+>
 > ## Conventions
+>
 > - Event names: Title Case, object-action ("Checkout Completed")
+>
 > ## Reference files
+>
 > - docs/analytics/taxonomy.md
 > ```
 >
@@ -111,9 +115,9 @@ step 7 depends on it.
   >
   > ```yaml
   > rules:
-  >   - pattern: "**"          # default project, all paths
+  >   - pattern: '**' # default project, all paths
   >     app_ids: [YOUR_APP_ID]
-  >   - pattern: "src/web/**"  # override a sub-tree
+  >   - pattern: 'src/web/**' # override a sub-tree
   >     app_ids: [YOUR_WEB_APP_ID]
   > ```
 
@@ -128,17 +132,18 @@ step 7 depends on it.
   If they pick **single-app (3)**: infer `appId` from what they gave you, set
   `appIdConfidence: "low"`, and carry that flag — steps 6 and 7 depend on it.
   Skip the rest of this section.
+
 - **If it exists:** parse its `rules`. Each rule maps a path pattern to one or
   more app-ids:
 
 ```yaml
 rules:
-  - pattern: "**"              # catch-all (also `*` or `/`) → the default app_id
+  - pattern: '**' # catch-all (also `*` or `/`) → the default app_id
     app_ids: [4567]
-  - pattern: "src/web/**"      # this directory and everything under it
+  - pattern: 'src/web/**' # this directory and everything under it
     app_ids: [1234]
-  - pattern: "packages/shared/**"
-    app_ids: [1234, 4567]      # shared code → event added to plan in BOTH projects
+  - pattern: 'packages/shared/**'
+    app_ids: [1234, 4567] # shared code → event added to plan in BOTH projects
 ```
 
 The **default app_id** is the one matched by the catch-all rule (`**`, `*`, or `/`).
@@ -171,7 +176,7 @@ Work through each priority-3 event one at a time:
 
 The event candidate has a `file` field pointing to where instrumentation likely
 belongs. Read that file completely. Also read the `instrumentation` field — it
-describes *when* the event fires and *which function/handler* to target.
+describes _when_ the event fires and _which function/handler_ to target.
 
 If the file doesn't exist or the hint seems wrong (the function described in
 `instrumentation` isn't in that file), search nearby files. The hint is a
@@ -307,6 +312,7 @@ too:
 
 > ⚠️ **X event(s) won't be added to Amplitude yet** because their app ID
 > couldn't be confirmed. To fix this:
+>
 > - Add `.amplitude/instrumentation-agent.yaml` mapping the relevant paths to
 >   app IDs (see step 3 — I can scan the repo and propose one for you), **or**
 > - Tell me the app ID for these paths directly.
@@ -325,7 +331,6 @@ Ask if they want to adjust anything before an engineer implements it.
 - **Scope is sacred.** Only use variables available at the insertion point. Don't propose refactors to thread data through — that's a separate PR.
 - **Critical means critical.** This skill only handles priority 3. If the user wants priority 2 events, they should say so explicitly and you can include them.
 
-
 ## 7. Update Tracking plan in Amplitude through MCP
 
 Add to plan **only** `appIdConfidence: "high"` events. Never write back a `med` or
@@ -333,12 +338,14 @@ Add to plan **only** `appIdConfidence: "high"` events. Never write back a `med` 
 first.
 
 Before adding to plan, confirm with the user what will be created. List:
+
 - Each event with `appIdConfidence: "high"` and the project(s) it will be
   added to plan in
 - Any events being skipped due to `med`/`low` confidence, and why
 
 Get explicit confirmation, then for each high-confidence event add it to plan in
 **every** project it routes to:
+
 - use the `create_events` tool to create the event in that project (`app_id`)
 - use the `create_properties` tool to create the properties attached to the
   correct event in that same project

--- a/plugins/amplitude/skills/investigate-ai-session/SKILL.md
+++ b/plugins/amplitude/skills/investigate-ai-session/SKILL.md
@@ -13,6 +13,7 @@ You investigate specific AI agent sessions or failure patterns to determine root
 ### Step 1: Determine Investigation Scope
 
 The user will provide one of:
+
 - **A specific session ID** → go directly to Step 2
 - **A failure pattern** (e.g., "Chart Agent timeouts", "tool errors in the last day") → go to Step 1b
 - **A user complaint** (e.g., "user X said the agent didn't work") → go to Step 1c
@@ -120,6 +121,7 @@ Structure the output as a root cause analysis.
 User says: "What happened in session abc-123?"
 
 Actions:
+
 1. Get detailed session data, conversation, and spans for abc-123 (3 parallel calls)
 2. Read the conversation to understand what the user wanted
 3. Trace the spans to find where the execution failed
@@ -131,6 +133,7 @@ Actions:
 User says: "Why are Chart Agent sessions failing?"
 
 Actions:
+
 1. Get AI schema to confirm "Chart Agent" is a valid agent name
 2. Query recent Chart Agent failures (hasTaskFailure: true, agentNames: ["Chart Agent"])
 3. Pick the 3 most recent failures and deep-dive into each
@@ -143,6 +146,7 @@ Actions:
 User says: "A customer said our AI gave them wrong data yesterday"
 
 Actions:
+
 1. Ask for the customer's email or user ID
 2. Search for their sessions from yesterday
 3. Deep-dive into the relevant session(s)
@@ -153,10 +157,13 @@ Actions:
 ## Troubleshooting
 
 ### Session ID not found
+
 The session may be from a different project, or outside the data retention window. Ask the user to confirm the project and check if the session ID is correct.
 
 ### Spans not available for a session
+
 Span-level data requires OpenTelemetry-compatible tracing in the AI agent. Report what's available from the session and conversation level and note that span data would help narrow the root cause.
 
 ### Too many failing sessions to investigate
+
 Don't try to investigate more than 5 sessions in detail. Instead, use `groupBy` on `query_agent_analytics_sessions` to find the common pattern, then deep-dive into 2-3 representative examples.

--- a/plugins/amplitude/skills/monitor-ai-quality/SKILL.md
+++ b/plugins/amplitude/skills/monitor-ai-quality/SKILL.md
@@ -103,15 +103,16 @@ Structure the output for quick scanning and action.
 
 **Status thresholds:**
 
-| Metric | Good | Warning | Critical |
-|--------|------|---------|----------|
-| Quality Score | >0.7 | 0.4-0.7 | <0.4 |
-| Success Rate | >80% | 60-80% | <60% |
-| Sentiment | >0.6 | 0.5-0.6 | <0.5 |
-| Task Failure Rate | <10% | 10-25% | >25% |
-| P90 Latency | <10s | 10-30s | >30s |
+| Metric            | Good | Warning | Critical |
+| ----------------- | ---- | ------- | -------- |
+| Quality Score     | >0.7 | 0.4-0.7 | <0.4     |
+| Success Rate      | >80% | 60-80%  | <60%     |
+| Sentiment         | >0.6 | 0.5-0.6 | <0.5     |
+| Task Failure Rate | <10% | 10-25%  | >25%     |
+| P90 Latency       | <10s | 10-30s  | >30s     |
 
 **Writing standards:**
+
 - Lead with the insight, not the data point
 - Use approximate numbers ("~85%" not "84.7%")
 - Always state the time window
@@ -125,6 +126,7 @@ Structure the output for quick scanning and action.
 User says: "How are our AI agents doing?"
 
 Actions:
+
 1. Get context and AI schema
 2. Query analytics overview + time series + recent failures + frustrated users (4 parallel calls)
 3. Identify the agent with the worst quality score and the top error category
@@ -136,6 +138,7 @@ Actions:
 User says: "How's the Chart Agent performing this week?"
 
 Actions:
+
 1. Get context, then query analytics with `agentNames: ["Chart Agent"]`
 2. Query time series for that agent specifically
 3. Pull recent failures and low-quality sessions for that agent
@@ -146,6 +149,7 @@ Actions:
 User says: "Our AI costs seem high — what's going on?"
 
 Actions:
+
 1. Get context, query analytics with `metrics: ["cost", "cost_by_model", "agent_stats", "cost_timeseries"]`
 2. Identify which agents and models drive the most cost
 3. Query spans grouped by model to see token usage patterns
@@ -155,10 +159,13 @@ Actions:
 ## Troubleshooting
 
 ### No AI session data
+
 The project may not have AI analytics instrumented. Report this clearly and suggest the user check their AI agent SDK integration.
 
 ### Very few sessions
+
 If <50 sessions in the window, note that sample sizes are small and findings may not be statistically meaningful. Extend the time window if possible.
 
 ### All metrics look healthy
+
 Frame it positively: "Your AI agents are performing well across the board. Here's the summary and a few minor things to watch." Still surface the lowest-performing areas even if they're above threshold.

--- a/plugins/amplitude/skills/monitor-chart-alerts/SKILL.md
+++ b/plugins/amplitude/skills/monitor-chart-alerts/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: monitor-chart-alerts
+description: Reads and manages Amplitude chart alert monitors with use_amplitude_chart_monitors — recent alert firings, monitor configuration and subscribers, the config audit trail, subscribing or unsubscribing, and enabling or disabling a monitor. Use when asked what alerted, who is subscribed, why a monitor changed, or to turn one on or off.
+x-amp-flags: [mcp-consolidate-charts]
+---
+
+# Monitor Chart Alerts
+
+`use_amplitude_chart_monitors` is one tool with six actions on `action`. The
+older `get_chart_alerts` and `get_chart_monitor` tools are folded into it.
+
+## Actions
+
+| `action` | Answers | Requires |
+|---|---|---|
+| `get_alerts` (default) | What has alerted recently? | `projectId` or `chartId` |
+| `get_config` | What is the monitor set to, and who is subscribed? | `chartId` |
+| `history` | Who changed this monitor, and when? | `monitorId` or `chartId` |
+| `subscribe` / `unsubscribe` | Add or remove a recipient | `monitorId`, `deliveryMethod` |
+| `update` | Turn a monitor on or off | `monitorId`, `enabled` |
+
+## The two mistakes that produce almost every failure
+
+**1. Not every chart has a monitor.** A chart with no alerting configured is
+the normal case, not an error state. Calling `get_config` on an arbitrary chart
+id returns `Chart monitor not found` far more often than it returns a config —
+this is the single most common failure on this tool. Start from
+`get_alerts` for the project to see which charts actually alert, and only then
+ask for a specific chart's config. If `get_config` says not found, report that
+the chart has no monitor and stop; do not retry with a different id spelling
+or fall back to the deprecated tools.
+
+**2. Chart monitors are a licensed feature.** `Chart monitors feature is not
+enabled` means the org does not have alerting, so no action on this tool can
+succeed. Say so plainly and move on — retrying, switching action, or trying
+`get_chart_alerts` will all return the same thing.
+
+## Resolving a monitorId
+
+`subscribe`, `unsubscribe`, and `update` need a `monitorId`, and there is no
+way to guess one. Always resolve it first:
+
+```jsonc
+// 1. chartId → monitor config, which carries the monitorId and subscribers
+{ "action": "get_config", "chartId": "abc123" }
+
+// 2. act on the monitorId that came back
+{ "action": "update", "monitorId": "mon_123", "enabled": false }
+```
+
+`history` is the exception — it accepts `chartId` directly and resolves the
+monitor itself.
+
+## Alerts vs history
+
+These sound alike and get swapped. `get_alerts` returns **anomalies the
+monitor fired on** — the data crossed a threshold. `history` returns **changes
+to the monitor's own configuration** — someone edited the threshold, or
+enabled it. "Why did we get paged?" is `get_alerts`; "who turned this off?" is
+`history`.
+
+## Scoping
+
+For `get_alerts`, `projectId` is optional only when you have access to exactly
+one project; with several, pass it explicitly or the call cannot be resolved.
+Add `chartId` to narrow to a single chart, `limit` (1–100, default 20) to cap
+the volume, and the unseen-only filter when triaging what is new.
+
+## Subscriptions
+
+Email subscriptions apply to **the current user only** — you cannot subscribe a
+colleague by email through this tool. For a Slack or Teams destination pass
+`deliveryChannel`, plus `deliveryWorkspaceId` when the org has more than one
+workspace connected.
+
+## Not this tool
+
+Reading the chart's actual data is `get_amplitude_charts` with
+`include: 'data'`, or `query_amplitude_data`. This tool only covers the
+alerting layer on top of a chart.

--- a/plugins/amplitude/skills/monitor-experiments-consolidated/SKILL.md
+++ b/plugins/amplitude/skills/monitor-experiments-consolidated/SKILL.md
@@ -37,6 +37,7 @@ Do NOT duplicate information between the summary table and the details. The summ
 
 1. Call `Amplitude:get_amplitude_context`. If multiple projects, ask which to monitor.
 2. Search for experiments:
+
 ```
 Amplitude:search({
   entityTypes: ["EXPERIMENT"],
@@ -47,6 +48,7 @@ Amplitude:search({
   limitPerQuery: 50
 })
 ```
+
 3. **Filtering rules — include experiments that are:**
    - **Running and not stale:** Any experiment in a running state that is NOT marked as stale. Stale experiments have gone idle and should be excluded.
    - **Recently decided:** Completed experiments that have a decision recorded AND were modified within the last 14 days. These are worth reviewing to confirm the decision or share learnings.
@@ -81,6 +83,7 @@ Date: [Today] | Project: [Name] ([ID])
 ```
 
 **Column definitions:**
+
 - **Experiment** — Human-readable name (NOT a URL, NOT an ID)
 - **State** — Running or Completed
 - **Duration** — Days since experiment started
@@ -89,17 +92,17 @@ Date: [Today] | Project: [Name] ([ID])
 
 **Verdict vocabulary:**
 
-| Verdict | When to use |
-|---------|-------------|
-| **Ship** | Significant positive primary, guardrails clean, data quality good |
-| **Iterate** | Positive signal but guardrail regression or quality concern |
-| **Monitor** | Running, not yet significant, nothing to act on |
-| **Abandon** | Significant negative primary, or critical data quality issues |
-| **Decided: Ship** | Recently completed, team decided to ship |
-| **Decided: Don't ship** | Recently completed, team decided not to ship |
-| **Fix config** | Query error, broken exposure event, or severely imbalanced traffic |
-| **Needs metrics** | Running without metrics — can't evaluate |
-| **N/A** | Survey/nudge deployment, not a feature experiment |
+| Verdict                 | When to use                                                        |
+| ----------------------- | ------------------------------------------------------------------ |
+| **Ship**                | Significant positive primary, guardrails clean, data quality good  |
+| **Iterate**             | Positive signal but guardrail regression or quality concern        |
+| **Monitor**             | Running, not yet significant, nothing to act on                    |
+| **Abandon**             | Significant negative primary, or critical data quality issues      |
+| **Decided: Ship**       | Recently completed, team decided to ship                           |
+| **Decided: Don't ship** | Recently completed, team decided not to ship                       |
+| **Fix config**          | Query error, broken exposure event, or severely imbalanced traffic |
+| **Needs metrics**       | Running without metrics — can't evaluate                           |
+| **N/A**                 | Survey/nudge deployment, not a feature experiment                  |
 
 #### Action items (immediately after the table)
 
@@ -147,33 +150,37 @@ If issues found, report before the primary metric:
 ```
 
 **SRM (Sample Ratio Mismatch):**
+
 - Use the `srmDetected` field from the API response
 - If `srmDetected: true`: **always report first and prominently**
 - Report: actual split vs. expected split with specific percentages
 
 **Traffic allocation changes:**
+
 - Compare the current variant weights against the cumulative exposure distribution
 - If they don't match (e.g., current weights are 100/0/0 but cumulative is 15/70/15), the allocation was changed mid-experiment
 - Flag this prominently — it means some variants may no longer be receiving new traffic
 
 **Sample size:**
+
 - <100 per variant: Flag as insufficient — too early for any conclusions
 - 100–1,000 per variant: Directional signals only, not enough for confident decisions
 - 1,000+: Adequate for analysis
 
 **Validity flags — only report failures:**
 
-| Flag | What it means when it fails | Severity |
-|------|----------------------------|----------|
-| `isVariancePositive` = false | Metric data is invalid — statistical tests can't run | Critical |
-| `isConfidenceIntervalNotFlipped` = false | Calculation error in results — don't trust the numbers | Critical |
-| `isMeanValid` = false | Metric values are broken (NaN/infinite) — can't analyze | Critical |
-| `statsAssumptionsMetForWholeExperiment` = false | Statistical assumptions aren't met — results may be unreliable | High |
-| `hasSuspiciousUplift` = true | Unusually large effect — may be a measurement error, not a real change | High |
-| `isPointEstimateInsideConfidenceInterval` = false | Internal math inconsistency — results may be wrong | High |
-| `isStandardErrorLargeEnough` = false | Too much noise to get reliable estimates | Medium |
+| Flag                                              | What it means when it fails                                            | Severity |
+| ------------------------------------------------- | ---------------------------------------------------------------------- | -------- |
+| `isVariancePositive` = false                      | Metric data is invalid — statistical tests can't run                   | Critical |
+| `isConfidenceIntervalNotFlipped` = false          | Calculation error in results — don't trust the numbers                 | Critical |
+| `isMeanValid` = false                             | Metric values are broken (NaN/infinite) — can't analyze                | Critical |
+| `statsAssumptionsMetForWholeExperiment` = false   | Statistical assumptions aren't met — results may be unreliable         | High     |
+| `hasSuspiciousUplift` = true                      | Unusually large effect — may be a measurement error, not a real change | High     |
+| `isPointEstimateInsideConfidenceInterval` = false | Internal math inconsistency — results may be wrong                     | High     |
+| `isStandardErrorLargeEnough` = false              | Too much noise to get reliable estimates                               | Medium   |
 
 If SRM is detected or a Critical flag fails:
+
 ```
 ⚠️ Results below should be interpreted with caution due to [issue].
 ```
@@ -192,11 +199,13 @@ If SRM is detected or a Critical flag fails:
 ```
 
 **Framing rules:**
+
 - **Do NOT include p-values.** Non-experts don't know what they mean.
 - Use "not significant" instead of "no effect." There may be an effect — the experiment just can't detect it at this sample size.
 - Lead with what happened in plain language.
 
 **Verdict words:**
+
 - **Significant positive** — CI entirely above zero, positive lift
 - **Significant negative** — CI entirely below zero, negative lift
 - **Not significant** — CI includes zero; we can't confidently say there's a real difference yet
@@ -213,11 +222,13 @@ Focus on catching regressions, not narrating every metric.
 If no significant regressions: "All guardrails and secondary metrics are clean — no significant regressions detected."
 
 If significant regressions found:
+
 ```
 - **[Metric Name]:** Significant regression ([−X%], CI: [A% to B%]) — [one sentence on impact]
 ```
 
 If large directional regressions (>20% relative lift) that aren't yet significant:
+
 ```
 - **[Metric Name]:** Not significant, but directionally negative ([−X%]) — worth watching
 ```
@@ -239,12 +250,12 @@ Call `Amplitude:get_feedback_insights` with experiment-related keywords. Report 
 
 **Decision matrix (internal reference, don't output):**
 
-| Signal | Ship | Iterate | Monitor | Abandon |
-|--------|------|---------|---------|---------|
-| Primary | Significant positive + practical | Significant positive but guardrail regression | Not yet significant, still running | Significant negative |
-| Quality | All pass | Minor flags | All pass or insufficient data | SRM or critical flags |
-| Guardrails | Clean | 1 regression needs fixing | Clean or not enough data | Significant regression on critical metric |
-| Experiment state | Completed | Completed | Running | Completed or running |
+| Signal           | Ship                             | Iterate                                       | Monitor                            | Abandon                                   |
+| ---------------- | -------------------------------- | --------------------------------------------- | ---------------------------------- | ----------------------------------------- |
+| Primary          | Significant positive + practical | Significant positive but guardrail regression | Not yet significant, still running | Significant negative                      |
+| Quality          | All pass                         | Minor flags                                   | All pass or insufficient data      | SRM or critical flags                     |
+| Guardrails       | Clean                            | 1 regression needs fixing                     | Clean or not enough data           | Significant regression on critical metric |
+| Experiment state | Completed                        | Completed                                     | Running                            | Completed or running                      |
 
 #### 4b: Running Experiments (monitoring, no action needed)
 

--- a/plugins/amplitude/skills/monitor-experiments/SKILL.md
+++ b/plugins/amplitude/skills/monitor-experiments/SKILL.md
@@ -37,6 +37,7 @@ Do NOT duplicate information between the summary table and the details. The summ
 
 1. Call `Amplitude:get_amplitude_context`. If multiple projects, ask which to monitor.
 2. Search for experiments:
+
 ```
 Amplitude:search({
   entityTypes: ["EXPERIMENT"],
@@ -47,6 +48,7 @@ Amplitude:search({
   limitPerQuery: 50
 })
 ```
+
 3. **Filtering rules — include experiments that are:**
    - **Running and not stale:** Any experiment in a running state that is NOT marked as stale. Stale experiments have gone idle and should be excluded.
    - **Recently decided:** Completed experiments that have a decision recorded AND were modified within the last 14 days. These are worth reviewing to confirm the decision or share learnings.
@@ -81,6 +83,7 @@ Date: [Today] | Project: [Name] ([ID])
 ```
 
 **Column definitions:**
+
 - **Experiment** — Human-readable name (NOT a URL, NOT an ID)
 - **State** — Running or Completed
 - **Duration** — Days since experiment started
@@ -89,17 +92,17 @@ Date: [Today] | Project: [Name] ([ID])
 
 **Verdict vocabulary:**
 
-| Verdict | When to use |
-|---------|-------------|
-| **Ship** | Significant positive primary, guardrails clean, data quality good |
-| **Iterate** | Positive signal but guardrail regression or quality concern |
-| **Monitor** | Running, not yet significant, nothing to act on |
-| **Abandon** | Significant negative primary, or critical data quality issues |
-| **Decided: Ship** | Recently completed, team decided to ship |
-| **Decided: Don't ship** | Recently completed, team decided not to ship |
-| **Fix config** | Query error, broken exposure event, or severely imbalanced traffic |
-| **Needs metrics** | Running without metrics — can't evaluate |
-| **N/A** | Survey/nudge deployment, not a feature experiment |
+| Verdict                 | When to use                                                        |
+| ----------------------- | ------------------------------------------------------------------ |
+| **Ship**                | Significant positive primary, guardrails clean, data quality good  |
+| **Iterate**             | Positive signal but guardrail regression or quality concern        |
+| **Monitor**             | Running, not yet significant, nothing to act on                    |
+| **Abandon**             | Significant negative primary, or critical data quality issues      |
+| **Decided: Ship**       | Recently completed, team decided to ship                           |
+| **Decided: Don't ship** | Recently completed, team decided not to ship                       |
+| **Fix config**          | Query error, broken exposure event, or severely imbalanced traffic |
+| **Needs metrics**       | Running without metrics — can't evaluate                           |
+| **N/A**                 | Survey/nudge deployment, not a feature experiment                  |
 
 #### Action items (immediately after the table)
 
@@ -147,33 +150,37 @@ If issues found, report before the primary metric:
 ```
 
 **SRM (Sample Ratio Mismatch):**
+
 - Use the `srmDetected` field from the API response
 - If `srmDetected: true`: **always report first and prominently**
 - Report: actual split vs. expected split with specific percentages
 
 **Traffic allocation changes:**
+
 - Compare the current variant weights against the cumulative exposure distribution
 - If they don't match (e.g., current weights are 100/0/0 but cumulative is 15/70/15), the allocation was changed mid-experiment
 - Flag this prominently — it means some variants may no longer be receiving new traffic
 
 **Sample size:**
+
 - <100 per variant: Flag as insufficient — too early for any conclusions
 - 100–1,000 per variant: Directional signals only, not enough for confident decisions
 - 1,000+: Adequate for analysis
 
 **Validity flags — only report failures:**
 
-| Flag | What it means when it fails | Severity |
-|------|----------------------------|----------|
-| `isVariancePositive` = false | Metric data is invalid — statistical tests can't run | Critical |
-| `isConfidenceIntervalNotFlipped` = false | Calculation error in results — don't trust the numbers | Critical |
-| `isMeanValid` = false | Metric values are broken (NaN/infinite) — can't analyze | Critical |
-| `statsAssumptionsMetForWholeExperiment` = false | Statistical assumptions aren't met — results may be unreliable | High |
-| `hasSuspiciousUplift` = true | Unusually large effect — may be a measurement error, not a real change | High |
-| `isPointEstimateInsideConfidenceInterval` = false | Internal math inconsistency — results may be wrong | High |
-| `isStandardErrorLargeEnough` = false | Too much noise to get reliable estimates | Medium |
+| Flag                                              | What it means when it fails                                            | Severity |
+| ------------------------------------------------- | ---------------------------------------------------------------------- | -------- |
+| `isVariancePositive` = false                      | Metric data is invalid — statistical tests can't run                   | Critical |
+| `isConfidenceIntervalNotFlipped` = false          | Calculation error in results — don't trust the numbers                 | Critical |
+| `isMeanValid` = false                             | Metric values are broken (NaN/infinite) — can't analyze                | Critical |
+| `statsAssumptionsMetForWholeExperiment` = false   | Statistical assumptions aren't met — results may be unreliable         | High     |
+| `hasSuspiciousUplift` = true                      | Unusually large effect — may be a measurement error, not a real change | High     |
+| `isPointEstimateInsideConfidenceInterval` = false | Internal math inconsistency — results may be wrong                     | High     |
+| `isStandardErrorLargeEnough` = false              | Too much noise to get reliable estimates                               | Medium   |
 
 If SRM is detected or a Critical flag fails:
+
 ```
 ⚠️ Results below should be interpreted with caution due to [issue].
 ```
@@ -192,11 +199,13 @@ If SRM is detected or a Critical flag fails:
 ```
 
 **Framing rules:**
+
 - **Do NOT include p-values.** Non-experts don't know what they mean.
 - Use "not significant" instead of "no effect." There may be an effect — the experiment just can't detect it at this sample size.
 - Lead with what happened in plain language.
 
 **Verdict words:**
+
 - **Significant positive** — CI entirely above zero, positive lift
 - **Significant negative** — CI entirely below zero, negative lift
 - **Not significant** — CI includes zero; we can't confidently say there's a real difference yet
@@ -213,11 +222,13 @@ Focus on catching regressions, not narrating every metric.
 If no significant regressions: "All guardrails and secondary metrics are clean — no significant regressions detected."
 
 If significant regressions found:
+
 ```
 - **[Metric Name]:** Significant regression ([−X%], CI: [A% to B%]) — [one sentence on impact]
 ```
 
 If large directional regressions (>20% relative lift) that aren't yet significant:
+
 ```
 - **[Metric Name]:** Not significant, but directionally negative ([−X%]) — worth watching
 ```
@@ -239,12 +250,12 @@ Call `Amplitude:get_feedback_insights` with experiment-related keywords. Report 
 
 **Decision matrix (internal reference, don't output):**
 
-| Signal | Ship | Iterate | Monitor | Abandon |
-|--------|------|---------|---------|---------|
-| Primary | Significant positive + practical | Significant positive but guardrail regression | Not yet significant, still running | Significant negative |
-| Quality | All pass | Minor flags | All pass or insufficient data | SRM or critical flags |
-| Guardrails | Clean | 1 regression needs fixing | Clean or not enough data | Significant regression on critical metric |
-| Experiment state | Completed | Completed | Running | Completed or running |
+| Signal           | Ship                             | Iterate                                       | Monitor                            | Abandon                                   |
+| ---------------- | -------------------------------- | --------------------------------------------- | ---------------------------------- | ----------------------------------------- |
+| Primary          | Significant positive + practical | Significant positive but guardrail regression | Not yet significant, still running | Significant negative                      |
+| Quality          | All pass                         | Minor flags                                   | All pass or insufficient data      | SRM or critical flags                     |
+| Guardrails       | Clean                            | 1 regression needs fixing                     | Clean or not enough data           | Significant regression on critical metric |
+| Experiment state | Completed                        | Completed                                     | Running                            | Completed or running                      |
 
 #### 4b: Running Experiments (monitoring, no action needed)
 

--- a/plugins/amplitude/skills/monitor-reliability/SKILL.md
+++ b/plugins/amplitude/skills/monitor-reliability/SKILL.md
@@ -99,12 +99,12 @@ Use `Amplitude:query_dataset` to score individual pages. Budget: 1-2 calls.
 
 2. **Score each page.** Assign a health grade:
 
-| Grade | Criteria |
-|-------|----------|
-| **Healthy** | All three signals below product-wide average |
-| **Degraded** | 1-2 signals above average, or any signal >2x average |
+| Grade         | Criteria                                                   |
+| ------------- | ---------------------------------------------------------- |
+| **Healthy**   | All three signals below product-wide average               |
+| **Degraded**  | 1-2 signals above average, or any signal >2x average       |
 | **Unhealthy** | All three signals above average, or any signal >5x average |
-| **Critical** | Any signal >10x average, or >5% of page visitors affected |
+| **Critical**  | Any signal >10x average, or >5% of page visitors affected  |
 
 3. Rank pages by severity. Surface the worst 5-10 pages.
 
@@ -155,6 +155,7 @@ Date: [Today] | Window: [Start] – [End] | Project: [Name] ([ID])
 ```
 
 Status thresholds:
+
 - 🟢 Stable or improving (change <10% relative)
 - 🟡 Degraded (change 10-50% relative)
 - 🔴 Critical (change >50% relative, or absolute value exceeds acceptable threshold)
@@ -183,6 +184,7 @@ Narrative paragraphs (3-5 max) covering the most important changes. Each paragra
 **[Headline — ≤10 words]** — What changed (with numbers and time context). Why it changed (deployment, experiment, external factor — or "no clear cause yet"). Who's affected (segment, page, user count). What to do about it (specific action).
 
 Prioritize:
+
 1. **New errors** (regressions) over chronic errors (tech debt)
 2. **Worsening trends** over stable-but-bad metrics
 3. **User-facing impact** (error clicks) over silent errors
@@ -228,6 +230,7 @@ Ask what to dig into: "Want me to investigate the chart builder errors in detail
 User says: "Give me a reliability check"
 
 Actions:
+
 1. Get context and project
 2. Query all three error events over 14 days — 7-day baseline vs 7-day current
 3. Compute all KPIs and page health scores
@@ -239,6 +242,7 @@ Actions:
 User says: "We shipped v4.3 yesterday — did it break anything?"
 
 Actions:
+
 1. Get context and deployments — find the v4.3 deploy timestamp
 2. Query all three events with pre-deploy (7d before) and post-deploy windows
 3. Identify new errors that didn't exist before the deploy
@@ -250,6 +254,7 @@ Actions:
 User says: "How's reliability on the experiment pages?"
 
 Actions:
+
 1. Get context
 2. Filter all three events to `[Amplitude] Page Path` containing experiment-related paths
 3. Compute KPIs scoped to those pages

--- a/plugins/amplitude/skills/replay-ux-audit/SKILL.md
+++ b/plugins/amplitude/skills/replay-ux-audit/SKILL.md
@@ -13,10 +13,12 @@ Watch 5-10 session replays for a specific feature, page, or flow, then synthesiz
 ## CRITICAL: Tool Reference
 
 **Primary tools:**
+
 - **`Amplitude:get_session_replays`** — Find sessions matching event filters, user properties, or time windows. Use this to target sessions for a specific feature or flow.
 - **`Amplitude:get_session_replay_events`** — Decode a replay into an interaction timeline: navigations, clicks, inputs, scrolls. This is what you "watch."
 
 **Supporting tools:**
+
 - **`Amplitude:get_events`** — Discover valid event names. Never guess event names.
 - **`Amplitude:get_properties`** — Discover properties for filtering (page path, feature area, etc.).
 - **`Amplitude:query_charts`** — Pull quantitative context (funnel conversion rates, feature adoption) to anchor the qualitative replay findings.
@@ -36,6 +38,7 @@ Determine what to audit from the user's request:
 - **Broad**: "Audit the whole product" — narrow this down. Ask: "Which area would you like me to start with?" Suggest 2-3 areas based on high-traffic pages or known problem areas if you can identify them.
 
 Also determine:
+
 - **Time window**: Default to last 14 days unless specified.
 - **User segment** (optional): Specific plan, platform, cohort, or user type.
 
@@ -79,17 +82,18 @@ For each session, call `Amplitude:get_session_replay_events` with `event_limit: 
 
 **While analyzing each session, track these friction signals:**
 
-| Signal | What to look for in the timeline |
-|---|---|
-| **Rage clicks** | 3+ clicks on the same coordinates within a short time span |
-| **Hesitation** | Long pauses (>10 seconds) between navigation and first interaction on a page |
-| **Back-and-forth** | Navigating to a page, then back, then forward again |
-| **Abandoned inputs** | Starting to type in a field, then navigating away without submitting |
-| **Excessive scrolling** | Large scroll deltas suggesting the user is searching for something |
-| **Dead-end navigation** | Visiting a page and immediately leaving (bounce within seconds) |
-| **Repeat attempts** | Performing the same action multiple times (re-submitting a form, re-clicking a button) |
+| Signal                  | What to look for in the timeline                                                       |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| **Rage clicks**         | 3+ clicks on the same coordinates within a short time span                             |
+| **Hesitation**          | Long pauses (>10 seconds) between navigation and first interaction on a page           |
+| **Back-and-forth**      | Navigating to a page, then back, then forward again                                    |
+| **Abandoned inputs**    | Starting to type in a field, then navigating away without submitting                   |
+| **Excessive scrolling** | Large scroll deltas suggesting the user is searching for something                     |
+| **Dead-end navigation** | Visiting a page and immediately leaving (bounce within seconds)                        |
+| **Repeat attempts**     | Performing the same action multiple times (re-submitting a form, re-clicking a button) |
 
 For each session, write a brief summary:
+
 - Pages visited in the target area
 - Key actions taken
 - Friction signals observed (with timestamps)
@@ -103,12 +107,12 @@ This is the core analytical step. Aggregate findings across all watched sessions
 2. **Count frequency.** How many of the watched sessions showed this friction? Express as "seen in X of Y sessions."
 3. **Assess severity.** Use this rubric:
 
-| Severity | Criteria |
-|---|---|
-| **Critical** | Blocks task completion. User gives up or encounters an error. Seen in 50%+ of sessions. |
-| **High** | Causes significant confusion or delay. User eventually succeeds but with visible struggle. Seen in 30%+ of sessions. |
-| **Medium** | Causes minor hesitation or suboptimal paths. User recovers quickly. Seen in 20%+ of sessions. |
-| **Low** | Cosmetic or minor annoyance. Seen in <20% of sessions or only in edge cases. |
+| Severity     | Criteria                                                                                                             |
+| ------------ | -------------------------------------------------------------------------------------------------------------------- |
+| **Critical** | Blocks task completion. User gives up or encounters an error. Seen in 50%+ of sessions.                              |
+| **High**     | Causes significant confusion or delay. User eventually succeeds but with visible struggle. Seen in 30%+ of sessions. |
+| **Medium**   | Causes minor hesitation or suboptimal paths. User recovers quickly. Seen in 20%+ of sessions.                        |
+| **Low**      | Cosmetic or minor annoyance. Seen in <20% of sessions or only in edge cases.                                         |
 
 4. **Identify root cause hypotheses.** For each friction pattern, hypothesize why it happens:
    - Unclear UI labeling or hierarchy
@@ -183,6 +187,7 @@ hesitate, what goes wrong. Be specific about the page and interaction.
 User says: "Audit the onboarding experience for new users"
 
 Actions:
+
 1. Get context, discover onboarding-related events
 2. Query the onboarding funnel for conversion rates and worst drop-off step
 3. Find 8-10 sessions of new users going through onboarding
@@ -195,6 +200,7 @@ Actions:
 User says: "What's the UX like on our pricing page?"
 
 Actions:
+
 1. Get context, find pricing page events (page view, plan selection, CTA clicks)
 2. Query pricing page traffic and click-through rate as baseline
 3. Find 8 sessions that visited the pricing page
@@ -207,6 +213,7 @@ Actions:
 User says: "Are enterprise users having trouble with the report builder?"
 
 Actions:
+
 1. Get context, find report builder events
 2. Filter sessions to enterprise plan users + report builder events
 3. Extract timelines from 6-8 sessions

--- a/plugins/amplitude/skills/review-agent-insights/SKILL.md
+++ b/plugins/amplitude/skills/review-agent-insights/SKILL.md
@@ -13,9 +13,11 @@ Surface everything Amplitude's AI agents have found recently. Query **every avai
 ## CRITICAL: Tool Reference
 
 **Primary tool:**
+
 - **`Amplitude:get_agent_results`** — Retrieve pre-computed analyses from Amplitude's AI agents. Supports multiple agent types (check the tool's `agent_type` enum for the current list). Each agent type is queried separately. All support filtering by `created_after`, `created_before`, `query`, `agent_params`, and `limit`.
 
 **Supporting tools:**
+
 - **`Amplitude:get_amplitude_context`** / **`Amplitude:get_amplitude_context`** — Bootstrap user, org, and project info.
 - **`Amplitude:get_deployments`** — Check whether fixes have shipped for flagged issues (staleness validation).
 
@@ -29,6 +31,7 @@ Surface everything Amplitude's AI agents have found recently. Query **every avai
 2. Call `Amplitude:get_amplitude_context` for the target project's settings and AI context.
 
 Determine the **review window** from the user's request:
+
 - Default: **last 7 days** (good balance of recency and coverage).
 - "What's new today?" → last 1-2 days.
 - "Catch me up on this month" → last 14-30 days.
@@ -45,6 +48,7 @@ Check the `get_agent_results` tool descriptor to discover every available `agent
 If the user asked about a specific area (e.g., "onboarding insights"), add a `query` matching that area to every call. If an agent type supports additional filtering via `agent_params` (e.g., impact ratings, categories, dashboard IDs), use them to focus results when the user's request suggests a narrower scope — otherwise omit `agent_params` to get the broadest view.
 
 For each result returned, note:
+
 - Which agent type produced it
 - The key findings or summary
 - When the analysis was run (creation date)
@@ -109,6 +113,7 @@ needs fresh validation. Omit this line if the finding is < 3 days old.
 4. **Follow-on prompt**: End with 2-3 specific options for what to dig into next, framed around the findings.
 
 **Writing standards:**
+
 - Narrative over structure. Write findings as paragraphs, not database records.
 - Lead with the insight, use agent type attribution as supporting evidence.
 - Approximate: "~42%" not "42.37%".
@@ -135,6 +140,7 @@ needs fresh validation. Omit this line if the finding is < 3 days old.
 User says: "What has the AI found recently?"
 
 Actions:
+
 1. Get context — identify key project and dashboards
 2. Check `get_agent_results` for all available agent types, query each in parallel with `created_after` set to 7 days ago
 3. Validate freshness — cross-reference against deployments, filter out stale findings
@@ -146,6 +152,7 @@ Actions:
 User says: "Any AI insights about onboarding?"
 
 Actions:
+
 1. Get context
 2. Query all agent types with `query: "onboarding"`, `created_after` set to 7 days ago
 3. Filter to only onboarding-related findings
@@ -156,6 +163,7 @@ Actions:
 User says: "Show me all AI agent insights"
 
 Actions:
+
 1. Get context
 2. All agent type queries return empty within the review window
 3. Present: "No AI agent results found in the last 7 days. Here's how to generate them:" — list each agent type that was queried, what it does, and suggest specific content to analyze

--- a/plugins/amplitude/skills/scheduled-report-refresh/SKILL.md
+++ b/plugins/amplitude/skills/scheduled-report-refresh/SKILL.md
@@ -5,7 +5,7 @@ description: Refreshes recurring reports (daily briefings, WBRs, experiment brie
 
 # Scheduled Report Refresh
 
-The dominant *automated* job on this MCP server: custom agents and
+The dominant _automated_ job on this MCP server: custom agents and
 scheduled runs re-pulling a known set of charts and summarizing changes.
 
 ## The arc

--- a/plugins/amplitude/skills/taxonomy/SKILL.md
+++ b/plugins/amplitude/skills/taxonomy/SKILL.md
@@ -55,24 +55,27 @@ These are **different problems** requiring **different solutions**:
 - **Taxonomy type counts** = number of distinct names across all schema dimensions (event types, event property types, user property types, group types, group property types). Each has its own limit.
 
 **Billing models — know which applies before advising:**
+
 - **Event volume billing**: customer has a contracted allocation of events per period. Exceeding it triggers overage costs. Flag significant event volume changes to these customers.
 - **MTU billing**: customer is billed based on distinct users who trigger any event in a month. Per-user event counts matter less; total unique user count matters more.
 
 **What customers usually mean:**
+
 - "I need to reduce my event volume" → worried about billing (volume-billed customers)
 - "I need to reduce my event types / schema count" → worried about hitting type limits (new types won't be queryable)
 
 **What actually reduces each:**
 
-| Goal | Action | Reduces Volume? | Reduces Type Count? |
-|------|--------|:---:|:---:|
-| Reduce volume | Block event | Yes | No |
-| Reduce volume | Delete event | Yes | Yes |
-| Reduce type count | Delete event/property/group type | — | Yes |
-| Reduce type count | Block event | No | **No** |
-| Reduce type count | Hide event | No | **No** |
+| Goal              | Action                           | Reduces Volume? | Reduces Type Count? |
+| ----------------- | -------------------------------- | :-------------: | :-----------------: |
+| Reduce volume     | Block event                      |       Yes       |         No          |
+| Reduce volume     | Delete event                     |       Yes       |         Yes         |
+| Reduce type count | Delete event/property/group type |        —        |         Yes         |
+| Reduce type count | Block event                      |       No        |       **No**        |
+| Reduce type count | Hide event                       |       No        |       **No**        |
 
 **Key rules:**
+
 - Blocking and hiding do NOT reduce type count. A quota-constrained customer must delete, not block.
 - **Never recommend sampling.** Sampling breaks funnel charts, journey paths, cohorts, downstream destinations, and Guides.
 - Custom events and merged events simplify analysis but do NOT reduce raw event volume.
@@ -80,15 +83,16 @@ These are **different problems** requiring **different solutions**:
 
 ## Event States and Metadata Permissions
 
-| Status | Meaning | Can Edit Metadata? |
-|--------|---------|:---:|
-| Planned | In tracking plan; not yet instrumented | Yes |
-| Live | Actively receiving data | Yes |
-| Blocked | Stops new ingestion; historical data accessible | Yes |
-| Unexpected | Receiving data but NOT in tracking plan | **No** — must add to tracking plan first |
-| Deleted | Stops ingestion; removed from new-chart dropdowns | **No** — must restore first |
+| Status     | Meaning                                           |            Can Edit Metadata?            |
+| ---------- | ------------------------------------------------- | :--------------------------------------: |
+| Planned    | In tracking plan; not yet instrumented            |                   Yes                    |
+| Live       | Actively receiving data                           |                   Yes                    |
+| Blocked    | Stops new ingestion; historical data accessible   |                   Yes                    |
+| Unexpected | Receiving data but NOT in tracking plan           | **No** — must add to tracking plan first |
+| Deleted    | Stops ingestion; removed from new-chart dropdowns |       **No** — must restore first        |
 
 **Unexpected events have special restrictions.** No metadata can be updated until the event is added to the tracking plan. When you encounter Unexpected events:
+
 - If they appear legitimate (real product actions, consistent volume): recommend adding to the tracking plan first, then apply metadata.
 - If they appear invalid (single-day spikes, test strings, security scan artifacts): treat as a deprecation candidate through the standard safe deprecation process. Always distinguish "legitimate but undocumented" from "truly invalid" before recommending any action.
 
@@ -96,10 +100,10 @@ These are **different problems** requiring **different solutions**:
 
 **Actual deprecation signals:**
 
-| Signal | Interpretation |
-|--------|----------------|
-| No recent volume | Event has gone stale |
-| No recent queries | Event is unused |
+| Signal            | Interpretation                   |
+| ----------------- | -------------------------------- |
+| No recent volume  | Event has gone stale             |
+| No recent queries | Event is unused                  |
 | **Both together** | **Strong deprecation candidate** |
 
 **Planned events:** Zero volume and queries are expected — evaluate by age, name collisions with Live events, and test-like names instead.
@@ -128,11 +132,11 @@ None reduce event volume. Each has distinct behavior:
 
 **Three key patterns:**
 
-| Pattern | Definition | Action |
-|---------|------------|--------|
-| Stale event | Has ingested before, but volume stopped | Confirm with customer before deprecating |
-| Test event | first seen = last seen, single day | Strong deprecation candidate; confirm first |
-| Firing but unqueried | Has volume, zero queries | Flag for review, not immediate removal |
+| Pattern              | Definition                              | Action                                      |
+| -------------------- | --------------------------------------- | ------------------------------------------- |
+| Stale event          | Has ingested before, but volume stopped | Confirm with customer before deprecating    |
+| Test event           | first seen = last seen, single day      | Strong deprecation candidate; confirm first |
+| Firing but unqueried | Has volume, zero queries                | Flag for review, not immediate removal      |
 
 **Safe to act on:** No volume for 6-12 months. Even if query activity exists, those queries return zero results.
 
@@ -141,12 +145,14 @@ None reduce event volume. Each has distinct behavior:
 Frame metadata and cleanup work as AI readiness improvements. Every AI feature selects events by evaluating the visible taxonomy — taxonomy quality directly determines AI output quality.
 
 **Flag these as AI quality issues:**
+
 - Cryptic event names with no description — AI cannot interpret them
 - Clusters of duplicate/near-duplicate names — AI will guess incorrectly between them
 - Implementation-focused descriptions (e.g., "fires when POST /purchase returns 200") — users ask behavioral questions, not backend questions
 - Large numbers of deprecated events still visible — noise that increases wrong AI selection
 
 **Event description structure (in order):**
+
 1. Non-technical behavior definition — what the user did, in plain language
 2. Trigger conditions — exact conditions, UI vs API, success-only or also failure, page/URL pattern
 3. Disambiguation — how this differs from similarly-named events
@@ -154,14 +160,16 @@ Frame metadata and cleanup work as AI readiness improvements. Every AI feature s
 5. Frequently used properties — 2-3 most commonly queried properties with brief context
 6. Technical details (optional) — implementation notes, source system, endpoint
 
-**Property descriptions:** Start with a clear definition, then include example values. Example: *"The category of the product the user viewed. Examples: 'electronics', 'apparel', 'home & garden'."*
+**Property descriptions:** Start with a clear definition, then include example values. Example: _"The category of the product the user viewed. Examples: 'electronics', 'apparel', 'home & garden'."_
 
 **AI readiness at instrumentation time:**
+
 - Choose clear, descriptive event and property names that don't require a display name to be interpretable. Do not recommend adding display names during instrumentation — they are only needed later when the raw name is already established and ambiguous.
 - Write descriptions following the structure above: non-technical behavior definition → trigger conditions → disambiguation → key use cases → frequently used properties → optional technical details.
 - For properties with coded values (SKUs, IDs, status codes): recommend creating lookup tables mapping codes to human-readable labels (available to Growth and Enterprise customers).
 
 **AI Controls recommendations:**
+
 - **Organization context** (10,000 char): company-wide standards, KPI definitions, standard terminology, global filters, fiscal calendar
 - **Project context** (10,000 char): product-specific events/funnels, project-specific metrics, segment definitions
 - Use audit findings to populate these recommendations. Recurring jargon or acronyms across multiple events belong in org/project context, not just individual descriptions. Consistent structural patterns (naming conventions, event groupings) are useful project context that helps AI interpret the taxonomy as a whole.
@@ -180,16 +188,19 @@ strategy and step-by-step procedures, see the Data Quality Audit procedure in th
 **Before/after confirmation required for all writes.** Never auto-apply. Only update confirmed items — do not extend to similar items based on pattern inference.
 
 **Per-field defaults:**
+
 - **Descriptions:** Do not remove existing content unless clearly erroneous. Append to or incorporate existing detail.
 - **Categories:** Only set when empty. Suggest changing only if clearly incorrect or user requests it.
 - **Tags:** Add only; never remove without explicit request.
 - **Display names:** Follow the project's existing naming conventions.
 
 **Restrictions:**
+
 - Do not write to bracket-prefixed or vendor-prefixed events unless explicitly requested.
 - Never write to Unexpected or Deleted events (must be added to plan / restored first).
 
 **When writes fail due to permissions:**
+
 - Explain that the user lacks write access.
 - Provide read-only guidance on what could be done and why.
 - Offer an "Ask an Admin to apply this" summary the user can share.
@@ -199,6 +210,7 @@ strategy and step-by-step procedures, see the Data Quality Audit procedure in th
 Deprecation must always follow a phased process. For the step-by-step procedure, see the governance skill's Deprecation Workflow.
 
 **Never:**
+
 - Present delete/hide/block as immediate one-step solutions
 - Recommend sampling, TTLs, automatic deletion rules, or moving events between projects
 - Recommend reconfiguring upstream integrations for volume control
@@ -210,19 +222,21 @@ Deprecation must always follow a phased process. For the step-by-step procedure,
 
 **Format: `[Object] [Past-Tense Verb]` in Title Case**
 
-| Good | Bad | Why |
-|------|-----|-----|
-| `Song Played` | `Play Song` | Past tense = completed action |
-| `Form Submitted` | `Submit Form` | Noun-first = scannable, sortable |
-| `Product Added` | `product added`, `product_added`, `productAdded` | Amplitude treats different casings as separate events — always use Title Case, not snake_case or camelCase |
+| Good             | Bad                                              | Why                                                                                                        |
+| ---------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `Song Played`    | `Play Song`                                      | Past tense = completed action                                                                              |
+| `Form Submitted` | `Submit Form`                                    | Noun-first = scannable, sortable                                                                           |
+| `Product Added`  | `product added`, `product_added`, `productAdded` | Amplitude treats different casings as separate events — always use Title Case, not snake_case or camelCase |
 
 **Consistency is the top priority.** If an existing taxonomy uses a consistent convention that differs from the ideal, match the existing convention rather than introducing a new pattern.
 
 **User perspective, not system perspective:**
+
 - `Message Sent` (user sent) not `Message Delivered` (system delivered)
 - `Purchase Completed` (user completed) not `Payment Processed` (system processed)
 
 **Specificity balance — one event + properties, not many events:**
+
 - **Good**: `Order Completed` with property `payment_method`
 - **Bad**: `Credit Card Order Completed`, `Apple Pay Order Completed`
 
@@ -244,14 +258,14 @@ Deprecation must always follow a phased process. For the step-by-step procedure,
 
 ### Property Type Standards
 
-| Type | Format | Example |
-|------|--------|---------|
-| IDs | Always string | `"user_id": "12345"` not `12345` |
-| Counts/amounts | Number | `"order_total": 59.99` |
-| Flags | Boolean | `"is_premium": true` |
-| Timestamps | ISO 8601 string | `"2024-03-10T14:30:00Z"` |
-| Enums/status | String | `"status": "In Progress"` |
-| Null handling | Pick one approach per property | Omit, `null`, or sentinel string like `"Unknown"` — never mix. Using an explicit sentinel string lets you distinguish intentionally unavailable values from instrumentation bugs. Inconsistent null handling is one of the most common causes of incorrect property filters and broken funnels. |
+| Type           | Format                         | Example                                                                                                                                                                                                                                                                                         |
+| -------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| IDs            | Always string                  | `"user_id": "12345"` not `12345`                                                                                                                                                                                                                                                                |
+| Counts/amounts | Number                         | `"order_total": 59.99`                                                                                                                                                                                                                                                                          |
+| Flags          | Boolean                        | `"is_premium": true`                                                                                                                                                                                                                                                                            |
+| Timestamps     | ISO 8601 string                | `"2024-03-10T14:30:00Z"`                                                                                                                                                                                                                                                                        |
+| Enums/status   | String                         | `"status": "In Progress"`                                                                                                                                                                                                                                                                       |
+| Null handling  | Pick one approach per property | Omit, `null`, or sentinel string like `"Unknown"` — never mix. Using an explicit sentinel string lets you distinguish intentionally unavailable values from instrumentation bugs. Inconsistent null handling is one of the most common causes of incorrect property filters and broken funnels. |
 
 ### User Identification Standards
 
@@ -272,16 +286,17 @@ Deprecation must always follow a phased process. For the step-by-step procedure,
 
 Use the Amplitude category metadata field — don't embed prefixes in event names. Common categories:
 
-| Category | Purpose | Examples |
-|----------|---------|---------|
-| Lifecycle | User journey milestones | Signup Completed, Trial Started, Subscription Cancelled |
-| Feature | Core product functionality | Task Created, Document Edited, Report Generated |
-| Engagement | Navigation and UI interaction | Page Viewed, Button Clicked, Search Performed |
-| Transaction | Revenue events | Purchase Completed, Checkout Started, Refund Requested |
-| System | Technical health | Error Occurred, API Request Completed, Timeout Occurred |
-| Growth | Acquisition and referral | Invite Sent, Share Completed, Referral Reward Earned |
+| Category    | Purpose                       | Examples                                                |
+| ----------- | ----------------------------- | ------------------------------------------------------- |
+| Lifecycle   | User journey milestones       | Signup Completed, Trial Started, Subscription Cancelled |
+| Feature     | Core product functionality    | Task Created, Document Edited, Report Generated         |
+| Engagement  | Navigation and UI interaction | Page Viewed, Button Clicked, Search Performed           |
+| Transaction | Revenue events                | Purchase Completed, Checkout Started, Refund Requested  |
+| System      | Technical health              | Error Occurred, API Request Completed, Timeout Occurred |
+| Growth      | Acquisition and referral      | Invite Sent, Share Completed, Referral Reward Earned    |
 
 **Assignment heuristics:**
+
 - If an event represents a first-time or milestone user action (signup, first purchase, first invite), prefer **Lifecycle** over Feature or Transaction.
 - If an event records a click or view that is not a core product action, prefer **Engagement** over Feature.
 - Integration-sourced events (`[Appboy]`, `[Adjust]`, etc.) may not fit neatly — assign System or Growth based on the integration's purpose, or leave unassigned.
@@ -293,11 +308,11 @@ Three dimensions:
 
 ### 1. Issue Impact
 
-| Level | Points | Definition | Examples |
-|-------|--------|------------|---------|
-| HIGH | 3 | Name is ambiguous — analyst cannot reliably interpret it | Jargon, acronyms, blob words, confusable names |
-| MEDIUM | 2 | Name is interpretable but taxonomy is messier for it | Convention outliers, unexpected events not on plan |
-| LOW | 1 | Name is clear; issue is missing polish | Missing description when name is self-explanatory |
+| Level  | Points | Definition                                               | Examples                                           |
+| ------ | ------ | -------------------------------------------------------- | -------------------------------------------------- |
+| HIGH   | 3      | Name is ambiguous — analyst cannot reliably interpret it | Jargon, acronyms, blob words, confusable names     |
+| MEDIUM | 2      | Name is interpretable but taxonomy is messier for it     | Convention outliers, unexpected events not on plan |
+| LOW    | 1      | Name is clear; issue is missing polish                   | Missing description when name is self-explanatory  |
 
 ### 2. Event Importance
 
@@ -315,6 +330,7 @@ Three dimensions:
 **Prioritization:** Lead with high-impact issues on high-importance events. Stale/test events are quick wins — surface them below real data quality problems.
 
 **Health grade:** (Total Points Earned / Total Points Possible) x 100%
+
 - 0-49%: Needs Improvement
 - 50-79%: Meets Expectations
 - 80-100%: Exceeds Expectations
@@ -322,6 +338,7 @@ Three dimensions:
 ## Authority Boundaries (Metadata-Only)
 
 **Allowed (non-destructive, metadata-only, with user approval):**
+
 - Update display names, descriptions, categories, tags
 - Set official status
 - Hide events (NOT block or delete)
@@ -329,6 +346,7 @@ Three dimensions:
 - Add AI Context to project settings
 
 **Not allowed:**
+
 - Blocking, deleting, merging, or transforming events
 - Block/Drop filters
 - Modifying ingestion pipelines or upstream integrations
@@ -342,61 +360,61 @@ Three dimensions:
 
 Default lookback: **180 days**.
 
-| Signal | Priority | Action |
-|--------|----------|--------|
-| Semantically unclear name | HIGH | Add display name + description |
-| Missing description (unclear name) | HIGH | Add description following AI readiness formula |
-| Semantic duplicate (true — same meaning, different casing) | HIGH | Merge or disambiguate |
-| Semantic duplicate (similar — different names, same action) | HIGH | Investigate; merge or disambiguate |
-| Zero volume (180 days) | MEDIUM | Investigate before acting |
-| Zero queries (180 days) | MEDIUM | Check asset dependencies first |
-| Duplicate property across event + user scope | MEDIUM | Clarify correct source of truth |
-| Missing description (clear name) | LOW | Add description; deprioritize |
-| Missing category | LOW | Add category |
-| Naming convention outlier | LOW | Flag for future realignment |
-| Unexpected event/property | LOW | Add to plan or block after review |
-| Stale (last seen beyond lookback) | LOW | Quick win — schedule for deprecation |
-| Single-day (first seen = last seen) | LOW | Quick win — likely test; verify first |
-| Test/QA artifact (`test_`, `debug_`, `tmp_`, `_qa`) | LOW | Quick win — standard deprecation process |
+| Signal                                                      | Priority | Action                                         |
+| ----------------------------------------------------------- | -------- | ---------------------------------------------- |
+| Semantically unclear name                                   | HIGH     | Add display name + description                 |
+| Missing description (unclear name)                          | HIGH     | Add description following AI readiness formula |
+| Semantic duplicate (true — same meaning, different casing)  | HIGH     | Merge or disambiguate                          |
+| Semantic duplicate (similar — different names, same action) | HIGH     | Investigate; merge or disambiguate             |
+| Zero volume (180 days)                                      | MEDIUM   | Investigate before acting                      |
+| Zero queries (180 days)                                     | MEDIUM   | Check asset dependencies first                 |
+| Duplicate property across event + user scope                | MEDIUM   | Clarify correct source of truth                |
+| Missing description (clear name)                            | LOW      | Add description; deprioritize                  |
+| Missing category                                            | LOW      | Add category                                   |
+| Naming convention outlier                                   | LOW      | Flag for future realignment                    |
+| Unexpected event/property                                   | LOW      | Add to plan or block after review              |
+| Stale (last seen beyond lookback)                           | LOW      | Quick win — schedule for deprecation           |
+| Single-day (first seen = last seen)                         | LOW      | Quick win — likely test; verify first          |
+| Test/QA artifact (`test_`, `debug_`, `tmp_`, `_qa`)         | LOW      | Quick win — standard deprecation process       |
 
 **Exception:** When customer is near quota, Stale/Single-day/Test signals become elevated priority.
 
 ## Key Audit Metrics
 
-| Metric | Impact |
-|--------|--------|
-| % of types at quota limit | HIGH when >90% |
-| New types added in last 7 days (spike = possible dynamic value leak) | HIGH if spike |
-| Total event volume change in last 7 days | HIGH if unexpected |
-| Number of duplicate types by name | HIGH |
-| Group types not instrumented (B2B products) | HIGH |
-| A/B experiments tracked as events instead of user properties | MEDIUM |
-| Events with zero queries in 180 days | MEDIUM |
-| Events with zero volume in 180 days | MEDIUM |
-| Single-day events | MEDIUM |
-| % of live events with descriptions | LOW |
-| % of live events with categories | LOW |
-| Number of Unexpected events/properties | LOW |
-| Naming convention inconsistencies | LOW |
+| Metric                                                               | Impact             |
+| -------------------------------------------------------------------- | ------------------ |
+| % of types at quota limit                                            | HIGH when >90%     |
+| New types added in last 7 days (spike = possible dynamic value leak) | HIGH if spike      |
+| Total event volume change in last 7 days                             | HIGH if unexpected |
+| Number of duplicate types by name                                    | HIGH               |
+| Group types not instrumented (B2B products)                          | HIGH               |
+| A/B experiments tracked as events instead of user properties         | MEDIUM             |
+| Events with zero queries in 180 days                                 | MEDIUM             |
+| Events with zero volume in 180 days                                  | MEDIUM             |
+| Single-day events                                                    | MEDIUM             |
+| % of live events with descriptions                                   | LOW                |
+| % of live events with categories                                     | LOW                |
+| Number of Unexpected events/properties                               | LOW                |
+| Naming convention inconsistencies                                    | LOW                |
 
 ## Good vs. Bad Metadata Examples
 
 **Display names:**
 
-| Before | After |
-|--------|-------|
-| `catSelectClick` | `Category Selected` |
-| `pgVw` | `Page Viewed` |
-| `ord_compl_v2` | `Order Completed` |
-| `usr_prop_acct_tier` | `Account Tier` |
+| Before               | After               |
+| -------------------- | ------------------- |
+| `catSelectClick`     | `Category Selected` |
+| `pgVw`               | `Page Viewed`       |
+| `ord_compl_v2`       | `Order Completed`   |
+| `usr_prop_acct_tier` | `Account Tier`      |
 
 **Descriptions:**
 
-| Bad (implementation-focused) | Good (intent + context) |
-|------------------------------|------------------------|
-| "Fired on click handler for nav component" | "Triggered when a customer selects a product category from the navigation menu. Example categories: Electronics, Apparel, Home." |
-| "Event fired on submit" | "Triggered when a user completes checkout and confirms their order. Includes all line items, discounts applied, and final order total." |
-| "See tracking plan" | "Fired the first time a new user completes onboarding by verifying their email. Fires once per user lifetime only." |
+| Bad (implementation-focused)               | Good (intent + context)                                                                                                                 |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| "Fired on click handler for nav component" | "Triggered when a customer selects a product category from the navigation menu. Example categories: Electronics, Apparel, Home."        |
+| "Event fired on submit"                    | "Triggered when a user completes checkout and confirms their order. Includes all line items, discounts applied, and final order total." |
+| "See tracking plan"                        | "Fired the first time a new user completes onboarding by verifying their email. Fires once per user lifetime only."                     |
 
 ---
 
@@ -407,20 +425,25 @@ These are the actual Amplitude MCP server tools available for taxonomy work. Too
 ## Context
 
 ### `get_amplitude_context`
+
 Get information about the current user, organization, and accessible projects. Call this first to discover project IDs.
 
 ### `get_amplitude_context` with `projectId`
+
 Get project-specific settings: time zone, currency, session definition, AI context. Use to understand project configuration before making changes.
 
 ### `search`
+
 Search for charts, dashboards, notebooks, experiments, events, properties, cohorts, and other Amplitude content. Use this before `get_events` to find the event you're looking for.
 
 ### `get_workspace_settings`
+
 Get workspace settings including approval workflow status. Check before writing to the default branch — when `approvalWF` is "Required", the user must create a non-default branch first.
 
 ## Event Discovery
 
 ### `get_events`
+
 Retrieve events from a project with filtering by event types, limit, and cursor pagination. Returns full event objects including category and active status.
 
 If the connected MCP server's `get_events` input schema accepts `_client`, every
@@ -436,6 +459,7 @@ attribution exactly. Otherwise, omit `_client`.
 - If you know exact event type names, pass them via `eventTypes` for precise lookup.
 
 ### `get_custom_or_labeled_events`
+
 Retrieve custom events, labeled (autotrack) events, or both from a project.
 
 - `eventKind: "_all"` — both custom and labeled events (default).
@@ -444,28 +468,31 @@ Retrieve custom events, labeled (autotrack) events, or both from a project.
 - Returns `isAutotrack` flag, definition, and `flattenedDefinition` (source event lists).
 
 ### `get_transformations`
+
 Retrieve data transformations (merge events, merge properties, map property values) from a project. Use to audit data cleaning rules.
 
 ## Property Discovery
 
 ### `get_properties`
+
 Retrieve properties from a project's taxonomy. Use `propertyType` to select which kind:
 
-| `propertyType` | What it returns | Key params |
-|---|---|---|
-| `event` | Properties for a specific event type | `eventType` (required) |
-| `user` | User-level properties | `sources`, `name` |
-| `derived` | Computed/formula properties | `derivedPropertyType`, `names` |
-| `group` | Group properties (e.g., company_name, plan_tier) | `groupTypes` |
-| `lookup` | CSV lookup table properties | `configurationFilter`, `lookupTableName` |
-| `channel` | Traffic source channel properties | `names` |
-| `persisted` | Event-to-user persisted properties | `names` |
+| `propertyType` | What it returns                                  | Key params                               |
+| -------------- | ------------------------------------------------ | ---------------------------------------- |
+| `event`        | Properties for a specific event type             | `eventType` (required)                   |
+| `user`         | User-level properties                            | `sources`, `name`                        |
+| `derived`      | Computed/formula properties                      | `derivedPropertyType`, `names`           |
+| `group`        | Group properties (e.g., company_name, plan_tier) | `groupTypes`                             |
+| `lookup`       | CSV lookup table properties                      | `configurationFilter`, `lookupTableName` |
+| `channel`      | Traffic source channel properties                | `names`                                  |
+| `persisted`    | Event-to-user persisted properties               | `names`                                  |
 
 All property types except `event` support limit/cursor pagination.
 
 ## Metadata Updates
 
 ### `update_event`
+
 Update event metadata: descriptions, display names, categories, official status, and event names. Operates on the tracking plan.
 
 - Event type keys must match the event `name` exactly (case-sensitive) — not the `displayName`. Resolve via `get_events` first if needed.
@@ -475,17 +502,19 @@ Update event metadata: descriptions, display names, categories, official status,
 - Requires "Update Tracking Plan" permission.
 
 ### `update_properties`
+
 Update property metadata (description, official status, category, and/or name). Use `propertyType` to select which kind:
 
-| `propertyType` | What it updates | Key params |
-|---|---|---|
-| `event` | Event property metadata (global or event-scoped) | `metadataScope`, `eventType` (when scope is `"event"`) |
-| `user` | User property metadata | `descriptions`, `isOfficial`, `categories`, `newNames` |
+| `propertyType` | What it updates                                  | Key params                                             |
+| -------------- | ------------------------------------------------ | ------------------------------------------------------ |
+| `event`        | Event property metadata (global or event-scoped) | `metadataScope`, `eventType` (when scope is `"event"`) |
+| `user`         | User property metadata                           | `descriptions`, `isOfficial`, `categories`, `newNames` |
 
 - Use `get_properties` first to verify property names and status before updating.
 - Requires "Update Tracking Plan" permission.
 
 ### `update_custom_or_labeled_events`
+
 Update descriptions, categories, names, official status, and/or definitions on custom or labeled events.
 
 - Only use when the user explicitly asks to update a "custom event" or "labeled event." For regular events, use `update_event`.

--- a/plugins/amplitude/skills/weekly-brief/SKILL.md
+++ b/plugins/amplitude/skills/weekly-brief/SKILL.md
@@ -31,7 +31,7 @@ Before scanning data, build context about who you're talking to and what they ca
 
 Gather data with a full-week lens. The primary time window is **the last 7 complete days**. Use the prior 4 weeks as a comparison baseline to contextualize whether this week's numbers represent a meaningful shift or normal variance.
 
-**Important: Cast a wide net across the platform.** Don't limit yourself to the user's most-viewed dashboards. Use the official/top-viewed content discovered in Phase 1 to surface things the user *wouldn't* have seen on their own. But be efficient — batch calls and avoid redundant fetches.
+**Important: Cast a wide net across the platform.** Don't limit yourself to the user's most-viewed dashboards. Use the official/top-viewed content discovered in Phase 1 to surface things the user _wouldn't_ have seen on their own. But be efficient — batch calls and avoid redundant fetches.
 
 Run these in parallel where possible:
 
@@ -79,13 +79,13 @@ Transform your analysis into a concise, narrative briefing the user could forwar
 
 **Persona calibration:**
 
-| Persona     | Language Style                                         | Lead With                    |
-|-------------|--------------------------------------------------------|------------------------------|
-| Executive   | Strategic (revenue, competitive position, market share) | Business outcomes            |
-| PM          | Feature-oriented (conversion, activation, adoption)    | Experiment results, funnels  |
-| Analyst     | Methodological (p-values, significance, confidence)    | Statistical rigor, drill-downs |
-| Growth      | Channel-focused (LTV, retention cohort, acquisition)   | Acquisition and retention    |
-| Engineering | Technical (error rate, p95 latency, crash-free rate)   | Deployments, error spikes    |
+| Persona     | Language Style                                          | Lead With                      |
+| ----------- | ------------------------------------------------------- | ------------------------------ |
+| Executive   | Strategic (revenue, competitive position, market share) | Business outcomes              |
+| PM          | Feature-oriented (conversion, activation, adoption)     | Experiment results, funnels    |
+| Analyst     | Methodological (p-values, significance, confidence)     | Statistical rigor, drill-downs |
+| Growth      | Channel-focused (LTV, retention cohort, acquisition)    | Acquisition and retention      |
+| Engineering | Technical (error rate, p95 latency, crash-free rate)    | Deployments, error spikes      |
 
 **Writing standards:**
 
@@ -121,6 +121,7 @@ Before delivering, verify your work. Prefer reviewing data you already have over
 User says: "Give me my weekly summary"
 
 Actions:
+
 1. Detect persona from context (executive based on dashboard usage patterns)
 2. Discover official dashboards, top-viewed charts across the org, and recently modified content
 3. Query all discovered charts at weekly granularity over the last 5 weeks, rank by WoW magnitude
@@ -143,6 +144,7 @@ Example output:
 > API growth is genuinely compounding with no signs of flattening — the power user cohort growing 30% WoW validates that customers are finding real value, not just kicking tires. Scheduled workflow adoption continues at a healthy clip (~450 new this week), signaling sticky, recurring usage.
 >
 > **Next week's priorities**
+>
 > 1. Segment the notification open rate decline by user activity level (power users vs. casual) and notification frequency to determine if fatigue is concentrated in high-volume recipients — this tells you whether frequency caps or digest mode is the right fix.
 > 2. Build a dashboard tracking the assistant feature's weekly trajectory, including active users, message volume, engagement rate, and satisfaction ratio by week — you need a persistent view to spot the inflection from early adopter to mainstream.
 > 3. Run a funnel analysis on API power users (50+ calls/week) to understand what they do differently in their first 7 days vs. users who churn — use this to inform an activation campaign for the next tier of adopters.
@@ -152,21 +154,26 @@ Example output:
 ## Troubleshooting
 
 ### Error: No dashboards found
+
 Cause: User may not have created dashboards, or the project has limited setup.
 Solution: Fall back to searching for any charts or events. Use `search` broadly and build context from whatever is available. Let the user know their setup is limited and suggest creating a key metrics dashboard.
 
 ### Error: Feedback API returns 400
+
 Cause: Called `get_feedback_insights` without first calling `get_feedback_sources`, or passed multiple values in the `types` array.
 Solution: ALWAYS call `get_feedback_sources` first. Only pass a single type value per call, or omit the types parameter entirely.
 
 ### Error: Metrics look flat / nothing interesting
+
 Cause: This week looks similar to the prior 4 weeks — stability is a finding worth reporting.
 Solution: Frame it as a positive: "Your key metrics held steady this week — no fires and no regressions. Here are the slow-moving trends worth watching over the next 2-4 weeks..."
 
 ### Error: Too many findings, report is overwhelming
+
 Cause: Broad gathering surfaced too much signal.
 Solution: Ruthlessly prioritize. Cap at 5 findings maximum. Use severity scoring (impact × confidence × strategic relevance) to rank. Merge related findings into narrative threads. Demote lower-priority items to a "Background Context" appendix.
 
 ### Error: Current week is only partially complete
+
 Cause: User asks for a weekly brief mid-week.
 Solution: Explicitly note the partial status up front ("through Wednesday, 4 of 7 days"). Compare pace (e.g., through-Wednesday this week vs. through-Wednesday last week) rather than raw weekly totals. Caveat any projections and avoid declaring trends based on incomplete data.

--- a/plugins/amplitude/skills/what-would-lenny-do/SKILL.md
+++ b/plugins/amplitude/skills/what-would-lenny-do/SKILL.md
@@ -42,6 +42,7 @@ From your search results, identify the **2–4 most relevant pieces** using this
 - **Diversity of perspective**: Where possible, include at least one founder/exec voice alongside a PM/operator voice
 
 For each selected piece:
+
 - **Full read** (`lennysdata:read_content`): Use when the piece is central and you need the full context, framework, or narrative arc
 - **Excerpt** (`lennysdata:read_excerpt`): Use when you only need a specific section — saves context and is faster when the piece is long and the relevant part is well-defined
 
@@ -62,7 +63,7 @@ Structure your response as:
 
 **The question, sharpened** (1 sentence): Restate the user's question in its clearest possible form — the real question is often subtly different from what was asked.
 
-**What the archive says** (3–5 paragraphs): Explore the solution space using specific frameworks, quotes, and operator experiences from what you read. Cover 2–3 distinct strategies or angles. Don't just summarize — *apply* the frameworks to the user's specific situation. Each paragraph should represent a distinct perspective, strategy, or tradeoff. Name the source and guest inline naturally: "In his conversation with Lenny, Jason Cohen argues..." or "Molly Graham's framework for rapid scale suggests..."
+**What the archive says** (3–5 paragraphs): Explore the solution space using specific frameworks, quotes, and operator experiences from what you read. Cover 2–3 distinct strategies or angles. Don't just summarize — _apply_ the frameworks to the user's specific situation. Each paragraph should represent a distinct perspective, strategy, or tradeoff. Name the source and guest inline naturally: "In his conversation with Lenny, Jason Cohen argues..." or "Molly Graham's framework for rapid scale suggests..."
 
 **The call** (1–2 paragraphs): Give a concrete, opinionated recommendation. Don't retreat into "it depends" — commit to a direction, explain the reasoning, and note the conditions under which a different path would be right. Lenny always makes a call; so should you.
 
@@ -93,6 +94,7 @@ Format: `— [Title] ([Guest], [Date]) — [what it contributed]`
 User asks: "We're at $2M ARR and growth has plateaued. What should I focus on?"
 
 Actions:
+
 1. Extract: stalled growth, ~$2M ARR, prioritization under uncertainty
 2. Search: "growth plateau stalled" + "5 questions product stops growing"
 3. Read Jason Cohen episode (5-question framework), Elena Verna episode (growth systems)
@@ -104,6 +106,7 @@ Actions:
 User asks: "How do I lead a team through rapid headcount growth without losing culture?"
 
 Actions:
+
 1. Extract: leadership at scale, managing culture through growth, team change management
 2. Search: "scale rapidly chaos leadership culture" + "leading growth change frameworks"
 3. Read Molly Graham episode (leading through chaos), Matt MacInnis episode (contrarian leadership truths)
@@ -115,6 +118,7 @@ Actions:
 User asks: "We're shipping AI features but users aren't adopting them. How do we change that?"
 
 Actions:
+
 1. Extract: AI feature adoption, user trust, behavioral friction
 2. Search: "AI product adoption trust users" + "eval feedback loop AI features"
 3. Read Hamel Husain/Shreya Shankar episode (AI evals), Aishwarya/Kiriti episode (actionable feedback loops)
@@ -126,6 +130,7 @@ Actions:
 User asks: "How should we price our new AI product?"
 
 Actions:
+
 1. Extract: AI product pricing model, value capture, B2B SaaS context
 2. Search: "pricing AI product lessons" + "outcome-based pricing SaaS"
 3. Read Madhavan Ramanujam episode (lessons from 400+ companies), Intercom/Eoghan McCabe episode (betting on AI, pricing shift)
@@ -135,16 +140,21 @@ Actions:
 ## Troubleshooting
 
 ### Search returns no relevant results
+
 Try shorter, more concrete keywords. Try synonyms or reframe around the underlying problem (e.g., "users don't trust AI" → "AI adoption friction" → "feature adoption behavioral"). As a fallback, `list_content` by recency and scan the last 6 months of titles and descriptions manually.
 
 ### Content is tangentially related but not a direct match
+
 Still use it — analogous situations are valuable. Explicitly frame it: "In an analogous situation, [guest] found that..." rather than pretending it's a perfect fit.
 
 ### User question is very broad
+
 Sharpen it before searching. Ask yourself: what specific tension is the user facing? Are they asking about prioritization? Team dynamics? User research? Pick the most likely specific interpretation and search for that. If genuinely ambiguous, ask one clarifying question.
 
 ### Conflicting advice across sources
+
 Surface the tension explicitly: "Lenny's conversation with X suggests doing Y, while Z recommends the opposite because..." Then explain which context determines which path is right — and still make your call.
 
 ### Strong search results but very long articles
+
 Use `read_excerpt` to extract the most relevant sections rather than reading the full piece. This keeps your context focused and your answer sharper.


### PR DESCRIPTION
## Summary
- Update Amplitude marketplace skills to the GA consolidated MCP tools (`get_amplitude_charts`, `query_amplitude_data`, `use_amp_experiments`, `use_amp_flags`, `get_amp_session_replay_info`, `search_amp_entities`, `get_amplitude_context`, etc.).
- Keep flag-gated skill pairs for charts and experiments now that `mcp-consolidate-*` is 100% in US/EU.

Linear: https://linear.app/amplitude/issue/MCP-679/mcp-server-ship-ga-consolidated-mcp-skills-and-pin-the-marketplace

## Test plan
- [ ] Spot-check a chart skill (`create-chart`, `build-charts-with-typed-params`) for `query_amplitude_data` / `get_amplitude_charts`
- [ ] Spot-check experiment skills for `use_amp_experiments` / `use_amp_flags`
- [ ] Confirm `x-amp-flags` / `x-amp-exclude-when-flags` still pair legacy vs consolidated skill variants
- [ ] Follow-up pin PR in `amplitude/javascript` for `server/packages/mcp-server/skills-marketplace`


Made with [Cursor](https://cursor.com)