### PR TITLE
MCP-679 [skills] update skills for GA consolidated MCP tools

### DIFF
--- a/plugins/amplitude/skills/analyze-account-health/SKILL.md
+++ b/plugins/amplitude/skills/analyze-account-health/SKILL.md
@@ -16,7 +16,7 @@ Deep-dive into a B2B account's product usage to prepare for QBRs, assess renewal
 - Ask user if not provided
 
 **Search for existing work:**
-Use `Amplitude:search` to find existing dashboards, charts, or notebooks for this account. If found, ask user if they want fresh analysis or to review existing.
+Use `Amplitude:search_amp_entities` to find existing dashboards, charts, or notebooks for this account. If found, ask user if they want fresh analysis or to review existing.
 
 **Resolve how accounts are modelled — do this before any query.**
 Every step below breaks down "by account", and there are three different ways a
@@ -41,7 +41,7 @@ used, since the numbers are not interchangeable.
 
 ### Step 1: Quick Health Triage
 
-Use `Amplitude:query_dataset` to run these queries in parallel:
+Use `Amplitude:query_amplitude_data` to run these queries in parallel:
 
 **Usage Trend:**
 - Event: `_active`, Metric: `uniques`, Group by: the account property resolved in Step 0 (with its scope)
@@ -66,7 +66,7 @@ Use `Amplitude:query_dataset` to run these queries in parallel:
 
 ### Step 2: User-Level Analysis
 
-Use `Amplitude:query_dataset` with user-level groupBy:
+Use `Amplitude:query_amplitude_data` with user-level groupBy:
 
 **Power Users:**
 - Top 3-5 users by event volume (champions to leverage)
@@ -81,7 +81,7 @@ Use `Amplitude:query_dataset` with user-level groupBy:
 
 ### Step 3: Feature Usage Analysis
 
-Use `Amplitude:query_dataset` grouped by events/features:
+Use `Amplitude:query_amplitude_data` grouped by events/features:
 
 **Feature Breadth:**
 - Which core features are being used (ask user for 5-10 key features)
@@ -100,16 +100,16 @@ Use `Amplitude:query_dataset` grouped by events/features:
 ### Step 4: Account Feedback Analysis
 
 **Get feedback sources:**
-Use `Amplitude:get_feedback_sources` to see what's available.
+Use `Amplitude:use_amplitude_ai_feedback` with `facet: "sources"` to see what's available.
 
 **Get feedback insights:**
-Use `Amplitude:get_feedback_insights` filtered by:
+Use `Amplitude:use_amplitude_ai_feedback` with `facet: "insights"` filtered by:
 - ampId for each user in the account
 - dateStart/dateEnd: Last 90 days
 - types: `bug`, `painPoint`, `complaint`, `request`, `lovedFeature`
 
 **Get specific mentions:**
-For top 3-5 insights, use `Amplitude:get_feedback_mentions` to get quotes.
+For top 3-5 insights, use `Amplitude:use_amplitude_ai_feedback` with `facet: "mentions"` to get quotes.
 
 **Correlate with behavior:**
 - Complaint about Feature X? Query their usage of Feature X

--- a/plugins/amplitude/skills/analyze-ai-topics/SKILL.md
+++ b/plugins/amplitude/skills/analyze-ai-topics/SKILL.md
@@ -13,20 +13,20 @@ You analyze what users ask AI agents about and how well each topic is served —
 ### Step 1: Get Context and Schema
 
 1. **Get context.** Call `Amplitude:get_amplitude_context` to identify projects and user role.
-2. **Get AI schema.** Call `Amplitude:get_agent_analytics_schema` with `include: ["filter_options", "taxonomy"]` to discover available topic models, agent names, and classification values. The schema tells you what topic dimensions exist (e.g., product_area, intent, error_domain) — these vary by project.
+2. **Get AI schema.** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "schema"` to discover available topic models, agent names, and classification values. The schema tells you what topic dimensions exist (e.g., product_area, intent, error_domain) — these vary by project.
 3. **Determine scope.** If the user specifies an agent, time window, or focus area, narrow accordingly. Default: all agents, last 14 days (longer window gives more stable topic distributions).
 
 ### Step 2: Map the Topic Landscape
 
 Run these in parallel:
 
-1. **Topic breakdown with quality.** Call `Amplitude:query_agent_analytics_metrics` with `metrics: ["topics"]`, `limit: 50`. This returns each topic with session count, average quality score, average sentiment, and failure rate. This is the core dataset.
+1. **Topic breakdown with quality.** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "sessions"` to retrieve sessions, then aggregate their evaluator results by topic into session count, average quality score, average sentiment, and failure rate. Limit the output to 50 topics. This is the core dataset.
 
-2. **Agent-by-topic matrix.** Call `Amplitude:query_agent_analytics_sessions` with `groupBy: ["agent_name", "primary_topic"]`, `limit: 100`. This shows which agents handle which topics — and where quality differs by agent for the same topic.
+2. **Agent-by-topic matrix.** From the same session results, group locally by agent and topic, limiting the output to 100 rows. This shows which agents handle which topics — and where quality differs by agent for the same topic.
 
-3. **Volume trend by topic.** Call `Amplitude:query_agent_analytics_metrics` with `metrics: ["volume_timeseries"]`, `interval: "DAY"`. While this is aggregate, combine it with the topic breakdown to understand whether total volume growth is driven by specific topics.
+3. **Volume trend by topic.** Group the session results locally by day and topic. Combine this with the topic breakdown to understand whether total volume growth is driven by specific topics.
 
-4. **Failure sessions by topic.** Call `Amplitude:query_agent_analytics_sessions` with `hasTaskFailure: true`, `groupBy: ["primary_topic"]`, `limit: 50`. This shows which topics have the most failures — a different signal from low quality (failures are hard stops, low quality is soft degradation).
+4. **Failure sessions by topic.** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "sessions"` and `hasTaskFailure: true`, then group the returned sessions locally by topic. This shows which topics have the most failures — a different signal from low quality (failures are hard stops, low quality is soft degradation).
 
 ### Step 3: Identify Underserved Topics
 
@@ -48,14 +48,14 @@ Also flag:
 
 For the 2-3 most impactful underserved topics:
 
-1. **Sample conversations.** Call `Amplitude:search_agent_analytics_conversations` with keywords from the topic to find representative conversations. Read 3-5 examples to understand:
+1. **Sample conversations.** Select representative sessions for the topic from the evaluator results, then call `Amplitude:get_amplitude_agent_analytics_info` with `view: "conversation"` for 3-5 examples to understand:
    - What specifically are users asking?
    - Where does the agent struggle — wrong answer, no answer, wrong tool, slow response?
    - Are there sub-patterns within the topic?
 
-2. **Detailed failing sessions.** Call `Amplitude:query_agent_analytics_sessions` filtered to the topic with `hasTaskFailure: true` or `maxQualityScore: 0.5`, `responseFormat: "detailed"`, `limit: 5`. Read the enrichment data for failure reasons and rubric scores.
+2. **Detailed failing sessions.** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "sessions"` and `hasTaskFailure: true`, then select up to 5 sessions for the topic or with evaluator quality scores at or below 0.5. Read the enrichment data for failure reasons and rubric scores.
 
-3. **Tool usage for the topic.** Call `Amplitude:query_agent_analytics_metrics` with `metrics: ["tool_stats"]` — if you can filter to sessions for this topic. Otherwise, pull span data for a few failing sessions with `Amplitude:query_agent_analytics_spans` to see which tools are involved.
+3. **Tool usage for the topic.** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "spans"` for a few representative failing sessions to see which tools are involved.
 
 ### Step 5: Synthesize into Product Insights
 
@@ -134,7 +134,7 @@ Actions:
 ## Troubleshooting
 
 ### No topic enrichment data
-Topics require session enrichment to be enabled. If topics are empty, fall back to `search_agent_analytics_conversations` with broad keyword searches to manually categorize common themes. Note the limitation and suggest enabling enrichment.
+Topics require session enrichment to be enabled. If topics are empty, use `get_amplitude_agent_analytics_info` with `view: "sessions"` to sample sessions, then `view: "conversation"` to manually categorize common themes. Note the limitation and suggest enabling enrichment.
 
 ### Too many topics (>50)
 Group similar topics and present the top 20 by volume. Offer to drill into specific clusters on request.

--- a/plugins/amplitude/skills/analyze-dashboard/SKILL.md
+++ b/plugins/amplitude/skills/analyze-dashboard/SKILL.md
@@ -21,11 +21,11 @@ If the user gives a URL, use `Amplitude:get_from_url` to get the dashboard ID
 
 ### Step 1: Retrieve the Dashboard
 
-Use `Amplitude:get_dashboard` with the dashboard ID to get the full structure and chart IDs.
+Use `Amplitude:use_amp_dashboards` with `action: "get"` and the dashboard ID to get the full structure and chart IDs.
 
 ### Step 2: Query All Charts
 
-Use `Amplitude:query_charts` to fetch data for up to 3 charts at a time. Prioritize:
+Use `Amplitude:get_amplitude_charts` with `include: "data"` to fetch data for up to 3 charts at a time. Prioritize:
 
 1. Primary KPI charts (usually at the top)
 2. Charts with recent changes
@@ -47,7 +47,7 @@ When analyzing charts, focus on the most decision-relevant signals for each type
 
 If significant changes or anomalies are detected, check if user feedback can explain them:
 
-1. Use `Amplitude:get_feedback_insights` with:
+1. Use `Amplitude:use_amplitude_ai_feedback` with `facet: "insights"` and:
    - The same `projectId` as the dashboard
    - `dateStart` and `dateEnd` matching the analysis period
    - Filter by relevant types: `request`, `complaint`, `lovedFeature`, `bug`, `painPoint`
@@ -57,7 +57,7 @@ If significant changes or anomalies are detected, check if user feedback can exp
    - Bug reports coinciding with conversion dips
    - Loved features matching usage increases
 
-3. If a relevant insight is found, use `Amplitude:get_feedback_mentions` with the `insightId` to pull specific user quotes that illustrate the pattern.
+3. If a relevant insight is found, use `Amplitude:use_amplitude_ai_feedback` with `facet: "mentions"` and the `insightId` to pull specific user quotes that illustrate the pattern.
 
 **Skip this step if:**
 - No feedback sources are configured for the project

--- a/plugins/amplitude/skills/analyze-experiment-consolidated/SKILL.md
+++ b/plugins/amplitude/skills/analyze-experiment-consolidated/SKILL.md
@@ -37,7 +37,7 @@ Perform comprehensive, detailed deep-dive analysis of experiments to make data-d
 - If ID: proceed to Step 1
 
 **If user asks about experiments generally:**
-- Use `Amplitude:search` with `entityTypes: ["EXPERIMENT"]` and relevant query terms
+- Use `Amplitude:search_amp_entities` with `entityTypes: ["EXPERIMENT"]` and relevant query terms
 - Present top 3-5 matches with names, IDs, and states
 - Ask user which experiment to analyze
 
@@ -60,8 +60,8 @@ Use `Amplitude:use_amp_experiments` with experiment ID to capture:
 - Extract metric IDs from the experiment response (e.g., "c4pn8fkv")
 - **CRITICAL: Amplitude MCP cannot retrieve metric names by ID directly**
 - Workaround options:
-  1. Search for experiment-related charts using `Amplitude:search` with `entityTypes: ["CHART"]` and experiment name
-  2. Use `Amplitude:get_charts` on related charts to examine their definitions for metric references
+  1. Search for experiment-related charts using `Amplitude:search_amp_entities` with `entityTypes: ["CHART"]` and experiment name
+  2. Use `Amplitude:get_amplitude_charts` with `include: "definition"` on related charts to examine their definitions for metric references
   3. Check if experiment description contains links to metric documentation
 - If metric names cannot be found, report as descriptive placeholders:
   - Primary metric: "Primary Goal Metric (ID: {id})"
@@ -83,13 +83,14 @@ If incomplete, explain what's missing and stop.
 when you need ad hoc per-variant numbers outside `analyze` (entry-point
 funnels, custom slices, cross-checks against another warehouse):
 
-- Discover the assignment event first: `search` for the experiment's flag
-  key and existing charts that filter on it — do not guess the event name.
+- Discover the assignment event first: use `search_amp_data_taxonomy` for the
+  experiment's flag key and `search_amp_entities` for existing charts that
+  filter on it — do not guess the event name.
 - Read how an existing experiment chart structures its variant segments
   (`get_amplitude_charts` with `include: "typed"` on one) and copy that
   pattern exactly — including the bucketing property (`subject_id_type`
   varies per experiment).
-- Verify assignment volume before analyzing: `query_dataset` for unique
+- Verify assignment volume before analyzing: `query_amplitude_data` for unique
   assignments per variant since launch. Zero or lopsided assignment =
   bucketing/ramp problem, not a metric result.
 
@@ -301,7 +302,7 @@ Based on the power and precision analysis from Step 2, evaluate if the experimen
 
 **For significant results (positive or negative):**
 
-Use `Amplitude:get_feedback_insights`:
+Use `Amplitude:use_amplitude_ai_feedback` with `facet: "insights"`:
 - Filter by experiment date range
 - For wins: look for `["lovedFeature", "mentionedFeature"]`
 - For losses: look for `["bug", "complaint", "painPoint"]`
@@ -525,14 +526,14 @@ If user wants to **design a new experiment**, guide them through:
 1. **Define hypothesis:** "We believe [change] will cause [users] to [behavior] because [reason]"
 
 2. **Select metrics:**
-   - Use `Amplitude:search` with `entityTypes: ["METRIC"]` to find candidates
+   - Use `Amplitude:search_amp_entities` with `entityTypes: ["METRIC"]` to find candidates
    - Primary: directly measures hypothesis
    - Guardrails: revenue, retention, core engagement (prevent unintended consequences)
 
 3. **Estimate sample size:**
    - Typical: 1-2 weeks minimum, 1000+ users per variant
    - Higher variance metrics need more data
-   - Use `Amplitude:query_charts` to check metric's historical variance
+   - Use `Amplitude:query_amplitude_data` to check the metric's historical variance
 
 4. **Create experiment:**
    - Use `Amplitude:use_amp_experiments` with projectIds, variants, and metrics

--- a/plugins/amplitude/skills/analyze-feedback/SKILL.md
+++ b/plugins/amplitude/skills/analyze-feedback/SKILL.md
@@ -11,11 +11,11 @@ Perform comprehensive feedback reviews, investigate specific feature requests, u
 
 ### Step 1: Understand Available Sources
 
-Use `Amplitude:get_feedback_sources` to see which feedback channels are connected (surveys, support, app reviews, etc.).
+Use `Amplitude:use_amplitude_ai_feedback` with `facet: "sources"` to see which feedback channels are connected (surveys, support, app reviews, etc.).
 
 ### Step 2: Get Themed Insights
 
-Use `Amplitude:get_feedback_insights` with appropriate filters:
+Use `Amplitude:use_amplitude_ai_feedback` with `facet: "insights"` and appropriate filters:
 
 - Filter by types: `request`, `complaint`, `lovedFeature`, `bug`, `painPoint`
 - Filter by date range for recent feedback
@@ -23,11 +23,11 @@ Use `Amplitude:get_feedback_insights` with appropriate filters:
 
 ### Step 3: Drill Into Specific Themes
 
-For top insights, use `Amplitude:get_feedback_mentions` to see the actual user feedback driving each theme.
+For top insights, use `Amplitude:use_amplitude_ai_feedback` with `facet: "mentions"` to see the actual user feedback driving each theme.
 
 ### Step 4: Connect to User Segments
 
-Use `Amplitude:get_cohorts` to understand if feedback themes correlate with:
+Use `Amplitude:use_amplitude_cohorts` with `action: "list"` to understand if feedback themes correlate with:
 
 - User tenure (new vs. established)
 - Plan type (free vs. paid)

--- a/plugins/amplitude/skills/build-charts-with-typed-params/SKILL.md
+++ b/plugins/amplitude/skills/build-charts-with-typed-params/SKILL.md
@@ -29,7 +29,7 @@ The compiler validates **structure**, not your taxonomy. An event or property
 name that doesn't exist won't error — it returns a well-formed chart with
 **empty data**, which reads like a real answer of "zero".
 
-Resolve names first with `search`, and `get_properties`
+Resolve names first with `search_amp_data_taxonomy`, and `get_properties`
 (`propertyType: 'event'`, `'user'`, or `'group'`). Use the exact name **and
 scope** that comes back. There is no `get_event_properties` tool — server
 descriptions and error messages sometimes mention it; use `get_properties`
@@ -37,11 +37,11 @@ instead.
 
 ## Two workflows
 
-**Create:** `search` for the taxonomy → build the typed `chart` → call
+**Create:** `search_amp_data_taxonomy` for the taxonomy → build the typed `chart` → call
 `query_amplitude_data` → `render_amplitude_chart` with the returned
 `chartEditId` to show it.
 
-**Modify or fork a saved chart:** `search` to find the chart id →
+**Modify or fork a saved chart:** `search_amp_entities` to find the chart id →
 `get_amplitude_charts` with `include: 'typed'` → edit the returned object →
 call `query_amplitude_data` with that `chart` **and** `chartId` set to the saved
 chart id. Passing `chartId` links the edit to its parent, and the parent's
@@ -51,7 +51,7 @@ params is also the fastest way to see how this project spells things.
 `get_amplitude_charts` has five modes on `include`: `link` (default; validates
 ids, returns URLs, doesn't run the chart), `typed`, `definition` (raw), `data`
 (runs it, max 3 ids), and `guide` (schema for the raw fallback). All except
-`guide` need concrete ids — resolve them via `search` or `get_from_url` first.
+`guide` need concrete ids — resolve them via `search_amp_entities` or `get_from_url` first.
 
 ## Building blocks
 
@@ -275,7 +275,7 @@ rather than trying a third spelling.
 
 ## When results come back empty
 
-1. Re-read every event and property name from `search` / `get_properties`, and
+1. Re-read every event and property name from `search_amp_data_taxonomy` / `get_properties`, and
    check the `scope` matches what the taxonomy returned — including
    `propertyType: 'group'` for account-level properties.
 2. Widen `date_range` — the window may predate instrumentation.

--- a/plugins/amplitude/skills/chart-link-analysis/SKILL.md
+++ b/plugins/amplitude/skills/chart-link-analysis/SKILL.md
@@ -45,9 +45,3 @@ understood, refreshed, or adapted.
   definitions first, then decide which 1–3 charts actually need data.
 - Just need the link for the user? `include: 'link'` (the default) validates
   the ids and returns URLs without running anything.
-
-## Legacy surface
-
-If `get_amplitude_charts` is not in the tool list: `get_charts` reads
-definitions, `query_charts` (≤3 ids) pulls data, `query_dataset` runs ad
-hoc, and `save_chart_edits` persists edits. The arc is unchanged.

--- a/plugins/amplitude/skills/compare-user-journeys/SKILL.md
+++ b/plugins/amplitude/skills/compare-user-journeys/SKILL.md
@@ -13,16 +13,16 @@ Investigate what distinguishes two user groups by pulling session replays and me
 ## CRITICAL: Tool Reference
 
 **Primary tools:**
-- **`Amplitude:get_session_replays`** — Find sessions for each user group using event count filters and user property filters. Run this twice — once per group.
-- **`Amplitude:get_session_replay_events`** — Decode replays into interaction timelines. Run this for sessions from both groups.
+- **`Amplitude:get_amp_session_replay_info`** with `action: "search"` — Find sessions for each user group using event count filters and user property filters. Run this twice — once per group.
+- **`Amplitude:get_amp_session_replay_info`** with `action: "events"` — Decode replays into interaction timelines. Run this for sessions from both groups.
 
 **Supporting tools:**
-- **`Amplitude:search`** — Search for existing charts, funnels, dashboards, events, and cohorts relevant to the comparison. Always check for existing analysis before building from scratch.
-- **`Amplitude:get_cohorts`** — Discover existing cohorts that define the groups (e.g., "power users", "churned", "converted").
-- **`Amplitude:get_events`** — Discover valid event names. Never guess event names.
+- **`Amplitude:search_amp_entities`** — Search for existing charts, funnels, dashboards, and cohorts relevant to the comparison. Always check for existing analysis before building from scratch.
+- **`Amplitude:use_amplitude_cohorts`** with `action: "list"` — Discover existing cohorts that define the groups (e.g., "power users", "churned", "converted").
+- **`Amplitude:manage_amp_events`** with `action: "get"` and `kind: "event"` — Discover valid event names. Never guess event names.
 - **`Amplitude:get_properties`** — Discover properties available for segmentation.
-- **`Amplitude:query_charts`** / **`Amplitude:query_charts`** — Pull quantitative metrics segmented by the two groups for statistical grounding.
-- **`Amplitude:get_feedback_insights`** / **`Amplitude:get_feedback_mentions`** — Check if feedback themes differ between groups.
+- **`Amplitude:get_amplitude_charts`** with `include: "data"` — Pull quantitative metrics segmented by the two groups for statistical grounding.
+- **`Amplitude:use_amplitude_ai_feedback`** with `facet: "insights"` / `facet: "mentions"` — Check if feedback themes differ between groups.
 
 ---
 
@@ -50,17 +50,17 @@ If the user's request is ambiguous (e.g., "compare power users"), ask: "What def
 ### Step 2: Get Context and Discover Segments
 
 1. Call `Amplitude:get_amplitude_context`. If multiple projects, ask which to compare within.
-2. Call `Amplitude:get_cohorts` to check if existing cohorts match the requested groups. Existing cohorts encode institutional knowledge — prefer them over ad-hoc definitions.
-3. Call `Amplitude:get_events` to discover events relevant to the comparison (the goal event for conversion comparisons, engagement events for activity comparisons, etc.).
+2. Call `Amplitude:use_amplitude_cohorts` with `action: "list"` to check if existing cohorts match the requested groups. Existing cohorts encode institutional knowledge — prefer them over ad-hoc definitions.
+3. Call `Amplitude:manage_amp_events` with `action: "get"` and `kind: "event"` to discover events relevant to the comparison (the goal event for conversion comparisons, engagement events for activity comparisons, etc.).
 4. Call `Amplitude:get_properties` for the key events to discover available segmentation properties.
 
 ### Step 3: Quantitative Comparison (Metrics)
 
 Before watching replays, establish the statistical picture. Budget: 3-4 chart queries.
 
-**First, search for existing analysis.** Call `Amplitude:search` with keywords related to the comparison (e.g., "onboarding funnel", "agent creation", "checkout conversion"). Existing charts and funnels encode institutional knowledge and save query budget. If you find a relevant funnel or segmented chart, use `Amplitude:query_charts` on it instead of building from scratch.
+**First, search for existing analysis.** Call `Amplitude:search_amp_entities` with keywords related to the comparison (e.g., "onboarding funnel", "agent creation", "checkout conversion"). Existing charts and funnels encode institutional knowledge and save query budget. If you find a relevant funnel or segmented chart, use `Amplitude:get_amplitude_charts` with `include: "data"` on it instead of building from scratch.
 
-Use `Amplitude:query_charts` or `Amplitude:query_charts` to compare the two groups on:
+Use `Amplitude:get_amplitude_charts` with `include: "data"` to compare the two groups on:
 
 1. **Volume & composition**: How many users are in each group? What's the ratio?
 2. **Key metrics segmented by group**: Conversion rates, session frequency, feature adoption, retention — whatever metrics are most relevant to the comparison.
@@ -76,7 +76,7 @@ Record the top 3-5 quantitative differences — these become hypotheses to valid
 
 ### Step 4: Find Sessions for Both Groups
 
-Run `Amplitude:get_session_replays` **twice** — once for each group. Request `limit: 8` for each.
+Run `Amplitude:get_amp_session_replay_info` with `action: "search"` **twice** — once for each group. Request `limit: 8` for each.
 
 **Exclude internal users by default.** Unless you're specifically studying internal behavior, add a user property filter to exclude your company's email domain (e.g., `gp:email does not contain "amplitude.com"`). This prevents internal test sessions from polluting the comparison.
 
@@ -85,20 +85,21 @@ Run `Amplitude:get_session_replays` **twice** — once for each group. Request `
 If groups are defined by a **cohort**, filter on the cohort's defining user property or event.
 
 If groups are defined by an **event outcome** (e.g., completed checkout vs. didn't):
-- **Group A (converters)**: Filter for sessions containing the conversion event (use `eventCountFilters` with `operator: "greater or equal"`, `count: "1"`).
-- **Group B (drop-offs)**: Filter for sessions containing the entry event but NOT the conversion event. Since `get_session_replays` doesn't support "did not do" filters directly, filter for the entry event only, then when watching replays in Step 5, check the interaction timeline for absence of the conversion event. Discard sessions where the user actually converted and replace with additional sessions until you have 4-6 confirmed drop-offs.
+- **Group A (converters)**: Filter for sessions containing the conversion event
+  (use `events: [{"name": "<conversion event>", "minCount": 1}]`).
+- **Group B (drop-offs)**: Filter for sessions containing the entry event but NOT the conversion event. Since `get_amp_session_replay_info` with `action: "search"` doesn't support "did not do" filters directly, filter for the entry event only, then when watching replays in Step 5, check the interaction timeline for absence of the conversion event. Discard sessions where the user actually converted and replace with additional sessions until you have 4-6 confirmed drop-offs.
 
 If groups are defined by a **user property** (plan, segment):
 - Use user property filters with `event_type: "_all"`.
 
 ### Step 5: Watch Sessions — Extract Interaction Timelines
 
-For each group, call `Amplitude:get_session_replay_events` for 4-6 sessions. Use `event_limit: 300`.
+For each group, call `Amplitude:get_amp_session_replay_info` with `action: "events"` for 4-6 sessions. Use `event_limit: 300`.
 
 **Budget: 8-12 total sessions (4-6 per group).**
 
 **Rate limiting and large responses:**
-- Call `get_session_replay_events` in batches of 3-4 at a time, not all at once. The Session Replay API enforces concurrency limits and will return 429 errors if overwhelmed. If you hit a 429, wait briefly and retry.
+- Call `get_amp_session_replay_info` with `action: "events"` in batches of 3-4 at a time, not all at once. The Session Replay API enforces concurrency limits and will return 429 errors if overwhelmed. If you hit a 429, wait briefly and retry.
 - Some sessions have extremely high interaction counts (100K+ raw events). If a response is too large and gets saved to a file, read the key portions from the saved file path. For sessions with very high `total_raw_events`, consider using a lower `event_limit` (e.g., 150) to stay within response size limits.
 
 **While analyzing, track these behavioral dimensions for each session:**
@@ -131,7 +132,7 @@ This is the core analytical step. Compare the two groups across the dimensions a
    - "Converters use templates because templates reduce time-to-value. If we surfaced templates more prominently, more users might convert."
    - "Churned users hit errors on the integration page. Fixing these errors could reduce churn."
 
-5. **Cross-reference with feedback** (optional but valuable). Call `Amplitude:get_feedback_insights` with terms related to the differentiating actions. If Group B complains about something Group A doesn't, that strengthens the signal.
+5. **Cross-reference with feedback** (optional but valuable). Call `Amplitude:use_amplitude_ai_feedback` with `facet: "insights"` and terms related to the differentiating actions. If Group B complains about something Group A doesn't, that strengthens the signal.
 
 ### Step 7: Present the Behavioral Comparison
 
@@ -193,7 +194,7 @@ For each differentiating behavior:
 - **One group has few sessions.** If one group has <3 watchable sessions, note the limited sample and reduce confidence. Present findings as "preliminary" and suggest waiting for more data or broadening the time window.
 - **User asks to compare 3+ groups.** Decline and suggest pairwise comparison: "Comparing more than 2 groups at once dilutes the analysis. Which two would you like me to start with?" Offer to run a second comparison after.
 - **Cohort doesn't exist.** If the user references a segment that doesn't have a cohort, build the group filter from events and user properties. Suggest creating a cohort for reuse: "There's no 'power users' cohort defined. I'll filter by [criteria]. Want me to suggest a cohort definition to save?"
-- **Conversion event isn't clear.** If comparing converters vs. non-converters but the conversion event isn't obvious, call `get_events` and propose 2-3 candidate events. Let the user confirm.
+- **Conversion event isn't clear.** If comparing converters vs. non-converters but the conversion event isn't obvious, call `manage_amp_events` with `action: "get"` and `kind: "event"` and propose 2-3 candidate events. Let the user confirm.
 - **nodeId limitations.** Interaction timelines show coordinates and node IDs, not element names. When comparing actions between groups, describe by page context and interaction sequence rather than specific UI elements. Focus on which pages and flows users engage with, not which buttons they click.
 
 ## Examples

--- a/plugins/amplitude/skills/create-dashboard/SKILL.md
+++ b/plugins/amplitude/skills/create-dashboard/SKILL.md
@@ -13,7 +13,7 @@ Create new team or initiative dashboards, organize scattered charts, build execu
 
 Before building, understand what you're tracking:
 - Search for existing dashboards/charts related to the topic
-- Search for relevant events: `Amplitude:search` with entityTypes: ["EVENT", "CUSTOM_EVENT"]
+- Search for relevant events with `Amplitude:search_amp_data_taxonomy`
 - Use `get_properties` to understand available properties for segmentation
 - Ask user for clarification on primary goals, key segments, or time horizons
 
@@ -29,20 +29,19 @@ Clarify:
 ### Step 2: Gather or Create Charts
 
 **If existing charts found (>5 relevant):**
-- Use `Amplitude:search` to find relevant existing charts
-- Use `Amplitude:get_charts` to retrieve their definitions
+- Use `Amplitude:search_amp_entities` to find relevant existing charts
+- Use `Amplitude:get_amplitude_charts` with `include: "definition"` to retrieve their definitions
 - Identify gaps that need new charts
 
 **If few/no charts exist (<5 relevant):**
 - Switch to "greenfield build" mode
-- Use `Amplitude:query_dataset` to create needed charts
-- Save all charts with `Amplitude:save_chart_edits` before building dashboard
+- Use `Amplitude:query_amplitude_data` to create needed charts
+- Keep the returned chart edit IDs; `use_amp_dashboards` promotes them when creating the dashboard
 - Consider searching for relevant events first with entityTypes: ["EVENT", "CUSTOM_EVENT"]
 
 **Creating new charts:**
-- Prototype with `query_dataset` to verify data
-- Save in batches using `save_chart_edits` (more efficient)
-- Collect all chart IDs before creating dashboard
+- Prototype with `query_amplitude_data` to verify data
+- Collect the returned chart edit IDs before creating the dashboard
 
 ### Step 3: Plan the Layout
 
@@ -55,7 +54,7 @@ Organize into logical sections:
 
 ### Step 4: Create the Dashboard
 
-Use `Amplitude:create_dashboard` with:
+Use `Amplitude:use_amp_dashboards` with `action: "create"` and:
 
 - Clear, descriptive name
 - Rows with appropriate heights (375, 500, 625, or 750px)

--- a/plugins/amplitude/skills/daily-brief/SKILL.md
+++ b/plugins/amplitude/skills/daily-brief/SKILL.md
@@ -17,9 +17,9 @@ Before scanning data, build context about who you're talking to and what they ca
 1. **Detect persona.** Ask or infer the user's role: executive, PM, analyst, growth, or engineering. This determines the language, depth, and framing of the entire briefing.
 2. **Bootstrap context (1 call first, then 2 discovery calls in parallel).** Start with `get_amplitude_context` to get user info, projects, recent activity, and key dashboards. Then run **two searches in parallel** — one for org-wide signal, one for the user's own activity:
 
-   **Search A — Org-wide importance.** `search` with `isOfficial: true`, `sortOrder: "viewCount"`, `limitPerQuery: 10`. Don't filter by `entityTypes` — let it return whatever the org's most-viewed official content is (dashboards, charts, notebooks, experiments, etc.). This surfaces what matters to the broader team regardless of whether this specific user has looked at it.
+   **Search A — Org-wide importance.** `search_amp_entities` with `isOfficial: true`, `sortOrder: "viewCount"`, `limitPerQuery: 10`. Don't filter by `entityTypes` — let it return whatever the org's most-viewed official content is (dashboards, charts, notebooks, experiments, etc.). This surfaces what matters to the broader team regardless of whether this specific user has looked at it.
 
-   **Search B — User-personalized activity.** `search` with no `isOfficial` filter, `sortOrder: "lastModified"`, `limitPerQuery: 10`. Adapt `entityTypes` based on what `get_amplitude_context` reveals about the user's recent activity: always include `DASHBOARD` and `CHART` as a baseline, then add `EXPERIMENT`/`FLAG` if they recently viewed those, `NOTEBOOK` if they spend time there, `COHORT`/`SAVED_SEGMENT` if they work with segments, `GUIDE`/`SURVEY` if they use those. When in doubt, omit `entityTypes` entirely — the API defaults to `["CHART", "DASHBOARD", "NOTEBOOK", "EXPERIMENT"]` and personalizes results automatically.
+   **Search B — User-personalized activity.** `search_amp_entities` with no `isOfficial` filter, `sortOrder: "lastModified"`, `limitPerQuery: 10`. Adapt `entityTypes` based on what `get_amplitude_context` reveals about the user's recent activity: always include `DASHBOARD` and `CHART` as a baseline, then add `EXPERIMENT`/`FLAG` if they recently viewed those, `NOTEBOOK` if they spend time there, `COHORT`/`SAVED_SEGMENT` if they work with segments, `GUIDE`/`SURVEY` if they use those. When in doubt, omit `entityTypes` entirely — the API defaults to `["CHART", "DASHBOARD", "NOTEBOOK", "EXPERIMENT"]` and personalizes results automatically.
 
    **Merge and deduplicate** the results from both searches. Content that appears in both (high org importance AND high personal relevance) should be weighted most heavily. Content that appears only in Search A surfaces things the user wouldn't find on their own — this is where the briefing adds the most value.
 
@@ -35,12 +35,12 @@ Gather data with a tight recency focus. The primary time window is **today (so f
 
 Run these in parallel where possible:
 
-1. **Fetch dashboards (1-2 calls).** Take the dashboard IDs from Phase 1 discovery plus the user's top 2-3 personal dashboards (from `get_amplitude_context` results). Deduplicate and call `get_dashboard` in batches of 3 (max 2 calls = 6 dashboards). This gives you all the chart IDs you need. If Phase 1 returned fewer than 3 dashboards, run one additional `search` with `entityTypes: ["DASHBOARD"]`, `sortOrder: "viewCount"`, `limitPerQuery: 5` to fill in — otherwise skip this.
-2. **Query charts in bulk (2-4 calls).** Collect all unique chart IDs from the dashboards above, plus any standalone chart/metric IDs from Phase 1 discovery. Use `query_charts` (plural) to query them in bulk batches with daily granularity over the last 7 days. Compare today and yesterday against the prior 5 days. Flag any metric where today or yesterday deviates >15% from the recent daily average or falls outside the prior 5-day range. Explicitly note if today's data is partial (e.g., "as of 2pm UTC, today is tracking at X vs. Y full-day yesterday").
+1. **Fetch dashboards (1-2 calls).** Take the dashboard IDs from Phase 1 discovery plus the user's top 2-3 personal dashboards (from `get_amplitude_context` results). Deduplicate and call `use_amp_dashboards` with `action: "get"` in batches of 3 (max 2 calls = 6 dashboards). This gives you all the chart IDs you need. If Phase 1 returned fewer than 3 dashboards, run one additional `search_amp_entities` with `entityTypes: ["DASHBOARD"]`, `sortOrder: "viewCount"`, `limitPerQuery: 5` to fill in — otherwise skip this.
+2. **Query charts in bulk (2-4 calls).** Collect all unique chart IDs from the dashboards above, plus any standalone chart/metric IDs from Phase 1 discovery. Use `get_amplitude_charts` with `include: "data"` to query them in bulk batches with daily granularity over the last 7 days. Compare today and yesterday against the prior 5 days. Flag any metric where today or yesterday deviates >15% from the recent daily average or falls outside the prior 5-day range. Explicitly note if today's data is partial (e.g., "as of 2pm UTC, today is tracking at X vs. Y full-day yesterday").
 3. **Anomaly scan (no additional calls).** From the chart results already fetched, compute day-over-day deltas for every metric. Rank by absolute magnitude of change. Surface the top 5-10 biggest movers regardless of which dashboard they live on. This is analytical work on data you already have — no new tool calls needed.
-4. **Experiment check (1-2 calls).** Call `get_experiments` once. Only call `query_experiment` for experiments that appear to have changed status recently or that the user owns. Skip querying experiments that are clearly irrelevant.
-5. **Feedback (2 calls).** Call `get_feedback_sources` once to get sourceIds, then call `get_feedback_insights` once with the most relevant sourceId. Focus on feedback from the last 1-2 days. Surface new or spiking themes, especially anything that appeared for the first time yesterday or today.
-6. **Deployment context (1 call).** Call `get_deployments` once. Use the results to explain metric movements — recent deployments should be the first hypothesis for any day-over-day change.
+4. **Experiment check (1-2 calls).** Call `use_amp_experiments` with `action: "get"` once. Only call `use_amp_experiments` with `action: "analyze"` for experiments that appear to have changed status recently or that the user owns. Skip querying experiments that are clearly irrelevant.
+5. **Feedback (2 calls).** Call `use_amplitude_ai_feedback` with `facet: "sources"` once to get sourceIds, then call it with `facet: "insights"` once with the most relevant sourceId. Focus on feedback from the last 1-2 days. Surface new or spiking themes, especially anything that appeared for the first time yesterday or today.
+6. **Deployment context (1 call).** Call `use_amp_flags` with `action: "list_deployments"` once. Use the results to explain metric movements — recent deployments should be the first hypothesis for any day-over-day change.
 
 ### Phase 3: Validate and Filter
 
@@ -51,7 +51,7 @@ Be the skeptic. Not everything that looks interesting is real or actionable.
    - **Day-of-week effects**: Compare today to the same day last week, not just yesterday. Monday vs Sunday is not a meaningful comparison.
    - **Rolling window artifacts**: 30-day active user counts always dip in recent windows.
    - **Retention cohort artifacts**: Recent cohorts haven't completed their window yet.
-   - **Launch phase growth**: Check `get_deployments` for flag ramp-ups that explain expected growth.
+   - **Launch phase growth**: Check `use_amp_flags` with `action: "list_deployments"` for flag ramp-ups that explain expected growth.
 2. **Apply confidence scoring.** Rate each finding 0.0–1.0. Drop anything below 0.6.
 3. **Apply the actionability filter.** If a finding can't plausibly lead to a concrete action, drop it. "Interesting but so what?" findings waste the user's time.
 
@@ -60,7 +60,7 @@ Be the skeptic. Not everything that looks interesting is real or actionable.
 Investigate WHY the top findings are happening, but be selective — only spend tool calls on the 2-3 most significant findings.
 
 1. **Explain from existing data first.** Before making any new calls, check if deployments, experiments, or feedback already explain the finding. Often they do, and you can skip the segment breakdown entirely.
-2. **Segment discovery (only for top 2-3 findings).** Use `query_dataset` to break the biggest anomalies down by platform, country, plan tier, etc. Find WHERE the change concentrates. Skip this for smaller findings — use reasoning instead.
+2. **Segment discovery (only for top 2-3 findings).** Use `query_amplitude_data` to break the biggest anomalies down by platform, country, plan tier, etc. Find WHERE the change concentrates. Skip this for smaller findings — use reasoning instead.
 3. **Hypothesis categories.** For each finding, consider: temporal (deployment or code change?), segmentation (specific user group?), funnel (conversion step broken?), external (seasonality, competitor move, incident?), data quality (instrumentation issue?).
 4. **Cross-check.** Look for shared root causes across findings. If two metrics moved for the same reason, merge them into one narrative.
 
@@ -103,7 +103,7 @@ Transform your analysis into a concise, narrative briefing the user could forwar
 
 Before delivering, verify your work. Prefer reviewing data you already have over making new tool calls.
 
-1. **Fact-check**: Review the data already fetched for the 2-3 most consequential claims. Only re-query with `query_charts` or `query_dataset` if you're genuinely uncertain about a number — not as a routine step. If the data came from a `query_charts` result, trust it.
+1. **Fact-check**: Review the data already fetched for the 2-3 most consequential claims. Only re-query with `get_amplitude_charts` `include: "data"` or `query_amplitude_data` if you're genuinely uncertain about a number — not as a routine step. If the data came from a `get_amplitude_charts` result, trust it.
 2. **Recency check**: Verify every finding is anchored to yesterday or today. If a finding is really about a week-long or month-long trend, either reframe it around what changed in the last 1-2 days or move it to brief background context.
 3. **Partial-day check**: If you cited today's data, confirm you noted it as partial and compared pace rather than raw totals.
 4. **Actionability gate**: Every finding MUST have at least one concrete action. If it doesn't, either add one or drop the finding.
@@ -193,11 +193,11 @@ Example output:
 
 ### Error: No dashboards found
 Cause: User may not have created dashboards, or the project has limited setup.
-Solution: Fall back to searching for any charts or events. Use `search` broadly and build context from whatever is available. Let the user know their setup is limited and suggest creating a key metrics dashboard.
+Solution: Fall back to searching for any charts or events. Use `search_amp_entities` broadly and build context from whatever is available. Let the user know their setup is limited and suggest creating a key metrics dashboard.
 
 ### Error: Feedback API returns 400
-Cause: Called `get_feedback_insights` without first calling `get_feedback_sources`, or passed multiple values in the `types` array.
-Solution: ALWAYS call `get_feedback_sources` first. Only pass a single type value per call, or omit the types parameter entirely.
+Cause: Called `use_amplitude_ai_feedback` with `facet: "insights"` without first calling it with `facet: "sources"`, or passed multiple values in the `types` array.
+Solution: ALWAYS call `use_amplitude_ai_feedback` with `facet: "sources"` first. Only pass a single type value per call, or omit the types parameter entirely.
 
 ### Error: Metrics look flat / nothing interesting
 Cause: Yesterday and today look similar to the prior days — stability is a finding.

--- a/plugins/amplitude/skills/debug-replay/SKILL.md
+++ b/plugins/amplitude/skills/debug-replay/SKILL.md
@@ -14,15 +14,15 @@ Investigate bugs by finding session replays where the error occurred, extracting
 
 This skill operates on three Amplitude Session Replay tools. Use them in this order:
 
-1. **`Amplitude:get_session_replays`** — Find sessions matching event filters (errors, specific users, time windows). Returns session metadata and replay links.
-2. **`Amplitude:list_session_replays`** — Simple paginated listing when you already have a user/device ID or just need recent sessions. Returns `replay_id` in `device_id/session_id` format.
-3. **`Amplitude:get_session_replay_events`** — Decode a specific replay into an interaction timeline: navigations, clicks, inputs, scrolls. Requires `replay_id` from the tools above.
+1. **`Amplitude:get_amp_session_replay_info`** with `action: "search"` — Find sessions matching event filters (errors, specific users, time windows). Returns session metadata and replay links.
+2. **`Amplitude:get_amp_session_replay_info`** with `action: "list"` — Simple paginated listing when you already have a user/device ID or just need recent sessions. Returns a session replay ID in `device_id/session_id` format.
+3. **`Amplitude:get_amp_session_replay_info`** with `action: "events"` — Decode a specific replay into an interaction timeline: navigations, clicks, inputs, scrolls. Pass the ID from the tools above as `sessionReplayId`.
 
 Supporting tools used in this skill:
-- **`Amplitude:get_users`** — Look up users by email, user ID, or other identifiers.
-- **`Amplitude:get_events`** — Discover valid event names before filtering. Never guess event names.
+- **`Amplitude:use_amplitude_cohorts`** with `action: "find"` — Look up users by email, user ID, or other identifiers.
+- **`Amplitude:manage_amp_events`** with `action: "get"` and `kind: "event"` — Discover valid event names before filtering. Never guess event names.
 - **`Amplitude:get_properties`** — Discover properties available on an event for filtering.
-- **`Amplitude:get_deployments`** — Check if error aligns with a recent deploy.
+- **`Amplitude:use_amp_flags`** with `action: "list_deployments"` — Check if error aligns with a recent deploy.
 
 ---
 
@@ -42,35 +42,23 @@ If the report is vague (e.g., "something is broken in checkout"), ask one clarif
 ### Step 2: Get Context and Find the Error Event
 
 1. Call `Amplitude:get_amplitude_context`. If multiple projects, ask which to investigate.
-2. Call `Amplitude:get_events` to confirm the error event name exists in the project. Common patterns:
+2. Call `Amplitude:manage_amp_events` with `action: "get"` and `kind: "event"` to confirm the error event name exists in the project. Common patterns:
    - `[Amplitude] Error Logged` — auto-captured JS errors
    - `[Amplitude] Network Request` with status code filters — API failures
    - Custom error events specific to the product
-3. If a user identifier was provided, call `Amplitude:get_users` to look up the user and get their user ID and device ID.
+3. If a user identifier was provided, call `Amplitude:use_amplitude_cohorts` with `action: "find"` to look up the user and get their user ID and device ID.
 
 ### Step 3: Find Error Sessions
 
-Use `Amplitude:get_session_replays` to find sessions where the error occurred. Build filters based on what you know:
+Use `Amplitude:get_amp_session_replay_info` with `action: "search"` to find sessions where the error occurred. Build filters based on what you know:
 
 **If you have a specific user:**
 ```json
 {
-  "eventCountFilters": [
-    {
-      "count": "1",
-      "operator": "greater or equal",
-      "event": {
-        "event_type": "_all",
-        "filters": [{"group_type": "User", "subprop_key": "gp:email", "subprop_op": "is", "subprop_type": "user", "subprop_value": ["user@example.com"]}],
-        "group_by": []
-      }
-    },
-    {
-      "count": "1",
-      "operator": "greater or equal",
-      "event": {"event_type": "[Amplitude] Error Logged", "filters": [], "group_by": []}
-    }
-  ],
+  "action": "search",
+  "projectId": "12345",
+  "userProperties": [{"name": "gp:email", "is": "user@example.com"}],
+  "events": [{"name": "[Amplitude] Error Logged"}],
   "limit": 5
 }
 ```
@@ -78,15 +66,12 @@ Use `Amplitude:get_session_replays` to find sessions where the error occurred. B
 **If you have an error message but no specific user:**
 ```json
 {
-  "eventCountFilters": [
+  "action": "search",
+  "projectId": "12345",
+  "events": [
     {
-      "count": "1",
-      "operator": "greater or equal",
-      "event": {
-        "event_type": "[Amplitude] Error Logged",
-        "filters": [{"group_type": "User", "subprop_key": "Error Message", "subprop_op": "contains", "subprop_type": "event", "subprop_value": ["TypeError"]}],
-        "group_by": []
-      }
+      "name": "[Amplitude] Error Logged",
+      "withProperty": {"name": "Error Message", "contains": "TypeError"}
     }
   ],
   "limit": 5
@@ -97,7 +82,7 @@ Request 3-5 sessions. More sessions give better pattern extraction; fewer saves 
 
 ### Step 4: Extract Interaction Timelines
 
-For each session found in Step 3, call `Amplitude:get_session_replay_events` with the `replay_id`.
+For each session found in Step 3, call `Amplitude:get_amp_session_replay_info` with `action: "events"` and the `sessionReplayId`.
 
 - Use `event_limit: 500` for standard sessions
 - Use `event_limit: 200` if analyzing 4+ sessions (to manage context)
@@ -121,7 +106,7 @@ If only 1 session is available, extract the timeline as-is and note that it hasn
 
 ### Step 6: Check Deployment Context
 
-Call `Amplitude:get_deployments` once. If an error spike aligns with a recent deploy, note it — this is critical context for the engineer.
+Call `Amplitude:use_amp_flags` with `action: "list_deployments"` once. If an error spike aligns with a recent deploy, note it — this is critical context for the engineer.
 
 ### Step 7: Present Reproduction Steps
 
@@ -168,12 +153,12 @@ Structure the output as an engineering-ready bug report.
 
 ## Edge Cases
 
-- **No error events found.** The project may not have auto-capture enabled, or the error may be tracked under a custom event name. Call `Amplitude:get_events` and search for error-related events. Report what you find and suggest what to instrument if nothing exists.
-- **User not found.** If `get_users` returns nothing, try searching with alternative identifiers (email domain, partial match). If still nothing, proceed without user filtering and search by error event alone.
+- **No error events found.** The project may not have auto-capture enabled, or the error may be tracked under a custom event name. Call `Amplitude:manage_amp_events` with `action: "get"` and `kind: "event"` and search for error-related events. Report what you find and suggest what to instrument if nothing exists.
+- **User not found.** If `use_amplitude_cohorts` with `action: "find"` returns nothing, try searching with alternative identifiers (email domain, partial match). If still nothing, proceed without user filtering and search by error event alone.
 - **Sessions found but no replay events.** Some sessions may not have rrweb data (replay disabled, ad blocker, etc.). Skip those sessions and note it. Try the next session.
 - **Only 1 session available.** Present the timeline as "unvalidated reproduction steps" with Low confidence. Suggest the user try to reproduce manually to confirm.
 - **Error is intermittent.** If sessions show different paths to the same error, present them as separate reproduction paths: "Path A (seen in 3/5 sessions)" and "Path B (seen in 2/5 sessions)."
-- **nodeId values can't be resolved.** `get_session_replay_events` returns DOM node IDs, not element names. Describe interactions by position (x, y coordinates), page context, and sequence rather than element identity. Use phrasing like "click in the upper-right area of the form" rather than "click the Submit button" unless you can infer from context.
+- **nodeId values can't be resolved.** `get_amp_session_replay_info` with `action: "events"` returns DOM node IDs, not element names. Describe interactions by position (x, y coordinates), page context, and sequence rather than element identity. Use phrasing like "click in the upper-right area of the form" rather than "click the Submit button" unless you can infer from context.
 
 ## Examples
 
@@ -183,8 +168,8 @@ User says: "Customer jane@acme.com says the export button doesn't work"
 
 Actions:
 1. Get context and confirm project
-2. Look up jane@acme.com via `get_users`
-3. Find her recent sessions with `get_session_replays` filtered to her email + any error events
+2. Look up jane@acme.com via `use_amplitude_cohorts` with `action: "find"`
+3. Find her recent sessions with `get_amp_session_replay_info` `action: "search"` filtered to her email + any error events
 4. Extract interaction timelines from 2-3 sessions
 5. Identify the common path: navigates to reports → clicks export → nothing happens (or error)
 6. Present numbered repro steps with replay links
@@ -195,7 +180,7 @@ User says: "TypeError errors doubled yesterday, can you get repro steps?"
 
 Actions:
 1. Get context, confirm `[Amplitude] Error Logged` exists
-2. Find sessions with TypeError in the last 48 hours via `get_session_replays`
+2. Find sessions with TypeError in the last 48 hours via `get_amp_session_replay_info` `action: "search"`
 3. Extract timelines from 3-5 sessions
 4. Compare timelines to find the common action sequence before the TypeError
 5. Check deployments for what shipped yesterday

--- a/plugins/amplitude/skills/diagnose-errors/SKILL.md
+++ b/plugins/amplitude/skills/diagnose-errors/SKILL.md
@@ -46,7 +46,7 @@ Run these in parallel where possible. Budget: 4-6 calls for this step.
 
 #### 2a. Network Failures
 
-Use `Amplitude:query_dataset` to query `[Amplitude] Network Request`:
+Use `Amplitude:query_amplitude_data` to query `[Amplitude] Network Request`:
 
 1. **Failure rate trend.** Filter `[Amplitude] Status Code` to 4xx and 5xx ranges. Measure daily event counts and unique users. Compare to total network request volume for a failure rate percentage.
 2. **Top failing endpoints.** Group by `[Amplitude] URL` to rank which APIs fail most. Include `[Amplitude] Status Code` as a secondary grouping to distinguish 401s (auth) from 500s (server errors) from 404s (missing).
@@ -54,7 +54,7 @@ Use `Amplitude:query_dataset` to query `[Amplitude] Network Request`:
 
 #### 2b. JavaScript Errors
 
-Use `Amplitude:query_dataset` to query `[Amplitude] Error Logged`:
+Use `Amplitude:query_amplitude_data` to query `[Amplitude] Error Logged`:
 
 1. **Error volume trend.** Daily error count and unique users affected over the time window. Flag day-over-day spikes >25%.
 2. **Top errors.** Group by `Error Message` to find the highest-volume errors. Include `Error Type` and `File Name` for context.
@@ -62,7 +62,7 @@ Use `Amplitude:query_dataset` to query `[Amplitude] Error Logged`:
 
 #### 2c. Error Clicks (Frustration Signal)
 
-Use `Amplitude:query_dataset` to query `[Amplitude] Error Click`:
+Use `Amplitude:query_amplitude_data` to query `[Amplitude] Error Click`:
 
 1. **Volume trend.** Daily error click count. Spikes indicate users are actively encountering and engaging with error states.
 2. **What users are clicking.** Group by `[Amplitude] Element Text` or `[Amplitude] Message` to see which error UI elements get the most interaction.
@@ -75,7 +75,7 @@ This is where the skill adds value beyond looking at each event in isolation.
 
 2. **Error → frustration chain.** Compare JS error pages with error click pages. High error click volume on pages with high JS error rates confirms users are seeing and interacting with the broken experience.
 
-3. **Page-level triage.** Use `Amplitude:query_dataset` to group all three events by `[Amplitude] Page Path`. Produce a page-level error heatmap:
+3. **Page-level triage.** Use `Amplitude:query_amplitude_data` to group all three events by `[Amplitude] Page Path`. Produce a page-level error heatmap:
    - Pages with network failures + JS errors + error clicks = **critical** (full causal chain)
    - Pages with JS errors + error clicks but no network failures = **frontend bug**
    - Pages with network failures but no JS errors = **backend issue, gracefully handled**
@@ -85,18 +85,18 @@ This is where the skill adds value beyond looking at each event in isolation.
 
 For the top 2-3 error patterns from Step 3:
 
-1. **User scope.** Use `Amplitude:query_dataset` to count unique users affected. Compare to total active users for an impact percentage.
+1. **User scope.** Use `Amplitude:query_amplitude_data` to count unique users affected. Compare to total active users for an impact percentage.
 2. **Segment breakdown.** Group by available user properties (platform, browser, country, plan tier, org) to determine if errors concentrate in a specific segment. Call `Amplitude:get_properties` if you need to discover available properties.
-3. **Session Replays.** For the most impactful error pattern, call `Amplitude:get_session_replays` filtered to sessions containing the error event. Provide 2-3 replay links so the user can see exactly what happened.
+3. **Session Replays.** For the most impactful error pattern, call `Amplitude:get_amp_session_replay_info` with `action: "search"` filtered to sessions containing the error event. Provide 2-3 replay links so the user can see exactly what happened.
 
 ### Step 5: Root Cause Hypothesis
 
 Build a root cause hypothesis using evidence from the prior steps:
 
-1. **Deployment correlation.** Call `Amplitude:get_deployments` once. Check if error spikes align with recent deploys. If a deployment shipped within 24 hours of the error spike, it's the leading hypothesis.
-2. **Experiment correlation.** If the user mentions an experiment or if errors concentrate in a segment that maps to an experiment variant, call `Amplitude:get_experiments` and `Amplitude:query_experiment` to check.
+1. **Deployment correlation.** Call `Amplitude:use_amp_flags` with `action: "list_deployments"` once. Check if error spikes align with recent deploys. If a deployment shipped within 24 hours of the error spike, it's the leading hypothesis.
+2. **Experiment correlation.** If the user mentions an experiment or if errors concentrate in a segment that maps to an experiment variant, call `Amplitude:use_amp_experiments` with `action: "get"`, then with `action: "analyze"` to check.
 3. **Temporal pattern.** Is the error constant, intermittent, or growing? Constant suggests a code bug. Intermittent suggests infrastructure. Growing suggests a progressive failure (memory leak, queue backlog).
-4. **Feedback correlation.** Call `Amplitude:get_feedback_sources` then `Amplitude:get_feedback_insights` with keywords from the top error messages. If users are reporting the same issue, it validates the impact and may provide additional context the data can't.
+4. **Feedback correlation.** Call `Amplitude:use_amplitude_ai_feedback` with `facet: "sources"` then `facet: "insights"` with keywords from the top error messages. If users are reporting the same issue, it validates the impact and may provide additional context the data can't.
 
 ### Step 6: Present the Diagnosis
 
@@ -164,7 +164,7 @@ Actions:
 User says: "Errors seem up since yesterday's deploy"
 
 Actions:
-1. Get context and check `get_deployments` for what shipped
+1. Get context and check `use_amp_flags` with `action: "list_deployments"` for what shipped
 2. Query `[Amplitude] Error Logged` comparing pre-deploy (7d before) vs post-deploy (last 24h)
 3. Identify new error messages that didn't exist before the deploy
 4. Check if new errors correlate with failing network requests

--- a/plugins/amplitude/skills/discover-analytics-patterns/SKILL.md
+++ b/plugins/amplitude/skills/discover-analytics-patterns/SKILL.md
@@ -48,9 +48,9 @@ Use two approaches based on what's available.
 
 ### If the Amplitude MCP is connected
 
-Call `get_events` (or equivalent) to fetch a sample of event names from the
-project. If its input schema accepts `_client`, every `get_events` call made by
-this skill MUST include the top-level argument
+Call `manage_amp_events` with `action: "get"` and `kind: "event"` to fetch a
+sample of event names from the project. If its input schema accepts `_client`,
+every `manage_amp_events` call made by this skill MUST include the top-level argument
 `"_client": { "type": "skill", "skill_name": "discover-analytics-patterns" }`
 in the tool arguments; otherwise, omit `_client`. Use those results to choose a
 few representative non-system product events, then call `get_properties`

--- a/plugins/amplitude/skills/discover-event-surfaces/SKILL.md
+++ b/plugins/amplitude/skills/discover-event-surfaces/SKILL.md
@@ -102,8 +102,9 @@ target. You need a `projectId` for the next call.
 
 ### Pull existing events
 
-Call `get_events` with the resolved `projectId`. If its input schema accepts
-`_client`, every `get_events` call made by this skill MUST include the top-level
+Call `manage_amp_events` with `action: "get"`, `kind: "event"`, and the resolved
+`projectId`. If its input schema accepts `_client`, every `manage_amp_events`
+call made by this skill MUST include the top-level
 argument
 `"_client": { "type": "skill", "skill_name": "discover-event-surfaces" }`
 in the tool arguments. Otherwise, omit `_client`. No cursor is needed — just the

--- a/plugins/amplitude/skills/discover-opportunities/SKILL.md
+++ b/plugins/amplitude/skills/discover-opportunities/SKILL.md
@@ -18,13 +18,13 @@ Before investigating, build context about the product and what matters.
 
 2. **Discover what exists (2 parallel searches).**
 
-   **Search A — Org-level signal.** `search` with `isOfficial: true`, `sortOrder: "viewCount"`, `limitPerQuery: 15`. Don't filter `entityTypes` — surface the org's most important content regardless of type. Official dashboards and charts reveal what the org tracks and values.
+   **Search A — Org-level signal.** `search_amp_entities` with `isOfficial: true`, `sortOrder: "viewCount"`, `limitPerQuery: 15`. Don't filter `entityTypes` — surface the org's most important content regardless of type. Official dashboards and charts reveal what the org tracks and values.
 
-   **Search B — Recent activity.** `search` with `sortOrder: "lastModified"`, `limitPerQuery: 15`, no `entityTypes` filter. This surfaces what's actively being worked on and investigated.
+   **Search B — Recent activity.** `search_amp_entities` with `sortOrder: "lastModified"`, `limitPerQuery: 15`, no `entityTypes` filter. This surfaces what's actively being worked on and investigated.
 
    Merge and deduplicate. Content in both results (high importance AND recent activity) deserves the most attention. Content only in Search A may reveal blind spots.
 
-3. **Understand existing segments.** Call `get_cohorts` for any cohort IDs surfaced in discovery. Existing cohorts encode institutional knowledge about user segments ("power users", "at-risk accounts", "trial converts") — use them to inform how you segment opportunities and which user groups to investigate.
+3. **Understand existing segments.** Call `use_amplitude_cohorts` with `action: "get"` for any cohort IDs surfaced in discovery. Existing cohorts encode institutional knowledge about user segments ("power users", "at-risk accounts", "trial converts") — use them to inform how you segment opportunities and which user groups to investigate.
 
 4. **Narrow scope.** If the user specified a product area, feature, or funnel — focus there. Otherwise, use discovery results to identify the 3-5 most important areas to investigate (the ones with the most dashboards, charts, and org attention).
 
@@ -34,8 +34,8 @@ Run these in parallel where possible. Budget: 10-15 tool calls total for this ph
 
 #### 2a. Dashboard and Chart Analysis
 
-1. **Fetch dashboards (1-2 calls).** Use `get_dashboard` for the top dashboards from Phase 1 (batch up to 3 per call). Extract all chart IDs.
-2. **Query charts in bulk (2-4 calls).** Use `query_charts` to fetch data for all discovered chart IDs, 3 at a time. Request 30-day daily granularity. For each metric, compute:
+1. **Fetch dashboards (1-2 calls).** Use `use_amp_dashboards` with `action: "get"` for the top dashboards from Phase 1 (batch up to 3 per call). Extract all chart IDs.
+2. **Query charts in bulk (2-4 calls).** Use `get_amplitude_charts` with `include: "data"` to fetch data for all discovered chart IDs, 3 at a time. Request 30-day daily granularity. For each metric, compute:
    - Week-over-week trend (this week vs. prior 3 weeks)
    - Day-over-day volatility
    - Whether the metric is accelerating, decelerating, or flat
@@ -48,34 +48,34 @@ For each funnel chart discovered, examine:
 - The step with the largest absolute drop-off
 - Whether drop-off is getting worse or better over time
 
-If no funnel charts exist but the user mentioned a flow, use `query_dataset` to build an ad-hoc funnel. Call `get_properties` for the relevant events first to discover which properties are available for segmentation (platform, plan, country, etc.) — don't guess property names.
+If no funnel charts exist but the user mentioned a flow, use `query_amplitude_data` to build an ad-hoc funnel. Call `get_properties` for the relevant events first to discover which properties are available for segmentation (platform, plan, country, etc.) — don't guess property names.
 
 #### 2c. Experiment Insights
 
-1. Call `get_experiments` to list experiments. Prioritize:
+1. Call `use_amp_experiments` with `action: "get"` to list experiments. Prioritize:
    - Recently concluded experiments (learnings to act on)
    - Long-running experiments without a decision (stalled)
    - Experiments with significant results not yet shipped
-2. Call `query_experiment` for the top 2-3 most relevant experiments.
+2. Call `use_amp_experiments` with `action: "analyze"` for the top 2-3 most relevant experiments.
 3. Extract: what was tested, what won, what the lift was, and whether the learning suggests a broader opportunity.
 
 #### 2d. Customer Feedback
 
-1. Call `get_feedback_sources` to discover feedback integrations.
-2. Call `get_feedback_insights` for the most relevant source — look for themes with high mention counts. Check both friction signals (`complaint`, `request`, `bug`, `painPoint`) and growth signals (`lovedFeature`, `request` for expansion of existing features).
-3. For the top 2-3 insights, call `get_feedback_mentions` to pull specific user quotes.
-4. If investigating a specific topic, call `get_feedback_comments` with `search` terms to find raw comments mentioning it. This catches signal that may not yet be grouped into an insight theme.
+1. Call `use_amplitude_ai_feedback` with `facet: "sources"` to discover feedback integrations.
+2. Call `use_amplitude_ai_feedback` with `facet: "insights"` for the most relevant source — look for themes with high mention counts. Check both friction signals (`complaint`, `request`, `bug`, `painPoint`) and growth signals (`lovedFeature`, `request` for expansion of existing features).
+3. For the top 2-3 insights, call `use_amplitude_ai_feedback` with `facet: "mentions"` to pull specific user quotes.
+4. If investigating a specific topic, call `use_amplitude_ai_feedback` with `facet: "comments"` and `search` terms to find raw comments mentioning it. This catches signal that may not yet be grouped into an insight theme.
 5. Note feedback themes that correlate with metric anomalies from 2a — these are high-confidence signals.
 
 #### 2e. Session Replays
 
 If investigating a specific flow or drop-off:
-1. Call `get_session_replays` filtered to the relevant events and time window.
+1. Call `get_amp_session_replay_info` with `action: "search"` filtered to the relevant events and time window.
 2. Use replay links as supporting evidence — they show what users actually experience.
 
 #### 2f. Deployment Context
 
-Call `get_deployments` once. Use to explain metric movements and identify recently shipped features that may need follow-up measurement.
+Call `use_amp_flags` with `action: "list_deployments"` once. Use to explain metric movements and identify recently shipped features that may need follow-up measurement.
 
 ### Phase 3: Synthesize Opportunities
 
@@ -231,10 +231,10 @@ Actions:
 ## Troubleshooting
 
 ### No dashboards or charts found
-Fall back to `search` with broad queries related to the user's product area. Use `query_dataset` to build ad-hoc charts from raw events. Suggest the user create a key metrics dashboard.
+Fall back to `search_amp_entities` with broad queries related to the user's product area. Use `query_amplitude_data` to build ad-hoc charts from raw events. Suggest the user create a key metrics dashboard.
 
 ### Feedback API returns errors
-Always call `get_feedback_sources` before `get_feedback_insights`. If no sources are configured, skip feedback and note it as a gap in the report — recommend the user connect a feedback source.
+Always call `use_amplitude_ai_feedback` with `facet: "sources"` before `facet: "insights"`. If no sources are configured, skip feedback and note it as a gap in the report — recommend the user connect a feedback source.
 
 ### Everything looks healthy — no anomalies
 Stability is a finding. Focus on: stalled experiments that need decisions, features with flat adoption that could grow, feedback themes that haven't been addressed, and conversion rates that are "fine" but benchmarkably low.

--- a/plugins/amplitude/skills/instrument-events/SKILL.md
+++ b/plugins/amplitude/skills/instrument-events/SKILL.md
@@ -339,6 +339,7 @@ Before adding to plan, confirm with the user what will be created. List:
 
 Get explicit confirmation, then for each high-confidence event add it to plan in
 **every** project it routes to:
-- use the `create_events` tool to create the event in that project (`app_id`)
+- use `manage_amp_events` with `action: "create"` and `kind: "event"` to create
+  the event in that project (`app_id`)
 - use the `create_properties` tool to create the properties attached to the
   correct event in that same project

--- a/plugins/amplitude/skills/investigate-ai-session/SKILL.md
+++ b/plugins/amplitude/skills/investigate-ai-session/SKILL.md
@@ -20,32 +20,32 @@ The user will provide one of:
 
 #### Step 1b: Find Sessions Matching a Pattern
 
-Call `Amplitude:get_agent_analytics_schema` with `include: ["filter_options"]` to discover valid agent names, tool names, and topic values. Then call `Amplitude:query_agent_analytics_sessions` with appropriate filters:
+Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "schema"` to discover valid agent names, tool names, and evaluator fields. Then call it with `view: "sessions"` and supported filters:
 
 - **Agent failures:** `agentNames: ["<agent>"]`, `hasTaskFailure: true`
 - **Tool errors:** `toolNames: ["<tool>"]`, `hasTaskFailure: true`
 - **Technical failures:** `hasTechnicalFailure: true`
-- **Low quality:** `maxQualityScore: 0.4`
-- **Frustrated users:** `maxSentimentScore: 0.4` or `hasNegativeFeedback: true`
+- **Low quality:** fetch recent sessions, then select evaluator quality scores at or below 0.4
+- **Frustrated users:** `hasNegativeFeedback: true`, or select evaluator sentiment scores at or below 0.4
 - **Expensive sessions:** `minCostUsd: <threshold>`
 - **Slow sessions:** `minDurationMs: <threshold>`
-- **Specific topic:** `primaryTopics: ["<topic>"]` or use `topicClassifications` for model-specific filtering
+- **Specific topic:** fetch recent sessions, then select matching evaluator topic classifications locally
 
 Use `responseFormat: "concise"`, `limit: 20`, and sort by `"-session_start"` to get recent examples. Select the 3-5 most representative sessions for deep investigation.
 
 #### Step 1c: Find a Specific User's Sessions
 
-Call `Amplitude:query_agent_analytics_sessions` with `searchQuery: "<email or user ID>"` to find their sessions. If they reported a specific timeframe, add `startDate`/`endDate`. Pick the session(s) that match the complaint.
+Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "sessions"` and the supported user identifier filter to find their sessions. If they reported a specific timeframe, add the date filters. Pick the session(s) that match the complaint.
 
 ### Step 2: Deep-Dive into Sessions (Budget: 3-6 calls)
 
 For each session being investigated (max 3-5 sessions), run these in parallel per session:
 
-1. **Full session detail.** Call `Amplitude:query_agent_analytics_sessions` with `sessionIds: ["<id>"]`, `responseFormat: "detailed"`. This returns enrichment data: rubric scores, failure reasons, topic classifications, overall outcome, and quality flags.
+1. **Full session detail.** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "sessions"`, `sessionIds: ["<id>"]`, and `responseFormat: "detailed"`. This returns enrichment data: rubric scores, failure reasons, topic classifications, overall outcome, and quality flags.
 
-2. **Conversation transcript.** Call `Amplitude:get_agent_analytics_conversation` with `sessionId: "<id>"`, `includeCategories: true`. Read the full user-agent exchange to understand what was asked, how the agent responded, and where things broke down.
+2. **Conversation transcript.** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "conversation"` and the session ID. Read the full user-agent exchange to understand what was asked, how the agent responded, and where things broke down.
 
-3. **Execution trace.** Call `Amplitude:query_agent_analytics_spans` with `sessionId: "<id>"`. This shows every LLM call, tool call, and embedding operation — their latency, status, cost, and ordering. Look for:
+3. **Execution trace.** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "spans"` and the session ID. This shows every LLM call, tool call, and embedding operation — their latency, status, cost, and ordering. Look for:
    - Spans with `status: "ERROR"` — direct failures
    - Tool calls with high latency (>10s) — timeouts or slow dependencies
    - Multiple retries of the same tool — agent struggling
@@ -64,21 +64,21 @@ With conversation + trace + enrichment data, build the diagnosis:
    - **Data/context issue:** The agent had insufficient context — missing schema, wrong project, stale data. Check what context was available.
 
 2. **Determine scope:** Is this a one-off or systemic?
-   - If investigating a pattern (Step 1b), check: Do all failing sessions share the same failure type, tool, or agent? Use `Amplitude:query_agent_analytics_sessions` with `groupBy: ["agent_name"]` or `groupBy: ["primary_topic"]` to see if failures cluster.
-   - If a single session, call `Amplitude:query_agent_analytics_sessions` with the same agent and time window to check if similar failures exist.
+   - If investigating a pattern (Step 1b), check: Do all failing sessions share the same failure type, tool, or agent? Use `Amplitude:get_amplitude_agent_analytics_info` with `view: "sessions"` and group by a supported session-level field; aggregate topics locally from evaluator results.
+   - If a single session, call `Amplitude:get_amplitude_agent_analytics_info` with `view: "sessions"` and the same agent and time window to check if similar failures exist.
 
 3. **Find the trigger:** What changed?
    - Check if failures started on a specific date (new deployment, model change, config update)
    - Check if failures correlate with specific topics or user segments
-   - Check if a tool's error rate changed using `Amplitude:query_agent_analytics_spans` with `groupBy: ["tool_name"]`
+   - Check if a tool's error rate changed using `Amplitude:get_amplitude_agent_analytics_info` with `view: "tool_reliability"`
 
 ### Step 4: Search for Related Patterns (Budget: 1-2 calls)
 
 If the root cause isn't clear from the session data alone:
 
-1. **Search conversations.** Call `Amplitude:search_agent_analytics_conversations` with keywords from the error or topic to find other sessions with the same issue. This surfaces patterns the session-level queries might miss.
+1. **Find related sessions.** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "sessions"` and supported error filters, then compare evaluator topics locally to find other sessions with the same issue.
 
-2. **Check tool/model health.** Call `Amplitude:query_agent_analytics_spans` with `groupBy: ["tool_name"]` or `groupBy: ["model_name"]` over the relevant time window. Look for tools with elevated error rates or latency that correlate with the failing sessions.
+2. **Check tool/model health.** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "tool_reliability"` for tool health or `view: "spans"` grouped by model over the relevant time window. Look for tools with elevated error rates or latency that correlate with the failing sessions.
 
 ### Step 5: Present the Investigation
 
@@ -107,8 +107,8 @@ Structure the output as a root cause analysis.
 6. **Scope assessment:** One-off vs. systemic. How many sessions are affected? Is it getting worse?
 
 7. **Recommended fixes** (2-4 numbered items): Concrete actions. Examples:
-   - "Add a retry with exponential backoff for the query_dataset tool — 8 of 15 failures are transient timeouts"
-   - "The agent is calling get_events before get_amplitude_context, causing a missing project ID error — fix the tool ordering in the agent prompt"
+   - "Add a retry with exponential backoff for the query_amplitude_data tool — 8 of 15 failures are transient timeouts"
+   - "The agent is calling manage_amp_events before get_amplitude_context, causing a missing project ID error — fix the tool ordering in the agent prompt"
    - "Users asking about retention are getting routed to the Chart Agent instead of the Funnel Agent — update the routing logic"
 
 8. **Follow-on prompt**: Offer next steps — "Want me to check if this tool timeout affects other agents, search for similar user complaints, or monitor this pattern over the next few days?"
@@ -159,4 +159,4 @@ The session may be from a different project, or outside the data retention windo
 Span-level data requires OpenTelemetry-compatible tracing in the AI agent. Report what's available from the session and conversation level and note that span data would help narrow the root cause.
 
 ### Too many failing sessions to investigate
-Don't try to investigate more than 5 sessions in detail. Instead, use `groupBy` on `query_agent_analytics_sessions` to find the common pattern, then deep-dive into 2-3 representative examples.
+Don't try to investigate more than 5 sessions in detail. Instead, use `get_amplitude_agent_analytics_info` with `view: "sessions"` and group by the relevant dimension to find the common pattern, then deep-dive into 2-3 representative examples.

--- a/plugins/amplitude/skills/live-data-forensics/SKILL.md
+++ b/plugins/amplitude/skills/live-data-forensics/SKILL.md
@@ -13,7 +13,7 @@ follow one arc — follow it too.
 
 1. **Context.** `get_amplitude_context` (no args) → again with `projectId`.
    Do not guess project IDs.
-2. **Reuse before rebuild.** `search` for existing analyses of the same
+2. **Reuse before rebuild.** `search_amp_entities` for existing analyses of the same
    area — saved charts already encode correct event names and segments.
 3. **Verify taxonomy before querying.** `manage_amp_events` `action: 'get'`
    to confirm candidate event names exist (returns category, isInSchema,
@@ -62,14 +62,6 @@ follow one arc — follow it too.
   a working example — fix from that and retry.
 - `read ETIMEDOUT` is a backend timeout — narrow the date range/filters and
   retry once.
-
-## Legacy surface
-
-If `query_amplitude_data` is not in the tool list, the caller is on the
-unramped surface: use `query_dataset` (same job; prototype with
-`get_chart_definition_params` + `verify_chart_definition` first),
-`get_events` for taxonomy, `get_users` for user sets, and
-`get_user_timeline` for timelines. The arc is unchanged.
 
 ## What to report back
 

--- a/plugins/amplitude/skills/monitor-ai-quality/SKILL.md
+++ b/plugins/amplitude/skills/monitor-ai-quality/SKILL.md
@@ -13,20 +13,20 @@ You are a proactive AI operations advisor that delivers a concise, actionable he
 ### Phase 1: Get Context and Schema
 
 1. **Get context.** Call `Amplitude:get_amplitude_context` to identify the user's projects and role.
-2. **Get AI schema.** Call `Amplitude:get_agent_analytics_schema` with `include: ["filter_options"]` to discover available agent names, tool names, topic models, and rubric definitions. This tells you what's in the data before you query it.
+2. **Get AI schema.** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "schema"` to discover available agent names, tool names, topic models, and rubric definitions. This tells you what's in the data before you query it.
 3. **Determine scope.** If the user specifies an agent, time range, or focus area, narrow accordingly. Otherwise default to all agents over the last 7 days.
 
 ### Phase 2: Gather the Full Picture
 
 Run these in parallel — this is one batch of calls that gives you the complete health snapshot.
 
-1. **Quality + cost + performance overview.** Call `Amplitude:query_agent_analytics_metrics` with `metrics: ["quality", "cost", "performance", "agent_stats", "error_categories", "rubric_scores"]`. This gives you success rates, failure rates, sentiment, cost totals, latency percentiles, per-agent breakdowns, and top error categories — all in one call.
+1. **Quality + cost + performance overview.** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "sessions"`, then aggregate quality, cost, latency, sentiment, failures, rubric scores, and error categories by agent from the returned sessions and evaluator results. This gives you the overall and per-agent health snapshot.
 
-2. **Time series trends.** Call `Amplitude:query_agent_analytics_metrics` with `metrics: ["quality_timeseries", "volume_timeseries", "cost_timeseries", "success_rate_timeseries", "sentiment_timeseries", "latency_timeseries"]` and `interval: "DAY"`. This gives you the trend lines to spot regressions and spikes.
+2. **Time series trends.** Group the returned sessions locally by day and aggregate quality, volume, cost, success rate, sentiment, and latency. This gives you the trend lines to spot regressions and spikes.
 
-3. **Recent failures.** Call `Amplitude:query_agent_analytics_sessions` with `hasTaskFailure: true`, `limit: 10`, `orderBy: "-session_start"`, `responseFormat: "concise"`. This gives you the most recent failed sessions for drill-down examples.
+3. **Recent failures.** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "sessions"`, filter to task failures, limit to 10, and order by newest session first. This gives you the most recent failed sessions for drill-down examples.
 
-4. **Frustrated users.** Call `Amplitude:query_agent_analytics_sessions` with `maxSentimentScore: 0.4`, `limit: 10`, `orderBy: "-session_start"`, `responseFormat: "concise"`. This surfaces sessions where users were unhappy.
+4. **Frustrated users.** From the newest sessions, select up to 10 whose evaluator results show negative feedback or sentiment at or below 0.4. This surfaces sessions where users were unhappy.
 
 ### Phase 3: Analyze and Triage
 
@@ -62,11 +62,11 @@ With all data in hand, perform these analyses:
 
 For the 2-3 most significant findings, get supporting detail:
 
-1. **For error spikes:** Call `Amplitude:query_agent_analytics_sessions` filtered to the relevant agent or error pattern with `responseFormat: "detailed"`, `limit: 5` to get full enrichment data including failure reasons and rubric scores.
+1. **For error spikes:** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "sessions"` filtered to the relevant agent or error pattern and limit to 5 to get enrichment data including failure reasons and rubric scores.
 
-2. **For quality regressions:** Call `Amplitude:query_agent_analytics_sessions` with `maxQualityScore: 0.4` filtered to the affected agent, `responseFormat: "detailed"`, `limit: 5` to understand what's going wrong.
+2. **For quality regressions:** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "sessions"` filtered to the affected agent, then select up to 5 sessions whose evaluator quality scores are at or below 0.4 to understand what's going wrong.
 
-3. **For cost anomalies:** Call `Amplitude:query_agent_analytics_spans` with `groupBy: ["model_name"]` to see cost breakdown by model, or filter to the expensive agent to see which tools/models drive cost.
+3. **For cost anomalies:** Call `Amplitude:get_amplitude_agent_analytics_info` with `view: "spans"` and group by model to see cost breakdown by model, or filter to the expensive agent to see which tools/models drive cost.
 
 ### Phase 5: Present the Health Report
 
@@ -146,7 +146,7 @@ Actions:
 User says: "Our AI costs seem high — what's going on?"
 
 Actions:
-1. Get context, query analytics with `metrics: ["cost", "cost_by_model", "agent_stats", "cost_timeseries"]`
+1. Get context, then use `get_amplitude_agent_analytics_info` with `view: "sessions"` and aggregate the returned cost data locally by agent and day
 2. Identify which agents and models drive the most cost
 3. Query spans grouped by model to see token usage patterns
 4. Pull the most expensive sessions for examples

--- a/plugins/amplitude/skills/monitor-experiments-consolidated/SKILL.md
+++ b/plugins/amplitude/skills/monitor-experiments-consolidated/SKILL.md
@@ -14,9 +14,9 @@ This is a **monitoring** skill — keep output accessible to non-experts. Avoid 
 
 ## CRITICAL: Managing Response Sizes
 
-1. **`use_amp_experiments` action `get`: 3-5 IDs max per call.** Filter using `search` results BEFORE fetching.
+1. **`use_amp_experiments` action `get`: 3-5 IDs max per call.** Filter using `search_amp_entities` results BEFORE fetching.
 2. **`use_amp_experiments` action `analyze` responses are large.** Extract only `summary` objects and validity flags. Ignore `timeseries`, `xValues`, bulk arrays.
-3. **Metric name resolution**: `search` does NOT match metric IDs in `queries`. Search with `entityTypes: ["METRIC"]`, empty `queries`, `limitPerQuery: 50`, scoped to project. Match IDs from results.
+3. **Metric name resolution**: `search_amp_entities` does NOT match metric IDs in `queries`. Search with `entityTypes: ["METRIC"]`, empty `queries`, `limitPerQuery: 50`, scoped to project. Match IDs from results.
 
 ---
 
@@ -38,7 +38,7 @@ Do NOT duplicate information between the summary table and the details. The summ
 1. Call `Amplitude:get_amplitude_context`. If multiple projects, ask which to monitor.
 2. Search for experiments:
 ```
-Amplitude:search({
+Amplitude:search_amp_entities({
   entityTypes: ["EXPERIMENT"],
   appIds: [projectId],
   queries: [],
@@ -59,7 +59,7 @@ Amplitude:search({
 1. Call `Amplitude:use_amp_experiments` with `action: "get"` and `ids` in batches of 3-5 (only the filtered set from Step 1).
 2. Extract: state, dates/duration, variants, metric IDs (primary where recommendation=true), decision, owner.
 3. Apply the filtering rules from Step 1 again using the detailed metadata (some fields like stale status or decision may only be available here).
-4. Resolve metric names via `Amplitude:search({ entityTypes: ["METRIC"], appIds: [projectId], queries: [], limitPerQuery: 50 })`. Build `{ id: name }` mapping.
+4. Resolve metric names via `Amplitude:search_amp_entities({ entityTypes: ["METRIC"], appIds: [projectId], queries: [], limitPerQuery: 50 })`. Build `{ id: name }` mapping.
 5. For experiments that have metrics configured, call `Amplitude:use_amp_experiments({ action: "analyze", id: "<id>" })` (no metricIds) to get primary metric results and data quality flags. This data feeds both the summary table and the deep-dives.
 
 **CRITICAL: Never show raw metric IDs to the user.** If a metric name can't be resolved, describe it by its role (e.g., "primary metric", "guardrail metric") — do NOT display strings like "rrgtky08" or "Metric gvgb5efj". Metric IDs are internal identifiers that mean nothing to a human reader.
@@ -226,7 +226,7 @@ Small directional changes that aren't significant should be omitted. If 5+ metri
 
 **Feedback (only if primary is significant):**
 
-Call `Amplitude:get_feedback_insights` with experiment-related keywords. Report 2-3 themes in one line each. If no relevant feedback, skip the section.
+Call `Amplitude:use_amplitude_ai_feedback` with `facet: "insights"` and experiment-related keywords. Report 2-3 themes in one line each. If no relevant feedback, skip the section.
 
 **Verdict:**
 

--- a/plugins/amplitude/skills/monitor-reliability/SKILL.md
+++ b/plugins/amplitude/skills/monitor-reliability/SKILL.md
@@ -31,7 +31,7 @@ All three share: `[Amplitude] Page Path`, `[Amplitude] Page URL`, `[Amplitude] S
 
 ## CRITICAL: Managing Response Sizes
 
-1. **`query_dataset` results can be large.** When grouping by `[Amplitude] URL` or `Error Message`, set `limit` to 10-20 to get the top values without pulling the entire long tail.
+1. **`query_amplitude_data` results can be large.** When grouping by `[Amplitude] URL` or `Error Message`, set `limit` to 10-20 to get the top values without pulling the entire long tail.
 2. **Parallelize where possible.** Steps 2a, 2b, and 2c can run in parallel — they query different events.
 3. **One time window, two purposes.** Always query the full 14-day window. Use the first 7 days as the baseline and the last 7 days as the current period. This avoids making separate calls for each period.
 
@@ -57,7 +57,7 @@ If the user provides a deployment date or says "did the release break anything,"
 2. Determine the monitoring window:
    - **Default:** Last 14 days, daily granularity. Days 1-7 = baseline, days 8-14 = current.
    - **Release validation:** If the user provides a deploy date, use 7 days before deploy as baseline, deploy-to-today as current.
-3. Call `Amplitude:get_deployments` once. Note recent deploys — they're the first hypothesis for any regression.
+3. Call `Amplitude:use_amp_flags` with `action: "list_deployments"` once. Note recent deploys — they're the first hypothesis for any regression.
 
 ### Phase 2: Compute Reliability KPIs
 
@@ -65,7 +65,7 @@ Run these in parallel. Budget: 4-6 calls for this phase.
 
 #### 2a. Network Reliability
 
-Use `Amplitude:query_dataset` to query `[Amplitude] Network Request`:
+Use `Amplitude:query_amplitude_data` to query `[Amplitude] Network Request`:
 
 1. **Network failure rate.** Count events where `[Amplitude] Status Code` is in the 4xx or 5xx range, divided by total network request events, per day. Compute the current-period average and the baseline average. Flag if current > baseline by more than 20% relative.
 2. **Slow request rate.** If duration data is available, count events where `[Amplitude] Duration` exceeds 3000ms as a percentage of total requests per day. This is the "slow request rate."
@@ -73,23 +73,23 @@ Use `Amplitude:query_dataset` to query `[Amplitude] Network Request`:
 
 #### 2b. JavaScript Error Health
 
-Use `Amplitude:query_dataset` to query `[Amplitude] Error Logged`:
+Use `Amplitude:query_amplitude_data` to query `[Amplitude] Error Logged`:
 
 1. **JS error rate.** Daily error count and unique users affected. Compute current vs baseline averages.
-2. **Error-free session rate.** This is the headline quality KPI. Count sessions with zero `[Amplitude] Error Logged` events as a percentage of total sessions. Use `query_dataset` with a session-scoped query if possible, or estimate from unique sessions with errors vs total DAU.
+2. **Error-free session rate.** This is the headline quality KPI. Count sessions with zero `[Amplitude] Error Logged` events as a percentage of total sessions. Use `query_amplitude_data` with a session-scoped query if possible, or estimate from unique sessions with errors vs total DAU.
 3. **New errors.** Group by `Error Message` in both periods. Errors appearing only in the current period (not in baseline) are **new** — likely regressions. Flag these prominently.
 4. **Top errors (current period).** Group by `Error Message`, limit to top 10. Include `Error Type`, `File Name`, and unique user count.
 
 #### 2c. User Frustration
 
-Use `Amplitude:query_dataset` to query `[Amplitude] Error Click`:
+Use `Amplitude:query_amplitude_data` to query `[Amplitude] Error Click`:
 
 1. **Error click rate.** Daily error click volume and unique users. Compute current vs baseline.
 2. **Top clicked errors.** Group by `[Amplitude] Element Text` or `[Amplitude] Message`, limit to top 5.
 
 ### Phase 3: Page Health Scoring
 
-Use `Amplitude:query_dataset` to score individual pages. Budget: 1-2 calls.
+Use `Amplitude:query_amplitude_data` to score individual pages. Budget: 1-2 calls.
 
 1. Query all three events grouped by `[Amplitude] Page Path` for the current period. For each page, compute:
    - Network failure count (4xx/5xx `[Amplitude] Network Request` events)
@@ -218,7 +218,7 @@ Ask what to dig into: "Want me to investigate the chart builder errors in detail
 - **Very low traffic.** If <1,000 network requests in the window, note that sample sizes are too small for reliable rates. Report absolute counts instead of percentages.
 - **All metrics are healthy.** This is a positive finding. Say so clearly: "All reliability KPIs are stable or improving. Error-free session rate is XX%, network failure rate is X.X%, and no new JS errors have appeared." Then surface the top chronic errors as tech debt candidates and suggest an error budget target.
 - **No baseline available.** If the project just started tracking these events, you only have the current period. Skip trend comparisons and present the current snapshot. Recommend checking back in 2 weeks for a meaningful comparison.
-- **User asks "did the release break anything" without a date.** Check `get_deployments` and use the most recent deploy's date. If no deployments are found, ask the user for the deploy date.
+- **User asks "did the release break anything" without a date.** Check `use_amp_flags` with `action: "list_deployments"` and use the most recent deploy's date. If no deployments are found, ask the user for the deploy date.
 - **Overwhelming number of errors.** If >50K JS errors in the window, focus exclusively on unique error messages and affected user counts. Group by `File Name` first to identify which codebases are noisiest, then drill into error messages within the worst file.
 
 ## Examples

--- a/plugins/amplitude/skills/replay-ux-audit/SKILL.md
+++ b/plugins/amplitude/skills/replay-ux-audit/SKILL.md
@@ -13,14 +13,14 @@ Watch 5-10 session replays for a specific feature, page, or flow, then synthesiz
 ## CRITICAL: Tool Reference
 
 **Primary tools:**
-- **`Amplitude:get_session_replays`** — Find sessions matching event filters, user properties, or time windows. Use this to target sessions for a specific feature or flow.
-- **`Amplitude:get_session_replay_events`** — Decode a replay into an interaction timeline: navigations, clicks, inputs, scrolls. This is what you "watch."
+- **`Amplitude:get_amp_session_replay_info`** with `action: "search"` — Find sessions matching event filters, user properties, or time windows. Use this to target sessions for a specific feature or flow.
+- **`Amplitude:get_amp_session_replay_info`** with `action: "events"` — Decode a replay into an interaction timeline: navigations, clicks, inputs, scrolls. This is what you "watch."
 
 **Supporting tools:**
-- **`Amplitude:get_events`** — Discover valid event names. Never guess event names.
+- **`Amplitude:manage_amp_events`** with `action: "get"` and `kind: "event"` — Discover valid event names. Never guess event names.
 - **`Amplitude:get_properties`** — Discover properties for filtering (page path, feature area, etc.).
-- **`Amplitude:query_charts`** — Pull quantitative context (funnel conversion rates, feature adoption) to anchor the qualitative replay findings.
-- **`Amplitude:get_feedback_insights`** / **`Amplitude:get_feedback_mentions`** — Cross-reference replay friction with customer feedback themes.
+- **`Amplitude:get_amplitude_charts`** with `include: "data"` — Pull quantitative context (funnel conversion rates, feature adoption) to anchor the qualitative replay findings.
+- **`Amplitude:use_amplitude_ai_feedback`** with `facet: "insights"` / `facet: "mentions"` — Cross-reference replay friction with customer feedback themes.
 
 ---
 
@@ -42,7 +42,7 @@ Also determine:
 ### Step 2: Get Context and Discover Events
 
 1. Call `Amplitude:get_amplitude_context`. If multiple projects, ask which to audit.
-2. Call `Amplitude:get_events` to find events related to the target area. Look for:
+2. Call `Amplitude:manage_amp_events` with `action: "get"` and `kind: "event"` to find events related to the target area. Look for:
    - Page view or navigation events for the target area
    - Key interaction events (clicks, form submissions) within the flow
    - Error or failure events that may indicate friction
@@ -52,7 +52,7 @@ Also determine:
 
 Before watching replays, establish context with 1-2 chart queries. Budget: 2 calls max.
 
-- If auditing a **funnel**: Use `Amplitude:query_charts` to get the current conversion rate and identify the worst drop-off step. This tells you where to focus your replay attention.
+- If auditing a **funnel**: Use `Amplitude:get_amplitude_charts` with `include: "data"` to get the current conversion rate and identify the worst drop-off step. This tells you where to focus your replay attention.
 - If auditing a **page**: Query the page's traffic volume and any error rates to understand scale.
 - If auditing a **feature**: Query adoption/usage frequency to understand how many users interact with it.
 
@@ -60,7 +60,7 @@ This quantitative baseline makes your qualitative findings more actionable — "
 
 ### Step 4: Find Target Sessions
 
-Use `Amplitude:get_session_replays` to find 8-12 sessions (request `limit: 12` to allow for some sessions with missing replay data).
+Use `Amplitude:get_amp_session_replay_info` with `action: "search"` to find 8-12 sessions (request `limit: 12` to allow for some sessions with missing replay data).
 
 **Filter strategy by audit type:**
 
@@ -73,7 +73,7 @@ If the user specified a segment (plan type, platform, etc.), add user property f
 
 ### Step 5: Watch Sessions — Extract Interaction Timelines
 
-For each session, call `Amplitude:get_session_replay_events` with `event_limit: 300`.
+For each session, call `Amplitude:get_amp_session_replay_info` with `action: "events"` and `event_limit: 300`.
 
 **Budget: 5-8 sessions.** Skip sessions that return empty or minimal data.
 
@@ -118,7 +118,7 @@ This is the core analytical step. Aggregate findings across all watched sessions
    - Error state without clear recovery path
    - Too many steps or cognitive load
 
-5. **Cross-reference with feedback** (if available). Call `Amplitude:get_feedback_insights` with keywords from your friction findings. If users are complaining about the same thing you're seeing in replays, that's high-confidence signal.
+5. **Cross-reference with feedback** (if available). Call `Amplitude:use_amplitude_ai_feedback` with `facet: "insights"` and keywords from your friction findings. If users are complaining about the same thing you're seeing in replays, that's high-confidence signal.
 
 ### Step 7: Present the UX Audit
 

--- a/plugins/amplitude/skills/review-agent-insights/SKILL.md
+++ b/plugins/amplitude/skills/review-agent-insights/SKILL.md
@@ -17,7 +17,7 @@ Surface everything Amplitude's AI agents have found recently. Query **every avai
 
 **Supporting tools:**
 - **`Amplitude:get_amplitude_context`** / **`Amplitude:get_amplitude_context`** — Bootstrap user, org, and project info.
-- **`Amplitude:get_deployments`** — Check whether fixes have shipped for flagged issues (staleness validation).
+- **`Amplitude:use_amp_flags`** with `action: "list_deployments"` — Check whether fixes have shipped for flagged issues (staleness validation).
 
 ---
 
@@ -64,7 +64,7 @@ Agent insights go stale within days. Before synthesizing, filter out or flag any
    - **7-14 days old**: Lower confidence — include only if no newer findings cover the same area. Label as "may be outdated."
    - **> 14 days old**: Stale — exclude from the main narrative. Mention in passing only if nothing newer exists for that area.
 
-2. **Cross-reference with deployments (1 call).** Call `get_deployments` once. For each AI-detected issue, check if a deployment shipped a fix or change to the affected area after the analysis was run. If so, note the finding as "potentially resolved by [deployment]" rather than presenting it as an active issue.
+2. **Cross-reference with deployments (1 call).** Call `use_amp_flags` with `action: "list_deployments"` once. For each AI-detected issue, check if a deployment shipped a fix or change to the affected area after the analysis was run. If so, note the finding as "potentially resolved by [deployment]" rather than presenting it as an active issue.
 
 3. **Deduplicate across agent types.** The same problem may surface from multiple agent types. Merge these into a single finding with multi-agent evidence — don't present the same issue multiple times.
 

--- a/plugins/amplitude/skills/scheduled-report-refresh/SKILL.md
+++ b/plugins/amplitude/skills/scheduled-report-refresh/SKILL.md
@@ -20,7 +20,7 @@ scheduled runs re-pulling a known set of charts and summarizing changes.
    the report uses.
 3. **Fill gaps ad hoc.** `query_amplitude_data` (typed `chart`) only for
    numbers no saved chart covers (a new funnel step, a one-off slice).
-4. **Context for movement.** `get_deployments` once — recent deploys are
+4. **Context for movement.** `use_amp_flags` `action: 'list_deployments'` once — recent deploys are
    the first hypothesis for any metric movement.
 5. **Report.** Delta table first (metric, current, baseline, % change),
    then notable movers with hypotheses. State explicitly when the current
@@ -37,9 +37,3 @@ scheduled runs re-pulling a known set of charts and summarizing changes.
 - If a chart errors or returns empty, report it as a broken report item
   rather than silently dropping it — a missing tile in a recurring report
   is itself a finding.
-
-## Legacy surface
-
-If `use_amp_dashboards` / `get_amplitude_charts` are not in the tool list:
-`get_dashboard` reads the chart list, `query_charts` (≤3 ids) pulls data,
-and `query_dataset` fills gaps. The arc is unchanged.

--- a/plugins/amplitude/skills/taxonomy/SKILL.md
+++ b/plugins/amplitude/skills/taxonomy/SKILL.md
@@ -412,31 +412,38 @@ Get information about the current user, organization, and accessible projects. C
 ### `get_amplitude_context` with `projectId`
 Get project-specific settings: time zone, currency, session definition, AI context. Use to understand project configuration before making changes.
 
-### `search`
-Search for charts, dashboards, notebooks, experiments, events, properties, cohorts, and other Amplitude content. Use this before `get_events` to find the event you're looking for.
+### `search_amp_entities` and `search_amp_data_taxonomy`
+Use `search_amp_entities` for charts, dashboards, notebooks, experiments,
+cohorts, and other Amplitude content. Use `search_amp_data_taxonomy` for events
+and properties.
 
-### `get_workspace_settings`
-Get workspace settings including approval workflow status. Check before writing to the default branch — when `approvalWF` is "Required", the user must create a non-default branch first.
+### `manage_amp_data_taxonomy`
+Use `action: "get"` for workspace settings, including approval workflow status.
+Check before writing to the default branch — when `approvalWF` is "Required",
+the user must create a non-default branch first.
 
 ## Event Discovery
 
-### `get_events`
-Retrieve events from a project with filtering by event types, limit, and cursor pagination. Returns full event objects including category and active status.
+### `manage_amp_events`
+Use `action: "get"` and `kind: "event"` to retrieve events from a project with
+filtering by event types, limit, and cursor pagination. Returns full event
+objects including category and active status.
 
-If the connected MCP server's `get_events` input schema accepts `_client`, every
-`get_events` call made by this skill MUST include this top-level caller
+If the connected MCP server's `manage_amp_events` input schema accepts `_client`,
+every `manage_amp_events` call made by this skill MUST include this top-level caller
 attribution exactly. Otherwise, omit `_client`.
 
 ```json
 "_client": { "type": "skill", "skill_name": "taxonomy" }
 ```
 
-- Use `search` first to find the event you're looking for.
-- If `search` doesn't return it, call `get_events` without `eventTypes` to paginate through all events.
+- Use `search_amp_data_taxonomy` first to find the event you're looking for.
+- If search doesn't return it, call `manage_amp_events` with `action: "get"` and
+  `kind: "event"` without `eventTypes` to paginate through all events.
 - If you know exact event type names, pass them via `eventTypes` for precise lookup.
 
-### `get_custom_or_labeled_events`
-Retrieve custom events, labeled (autotrack) events, or both from a project.
+Use `manage_amp_events` with `action: "get"` and `kind: "custom"`, `"labeled"`,
+or `"all"` to retrieve custom events, labeled (autotrack) events, or both.
 
 - `eventKind: "_all"` — both custom and labeled events (default).
 - `eventKind: "custom"` — non-autotrack custom events only.
@@ -465,10 +472,13 @@ All property types except `event` support limit/cursor pagination.
 
 ## Metadata Updates
 
-### `update_event`
-Update event metadata: descriptions, display names, categories, official status, and event names. Operates on the tracking plan.
+Use `manage_amp_events` with `action: "update"` and `kind: "event"` to update
+event metadata: descriptions, display names, categories, official status, and
+event names. It operates on the tracking plan.
 
-- Event type keys must match the event `name` exactly (case-sensitive) — not the `displayName`. Resolve via `get_events` first if needed.
+- Event type keys must match the event `name` exactly (case-sensitive) — not the
+  `displayName`. Resolve via `manage_amp_events` with `action: "get"` and
+  `kind: "event"` first if needed.
 - Supports `branchId` or `branchName` to target non-default branches.
 - Do not overwrite existing descriptions — append additional context instead.
 - Never update bracket-prefixed or vendor-prefixed events (`[Amplitude]`, `[Experiment]`, etc.) unless explicitly requested.
@@ -485,10 +495,12 @@ Update property metadata (description, official status, category, and/or name). 
 - Use `get_properties` first to verify property names and status before updating.
 - Requires "Update Tracking Plan" permission.
 
-### `update_custom_or_labeled_events`
-Update descriptions, categories, names, official status, and/or definitions on custom or labeled events.
+Use `manage_amp_events` with `action: "update"` and `kind: "custom"` or
+`"labeled"` to update descriptions, categories, names, official status, and/or
+definitions on custom or labeled events.
 
-- Only use when the user explicitly asks to update a "custom event" or "labeled event." For regular events, use `update_event`.
+- Only use when the user explicitly asks to update a "custom event" or "labeled
+  event." For regular events, use `kind: "event"`.
 - Definitions are **replaced in full**, not merged — pass the complete new source-event list.
 - Renaming will break chart references — always warn the user.
 

--- a/plugins/amplitude/skills/user-cohort-forensics/SKILL.md
+++ b/plugins/amplitude/skills/user-cohort-forensics/SKILL.md
@@ -22,7 +22,7 @@ analysis; hundreds of calls total is fine. Keep each call narrow (event
 types, window) so responses stay small.
 
 **Cohort spot-check:** prefer existing cohorts — `use_amplitude_cohorts`
-`action: 'list'` (backed by `search`) or `action: 'get'` before building ad
+`action: 'list'` or `action: 'get'` before building ad
 hoc definitions. `action: 'membership'` verifies specific users. Check a
 member's timeline for the exact markers (purchase, typing, checkout events)
 rather than trusting the cohort definition blindly.
@@ -41,10 +41,3 @@ For bulk exports, batch and note the retry pattern on individual failures.
 - User identity: a user can match multiple IDs (device, user, email). Say
   which identity you resolved and flag ambiguous matches instead of picking
   one silently.
-
-## Legacy surface
-
-If `get_amp_user_data` / `use_amplitude_cohorts` are not in the tool list:
-`get_users` resolves and lists users, `get_user_profile` / `get_user_timeline`
-read one user each, and `get_cohorts` / `check_cohort_membership` cover
-cohorts. The arcs are unchanged.

--- a/plugins/amplitude/skills/weekly-brief/SKILL.md
+++ b/plugins/amplitude/skills/weekly-brief/SKILL.md
@@ -17,9 +17,9 @@ Before scanning data, build context about who you're talking to and what they ca
 1. **Detect persona.** Ask or infer the user's role: executive, PM, analyst, growth, or engineering. This determines the language, depth, and framing of the entire briefing.
 2. **Bootstrap context (1 call first, then 2 discovery calls in parallel).** Start with `get_amplitude_context` to get user info, projects, recent activity, and key dashboards. Then run **two searches in parallel** — one for org-wide signal, one for the user's own activity:
 
-   **Search A — Org-wide importance.** `search` with `isOfficial: true`, `sortOrder: "viewCount"`, `limitPerQuery: 10`. Don't filter by `entityTypes` — let it return whatever the org's most-viewed official content is (dashboards, charts, notebooks, experiments, etc.). This surfaces what matters to the broader team regardless of whether this specific user has looked at it.
+   **Search A — Org-wide importance.** `search_amp_entities` with `isOfficial: true`, `sortOrder: "viewCount"`, `limitPerQuery: 10`. Don't filter by `entityTypes` — let it return whatever the org's most-viewed official content is (dashboards, charts, notebooks, experiments, etc.). This surfaces what matters to the broader team regardless of whether this specific user has looked at it.
 
-   **Search B — User-personalized activity.** `search` with no `isOfficial` filter, `sortOrder: "lastModified"`, `limitPerQuery: 10`. Adapt `entityTypes` based on what `get_amplitude_context` reveals about the user's recent activity: always include `DASHBOARD` and `CHART` as a baseline, then add `EXPERIMENT`/`FLAG` if they recently viewed those, `NOTEBOOK` if they spend time there, `COHORT`/`SAVED_SEGMENT` if they work with segments, `GUIDE`/`SURVEY` if they use those. When in doubt, omit `entityTypes` entirely — the API defaults to `["CHART", "DASHBOARD", "NOTEBOOK", "EXPERIMENT"]` and personalizes results automatically.
+   **Search B — User-personalized activity.** `search_amp_entities` with no `isOfficial` filter, `sortOrder: "lastModified"`, `limitPerQuery: 10`. Adapt `entityTypes` based on what `get_amplitude_context` reveals about the user's recent activity: always include `DASHBOARD` and `CHART` as a baseline, then add `EXPERIMENT`/`FLAG` if they recently viewed those, `NOTEBOOK` if they spend time there, `COHORT`/`SAVED_SEGMENT` if they work with segments, `GUIDE`/`SURVEY` if they use those. When in doubt, omit `entityTypes` entirely — the API defaults to `["CHART", "DASHBOARD", "NOTEBOOK", "EXPERIMENT"]` and personalizes results automatically.
 
    **Merge and deduplicate** the results from both searches. Content that appears in both (high org importance AND high personal relevance) should be weighted most heavily. Content that appears only in Search A surfaces things the user wouldn't find on their own.
 
@@ -35,12 +35,12 @@ Gather data with a full-week lens. The primary time window is **the last 7 compl
 
 Run these in parallel where possible:
 
-1. **Fetch dashboards (1-2 calls).** Take the dashboard IDs from Phase 1 discovery plus the user's top 2-3 personal dashboards (from `get_amplitude_context` results). Deduplicate and call `get_dashboard` in batches of 3 (max 2 calls = 6 dashboards). This gives you all the chart IDs you need. If Phase 1 returned fewer than 3 dashboards, run one additional `search` with `entityTypes: ["DASHBOARD"]`, `sortOrder: "viewCount"`, `limitPerQuery: 5` to fill in — otherwise skip this.
-2. **Query charts in bulk (2-4 calls).** Collect all unique chart IDs from the dashboards above, plus any standalone chart/metric IDs from Phase 1 discovery. Use `query_charts` (plural) to query them in bulk batches with **weekly granularity over the last 5 weeks**. Compare this week against the prior 4-week average. Flag any metric where this week deviates >10% from the trailing 4-week average or shows a consistent multi-week trend (3+ weeks in the same direction). Note if the current week is partial and adjust comparisons accordingly.
+1. **Fetch dashboards (1-2 calls).** Take the dashboard IDs from Phase 1 discovery plus the user's top 2-3 personal dashboards (from `get_amplitude_context` results). Deduplicate and call `use_amp_dashboards` with `action: "get"` in batches of 3 (max 2 calls = 6 dashboards). This gives you all the chart IDs you need. If Phase 1 returned fewer than 3 dashboards, run one additional `search_amp_entities` with `entityTypes: ["DASHBOARD"]`, `sortOrder: "viewCount"`, `limitPerQuery: 5` to fill in — otherwise skip this.
+2. **Query charts in bulk (2-4 calls).** Collect all unique chart IDs from the dashboards above, plus any standalone chart/metric IDs from Phase 1 discovery. Use `get_amplitude_charts` with `include: "data"` to query them in bulk batches with **weekly granularity over the last 5 weeks**. Compare this week against the prior 4-week average. Flag any metric where this week deviates >10% from the trailing 4-week average or shows a consistent multi-week trend (3+ weeks in the same direction). Note if the current week is partial and adjust comparisons accordingly.
 3. **Trend detection (no additional calls).** From the chart results already fetched, compute week-over-week deltas for every metric. Identify: (a) **accelerating trends** — metrics that moved >10% WoW for 2+ consecutive weeks, (b) **inflection points** — metrics that reversed direction this week, (c) **new highs/lows** — metrics that hit their best or worst value in the 5-week window. Rank by magnitude and strategic importance.
-4. **Experiment check (1-2 calls).** Call `get_experiments` once. Focus on experiments that concluded this week, hit significance this week, or have been running >14 days without a call. Only call `query_experiment` for the most relevant ones.
-5. **Feedback (2 calls).** Call `get_feedback_sources` once to get sourceIds, then call `get_feedback_insights` once with the most relevant sourceId. Focus on themes that emerged or intensified over the past week — not individual data points.
-6. **Deployment context (1 call).** Call `get_deployments` once. Build a timeline of what shipped this week to explain metric movements and contextualize the findings.
+4. **Experiment check (1-2 calls).** Call `use_amp_experiments` with `action: "get"` once. Focus on experiments that concluded this week, hit significance this week, or have been running >14 days without a call. Only call `use_amp_experiments` with `action: "analyze"` for the most relevant ones.
+5. **Feedback (2 calls).** Call `use_amplitude_ai_feedback` with `facet: "sources"` once to get sourceIds, then call it with `facet: "insights"` once with the most relevant sourceId. Focus on themes that emerged or intensified over the past week — not individual data points.
+6. **Deployment context (1 call).** Call `use_amp_flags` with `action: "list_deployments"` once. Build a timeline of what shipped this week to explain metric movements and contextualize the findings.
 
 ### Phase 3: Validate and Filter
 
@@ -51,7 +51,7 @@ Be the skeptic. Weekly data smooths out daily noise, but introduces its own arti
    - **Holiday/seasonal effects**: Check if this week or the comparison weeks include holidays, end-of-quarter patterns, or seasonal events that explain the variance.
    - **One-day spikes inflating the week**: If a weekly metric was driven by a single anomalous day, call it out — it's a daily story dressed up as a weekly trend.
    - **Rolling window artifacts**: 30-day active user counts always dip in recent windows.
-   - **Launch phase growth**: Check `get_deployments` for flag ramp-ups that explain expected growth.
+   - **Launch phase growth**: Check `use_amp_flags` with `action: "list_deployments"` for flag ramp-ups that explain expected growth.
 2. **Apply confidence scoring.** Rate each finding 0.0–1.0. Drop anything below 0.6.
 3. **Apply the "so what" filter.** Weekly briefings serve strategic decisions. If a finding doesn't inform a decision that matters this week or next, drop it.
 
@@ -60,7 +60,7 @@ Be the skeptic. Weekly data smooths out daily noise, but introduces its own arti
 Investigate WHY the top findings are happening, but be selective — only spend tool calls on the 2-3 most significant findings.
 
 1. **Explain from existing data first.** Before making any new calls, check if deployments, experiments, or feedback already explain the finding. Often they do, and you can skip the segment breakdown entirely.
-2. **Segment discovery (only for top 2-3 findings).** Use `query_dataset` to break the biggest anomalies down by platform, country, plan tier, etc. Find WHERE the change concentrates. Skip this for smaller findings — use reasoning instead.
+2. **Segment discovery (only for top 2-3 findings).** Use `query_amplitude_data` to break the biggest anomalies down by platform, country, plan tier, etc. Find WHERE the change concentrates. Skip this for smaller findings — use reasoning instead.
 3. **Connect the dots across findings.** Weekly briefings should surface narrative threads — if multiple related metrics are all moving in the same direction, that's one story, not three separate findings.
 4. **Cross-check.** Look for shared root causes across findings. If two metrics moved for the same reason, merge them into one narrative.
 
@@ -104,7 +104,7 @@ Transform your analysis into a concise, narrative briefing the user could forwar
 
 Before delivering, verify your work. Prefer reviewing data you already have over making new tool calls.
 
-1. **Fact-check**: Review the data already fetched for the 2-3 most consequential claims. Only re-query with `query_charts` or `query_dataset` if you're genuinely uncertain about a number — not as a routine step. If the data came from a `query_charts` result, trust it.
+1. **Fact-check**: Review the data already fetched for the 2-3 most consequential claims. Only re-query with `get_amplitude_charts` `include: "data"` or `query_amplitude_data` if you're genuinely uncertain about a number — not as a routine step. If the data came from a `get_amplitude_charts` result, trust it.
 2. **Trend check**: Verify every finding is framed as a week-over-week or multi-week trend, not a single-day event. If a finding is really a daily story, either reframe it in weekly context or flag it as a one-day spike within the weekly narrative.
 3. **Partial-week check**: If you cited this week's data and it's incomplete, confirm you compared pace rather than raw totals and noted the partial status.
 4. **Actionability gate**: Every finding MUST have at least one concrete action. If it doesn't, either add one or drop the finding.
@@ -153,11 +153,11 @@ Example output:
 
 ### Error: No dashboards found
 Cause: User may not have created dashboards, or the project has limited setup.
-Solution: Fall back to searching for any charts or events. Use `search` broadly and build context from whatever is available. Let the user know their setup is limited and suggest creating a key metrics dashboard.
+Solution: Fall back to searching for any charts or events. Use `search_amp_entities` broadly and build context from whatever is available. Let the user know their setup is limited and suggest creating a key metrics dashboard.
 
 ### Error: Feedback API returns 400
-Cause: Called `get_feedback_insights` without first calling `get_feedback_sources`, or passed multiple values in the `types` array.
-Solution: ALWAYS call `get_feedback_sources` first. Only pass a single type value per call, or omit the types parameter entirely.
+Cause: Called `use_amplitude_ai_feedback` with `facet: "insights"` without first calling it with `facet: "sources"`, or passed multiple values in the `types` array.
+Solution: ALWAYS call `use_amplitude_ai_feedback` with `facet: "sources"` first. Only pass a single type value per call, or omit the types parameter entirely.
 
 ### Error: Metrics look flat / nothing interesting
 Cause: This week looks similar to the prior 4 weeks — stability is a finding worth reporting.


### PR DESCRIPTION
## Summary
- Replace retired MCP leaf-tool instructions with the exact GA consolidated wrappers and discriminators.
- Update agent-analytics and Session Replay guidance for the current wrapper schemas, including removed/deprecated parameters.
- Preserve the intentionally flag-gated legacy chart and experiment skills unchanged.

Linear: https://linear.app/amplitude/issue/MCP-679/mcp-server-ship-ga-consolidated-mcp-skills-and-pin-the-marketplace

## Scope
- Skill Markdown only: 27 `plugins/amplitude/skills/**/SKILL.md` files.
- No README, manifest, JSON, formatting-only, version, or `monitor-chart-alerts` changes.
- `monitor-chart-alerts` remains in its existing PR: https://github.com/amplitude/mcp-marketplace/pull/52

## Testing
- `git diff --check`
- Audited retired names against `server/packages/mcp-server/src/tools/external-wrappers/**` registrations and schemas.
- Verified remaining retired references are limited to intentionally excluded pre-GA skills.


Made with [Cursor](https://cursor.com)