### PR TITLE
feat(amplitude): add tracking plan deletion audit skill

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,4 +16,5 @@ plugins/amplitude/skills/discover-analytics-patterns/** @amplitude/mcp @amplitud
 plugins/amplitude/skills/discover-event-surfaces/** @amplitude/mcp @amplitude/amplitude-mcp @amplitude/governance-pe
 plugins/amplitude/skills/instrument-events/** @amplitude/mcp @amplitude/amplitude-mcp @amplitude/governance-pe
 plugins/amplitude/skills/taxonomy/** @amplitude/mcp @amplitude/amplitude-mcp @amplitude/governance-pe
+plugins/amplitude/skills/tracking-plan-audit/** @amplitude/mcp @amplitude/amplitude-mcp @amplitude/governance-pe
 plugins/amplitude-experimental/skills/event-description-generator/** @amplitude/mcp @amplitude/amplitude-mcp @amplitude/governance-pe

--- a/README.md
+++ b/README.md
@@ -122,8 +122,11 @@ The amplitude plugin turns your AI assistant into an expert product analyst and 
 | `instrument-events` | From prioritized event candidates, builds a concrete instrumentation plan and JSON tracking plan |
 | `add-analytics-instrumentation` | End-to-end workflow — reads code, decides what to track, and produces a full instrumentation plan in one pass |
 | `taxonomy` | Source of truth for event taxonomy generation, data auditing, and governance best practices |
+| `tracking-plan-audit` | Audits telemetry, source code, ownership, dependencies, and tracking-plan branches for safe event and event-property deletion candidates |
 
 A typical flow: `diff-intake` → `discover-event-surfaces` → `instrument-events`, with `discover-analytics-patterns` ensuring new tracking matches existing conventions.
+
+For deletion cleanup, ask: “Audit this project for stale events and properties; the emitting source roots are `path/to/web` and `path/to/service`.” The `tracking-plan-audit` skill requires complete source coverage before recommending deletions and asks for explicit confirmation before every destructive mutation.
 
 ### Briefings
 
@@ -184,6 +187,7 @@ plugins/
       replay-ux-audit/
       review-agent-insights/
       taxonomy/
+      tracking-plan-audit/
       weekly-brief/
       what-would-lenny-do/
 ```

--- a/plugins/amplitude/README.md
+++ b/plugins/amplitude/README.md
@@ -58,6 +58,8 @@ Cursor:
 | **discover-opportunities** | Discover product opportunities by mining analytics, experiments, replays, and feedback — synthesized into RICE-scored, actionable recommendations |
 | **instrument-events** | Convert priority events into a detailed, line-by-line instrumentation plan grounded in the target code |
 | **add-analytics-instrumentation** | Run the full end-to-end instrumentation workflow for a PR, branch, file, or feature request |
+| **taxonomy** | Provide broad tracking-plan governance, naming, metadata, and data-quality guidance |
+| **tracking-plan-audit** | Identify evidence-backed event and event-property deletion candidates across telemetry, source code, ownership, dependencies, and tracking-plan branches |
 | **monitor-experiments** | Monitor active and recently completed experiments, triage by importance, and deep-dive on the most impactful ones |
 
 ---
@@ -87,6 +89,7 @@ Cursor:
 "Find product opportunities"                       → discover-opportunities activates
 "Check on experiments"                             → monitor-experiments activates
 "Instrument the checkout flow"                     → add-analytics-instrumentation activates
+"Audit stale events; emitters are in ./web and ./api" → tracking-plan-audit activates
 "What happened this week?"                         → weekly-brief activates
 ```
 
@@ -175,6 +178,13 @@ Cursor:
 2. Skill inspects the diff and existing tracking patterns in the codebase
 3. Skill identifies the highest-value events and the exact handlers or callbacks where they belong
 4. You get a prioritized event list plus a concrete instrumentation plan an engineer can implement
+
+#### Tracking Plan Deletion Audit
+
+1. Ask: "Audit stale events and properties in this project; all emitting code is in `./web`, `./api`, and `./mobile`"
+2. The skill fully reads the tracking plan, telemetry, ownership, and dependencies, then searches every identified source root, including dynamic and generated instrumentation
+3. You get confidence-ranked deletion candidates without property values, credentials, PII, or customer-sensitive payloads
+4. The skill makes no tracking-plan change until you explicitly confirm the exact deletion; global orphan properties are swept and confirmed separately after event deletion
 
 ---
 

--- a/plugins/amplitude/skills/tracking-plan-audit/SKILL.md
+++ b/plugins/amplitude/skills/tracking-plan-audit/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: tracking-plan-audit
+description: Use when auditing Amplitude tracking plans for safe deletion candidates among stale, duplicate, orphaned, cross-app, retired, high-volume, generated-client, never-ingested, or deleted-but-still-emitted events and event properties.
+---
+
+# Tracking Plan Audit
+
+Produce a deletion-focused, evidence-backed cleanup inventory. This skill
+specializes in deletion audits across telemetry, source code, ownership,
+dependencies, and tracking-plan branches. Use `taxonomy` for broad taxonomy
+design, naming, metadata, and governance guidance.
+
+Do not add or restore taxonomy objects, make metadata-only changes, or create,
+mutate, merge, or delete an Amplitude branch unless the user explicitly asks.
+
+At the start, establish:
+
+- the Amplitude project and environment;
+- whether the goal is lower ingestion volume, fewer taxonomy types, or both;
+- every repository or directory that may emit the project's data;
+- the requested audit mode and lookback window.
+
+## Source-code gate
+
+Source code is required. If the user has not identified every repository or
+directory that can emit into the project, ask for those locations before
+recommending deletion candidates. You may inventory taxonomy objects while
+waiting, but label the result incomplete and do not recommend or execute any
+deletion. Before lifting this gate, ask the user to confirm that the supplied
+source inventory covers every known emitter.
+Never report "no code reference" unless every user-identified source root was
+searched.
+
+Do not assume repository names, services, languages, project IDs, event names,
+observability systems, or filesystem layouts. Inspect each source root's local
+instructions before searching it.
+
+## Route the audit
+
+Choose a primary mode and state it before discovery. Run additional requested
+modes sequentially so each keeps its own criteria. Read
+[references/modes.md](references/modes.md) for each mode's criteria.
+
+1. General stale events/properties
+2. Cross-app overlap
+3. Planned but never ingested
+4. Global orphan properties
+5. Dead generated-client definitions
+6. Duplicate events/properties
+7. Retired features, routes, flags, or experiments
+8. High-volume, low-query instrumentation
+9. Code still emitting deleted or blocked events
+
+If the user requests taxonomy changes, also read
+[references/mutations.md](references/mutations.md) before any mutation.
+
+## Non-negotiable evidence rules
+
+- Keep telemetry, query/dependency usage, code references, source ownership,
+  and taxonomy state as separate signals. No single signal proves deletion is
+  safe.
+- Audit every identified source root. Include generated clients, direct SDK
+  use, wrappers, dynamic dispatch, frontend, backend, mobile, jobs, and
+  integrations where present.
+- A generated definition is potential usage, not a production call site. Trace
+  its method or class through imports, wrappers, registries, aliases, tests,
+  and production callers.
+- A literal-search miss is insufficient. Check generic trackers, constructed
+  names or keys, dictionary spreads, serializers, constants, and
+  service-specific clients.
+- Determine whether each enclosing code path is reachable through imports,
+  route wiring, flags, experiments, jobs, tests, and callers. Distinguish dead
+  code from a live feature whose analytics call alone should be removed.
+- Recent ingestion with no owner in the known roots indicates an external or
+  unidentified source. Report it and ask for another likely source root before
+  recommending deletion.
+- Check charts, dashboards, cohorts, metrics, experiments, transformations,
+  derived properties, lookups, alerts, exports, and other relationships where
+  available. A zero saved-query count does not prove there is no dependency.
+  If a required dependency surface is unavailable, mark it unresolved and do
+  not recommend deletion.
+- When retirement or production activity matters, ask which monitoring,
+  feature-flag, experimentation, and deployment systems the user has connected.
+  Prefer their read-only MCP or app capabilities over assumptions or manual
+  screenshots.
+- Treat default/system objects and experiment, session-replay, or agent fields
+  cautiously unless the selected mode explicitly investigates them.
+- Do not expose credentials, property values, PII, customer payloads, or other
+  customer-sensitive data. Report aggregates, names only when necessary, and
+  access-controlled evidence links.
+
+## Public Amplitude MCP capabilities
+
+Inspect the connected public Amplitude MCP catalog at runtime and use only the
+capabilities, action values, parameters, and limits it advertises. Do not
+hard-code or invent tool names: public tools can be consolidated, renamed, or
+exposed differently during a rollout.
+
+Use the available capabilities to:
+
+- discover accessible projects and ask the user to select one when its ID is
+  missing; never infer an ID from a name;
+- read raw events and event properties, preferring the consolidated taxonomy
+  reader when the catalog exposes one;
+- include deleted objects when comparing states or historical ownership;
+- select exactly one branch identifier when auditing a tracking-plan branch;
+- distinguish project-wide/global properties from properties attached to one
+  event using the response's documented scope fields.
+
+For mutation capability selection and exact confirmation behavior, read
+[references/mutations.md](references/mutations.md).
+
+## Complete taxonomy reads
+
+For every exhaustive paginated read:
+
+1. Request the largest supported page size, up to 500.
+2. Follow every returned cursor until the response says there are no more
+   rows.
+3. Track unique rows using the response's stable identity plus property/event
+   scope, then compare the accumulated count with the API's reported total.
+4. Retry transient timeouts and gateway/server failures from the last known
+   cursor using bounded retries and backoff appropriate to the connected host.
+   Never treat an error payload or failed empty page as completion.
+5. If retries are exhausted or counts disagree, report incomplete coverage and
+   do not recommend deletions from the partial result.
+
+Use a complete tracking-plan export when available to reconstruct
+event-to-property ownership and compare main with a branch. A project-wide
+property listing exposes global definitions but may not enumerate every event
+attachment. Do not infer ownership from it alone, the export `Action` column,
+or branch UI counters; compare taxonomy states explicitly.
+
+## Shared audit workflow
+
+1. Snapshot the relevant main or branch taxonomy and telemetry window.
+2. Fully paginate required reads and record coverage against reported totals.
+3. Build ownership from complete exports, including active and deleted scopes.
+4. Search every identified source root; classify production, dynamic,
+   generated-only, test-only, dead, and unknown-external references.
+5. Check dependencies and resolve every code, ownership, and source signal.
+6. Classify candidates by confidence, evidence, uncertainty, and recommended
+   deletion transition.
+7. After any event deletion, always perform a global orphan-property sweep.
+   Present global property candidates separately and ask for separate explicit
+   confirmation; event deletion never authorizes or implies global deletion.
+
+Strong candidates normally have no reachable emitter, no recent ingestion,
+little or no query usage, no active owner or dependency, and no unresolved
+dynamic or external source. Existing telemetry, dependencies, generic names,
+required schemas, or unknown ownership require investigation, not deletion.
+
+For properties, report at least:
+
+```text
+property | scope/owners | code references by source | volume/query window | last seen | required | dependencies | confidence | recommendation
+```
+
+Also report source coverage, exclusions, unresolved paths, sensitive-data
+redactions, and a reviewable batch. Keep mutation batches within the user's
+requested limit; otherwise prefer a small first batch.

--- a/plugins/amplitude/skills/tracking-plan-audit/references/modes.md
+++ b/plugins/amplitude/skills/tracking-plan-audit/references/modes.md
@@ -1,0 +1,124 @@
+# Audit modes
+
+Read only the selected mode plus the shared rules in `../SKILL.md`.
+
+## 1. General stale events/properties
+
+Find objects with no meaningful activity over the last two to three months,
+preferably using a 180-day volume and query window, and no current code
+references. Exclude default/system objects, required active schema fields,
+unresolved dynamic instrumentation, and planned objects with no first-seen date
+unless the user explicitly widens the audit.
+
+## 2. Cross-app overlap
+
+Compare the target project with another app or source. A same-named object is a
+candidate only when target-side ingestion is zero and ownership plus source
+code show it belongs to the other app. Audit both apps' emitting code. Treat
+global and event-scoped properties separately.
+
+## 3. Planned but never ingested
+
+Use event metadata, not only an export, to inspect creation time, first seen,
+last seen, status, sources, owner, and schema. Prioritize old creation dates
+with empty first-seen values, then check all identified source roots, generated
+clients, dynamic paths, and upcoming work. A planned object may be intentionally
+staged. For properties, verify owning events, required status, and global/event
+scope.
+
+## 4. Global orphan properties
+
+Find active global properties with zero active event attachments. Reconstruct
+ownership from a complete export and verify global state through fully
+paginated taxonomy reads. Keep these distinct:
+
+- active globals with no active owner;
+- globals owned only by deleted events;
+- already globally deleted properties;
+- shared globals with another active owner.
+
+Recent global `lastSeen` can come from an unexpected or dynamically emitted
+event even when no active schema attachment is visible. Compare it with parent
+event last-seen times and inspect code before deleting.
+
+## 5. Dead generated-client definitions
+
+Map each generated event or property to its method or class, then trace all
+production consumers. Classify it as reachable production, dynamic/wrapper,
+tests only, generated only, or unknown external owner. Audit every repository
+that can consume the generated source, not just the repository containing it.
+Only generated-only or independently proven dead definitions are strong
+candidates.
+
+When code cleanup is requested, pull the affected generated client from the
+tracking-plan branch and inspect its diff. Reject unrelated drift or removals
+that break reachable callers. After the tracking-plan branch merges, point the
+client configuration back to main, pull again, and rerun affected builds and
+consumer type checks using the customer's actual commands.
+
+## 6. Duplicate events/properties
+
+Generate candidates from casing, separators, prefixes, aliases, scoping,
+custom-event overlap, and similar payloads. Choose the canonical object from
+current production emission and telemetry, not plan status or naming
+convention alone. Check schemas, dependencies, dual emission, migration
+comments, and dynamically constructed final names.
+
+If the canonical object must be added or restored, stop this deletion audit and
+report that prerequisite. It belongs in a separate additive workflow and must
+be completed before a fresh deletion-only audit begins.
+
+## 7. Retired features, routes, flags, or experiments
+
+Find objects tied to removed features, routes, experiments, or flags. Verify
+retirement in code, production activity, and lifecycle metadata.
+
+Before auditing, ask the user which connected capabilities cover:
+
+- monitoring, APM, logs, route traffic, and background jobs;
+- feature flags and remote configuration;
+- experiments and rollouts;
+- deployments or change history when useful for timing.
+
+Inspect the available MCP or app catalog and use the customer's connected
+systems read-only. For routes and jobs, check traffic over a
+project-appropriate window and account for aliases, retries, scheduled cadence,
+and environment. For flags and experiments, inspect active or archived state,
+allocation, rollout history, last exposure, and related code references. For
+deployments, correlate removal dates with the drop in ingestion or traffic.
+
+If a relevant system is not connected, ask the user for an alternative source
+or exported evidence and mark that signal unresolved. Do not infer retirement
+from missing access. Code absence, zero traffic, archival, or stale ingestion
+is supporting evidence, not proof by itself; resolve dynamic paths,
+dependencies, and source ownership. Do not mutate monitoring, flag,
+experiment, or deployment systems as part of this audit.
+
+## 8. High-volume, low-query instrumentation
+
+Prioritize project-relative high-volume objects with little or no saved-query
+usage. Volume is the prioritization signal; do not impose a universal cutoff.
+Inspect amplification from mount effects, hovers, loops, per-item logging,
+retries, mirrored services, temporary diagnostics, and observability already
+covered elsewhere.
+
+For actively ingested objects:
+
+1. Remove emitters in separate PRs by repository or independently deployable
+   service ownership.
+2. Deploy and verify ingestion reaches zero while product and operational
+   behavior remain intact.
+3. Delete taxonomy objects later on a deletion-only tracking-plan branch.
+4. Sweep global properties owned only by the deleted events.
+
+Deduplicate savings across mirrored implementations. Report the measured
+lookback and label any annualized estimate.
+
+## 9. Code still emitting deleted or blocked events
+
+Find deleted or blocked events still emitted by production code. Search
+generated clients, direct SDK calls, wrappers, constructed names, and every
+identified emitter. Remove only analytics instrumentation while preserving
+product and API behavior. Keep code PRs split by repository and independently
+deployable service. Report unresolved external owners instead of guessing. Do
+not restore taxonomy objects in this mode.

--- a/plugins/amplitude/skills/tracking-plan-audit/references/mutations.md
+++ b/plugins/amplitude/skills/tracking-plan-audit/references/mutations.md
@@ -1,0 +1,105 @@
+# Deletion mutation and verification
+
+Read this before creating or changing an Amplitude tracking-plan branch.
+
+## Authorization and scope
+
+- Use the catalog's workspace or branch read capability to inspect approval,
+  protection, and branch settings when exposed.
+- Create a uniquely named feature branch from current main only when the user
+  explicitly requests it. If safe branch-based review is required but
+  unavailable, stop before destructive writes and explain the limitation.
+- Re-read the exact candidates on fresh main and branch snapshots.
+- Run every deletion as a two-step operation: first omit the current schema's
+  confirmation control and show the confirmation-required response, including
+  exact names, scope, project, branch, and soft-delete/hard-removal buckets;
+  then wait for explicit user confirmation before making the confirmed call
+  exactly as that schema requires. If candidate state or the preview changes
+  while waiting, show a fresh preview and obtain confirmation again.
+- Delete only the confirmed names and scopes. Earlier general approval such as
+  "clean up related objects" is not confirmation for newly discovered targets.
+- Do not merge or delete the tracking-plan branch unless the user separately
+  asks and confirms that exact destructive action.
+- If additions, restorations, or metadata changes are needed, stop and report
+  the prerequisite. Do not perform it inside this skill.
+
+## Select public mutation capabilities
+
+Inspect the connected public Amplitude MCP catalog immediately before each
+mutation. Select only capabilities whose advertised schemas explicitly support:
+
+- raw tracking-plan event deletion by exact name and branch;
+- event-property deletion by exact name, property scope, and branch;
+- a two-step destructive confirmation response and confirmed retry;
+- the intended soft-delete or hard-removal transition.
+
+For property deletion, use the schema's documented per-event scope field to
+delete only one event attachment. Omit that field only when the schema
+explicitly documents omission as a plan-wide/global deletion and the user has
+separately confirmed that broader scope. Never guess an action, parameter, or
+omission behavior from an older tool version.
+
+## Soft-delete versus hard removal
+
+Explain the tool's bucketed behavior before asking for confirmation:
+
+- An ingested event is soft-deleted and can be restored by a separate workflow.
+  A never-ingested planned event is hard-removed and cannot be restored.
+- A live or unexpected event property is soft-deleted. A planned property is
+  hard-removed. For an event-scoped target, hard removal unlinks only that
+  event; for a global target, it removes the plan-wide property.
+- Soft-deleted objects remain visible when the active taxonomy reader is asked
+  to include deleted objects. A hard-removed never-ingested object is absent.
+
+Deletion or blocking does not erase already-ingested historical data.
+Historical data remains queryable in existing analyses, while future ingestion
+for the deleted or blocked tracking-plan object stops immediately on main or
+after its branch is merged. Check enforcement settings to explain the exact
+rejection or handling behavior without weakening that distinction.
+
+## Global property scope
+
+Deleting a property attachment under one event is not global property
+deletion. Set the mutation schema's event-scope field for an event-scoped
+target; omit it only when the current schema explicitly defines omission as a
+separately confirmed plan-wide/global delete. Never create or restore a global
+property as a cleanup side effect.
+
+After deleting events, always perform a global orphan-property sweep. Present
+the resulting global candidates as a separate batch and obtain separate
+explicit confirmation before deleting any of them.
+
+## Deletion-only invariant
+
+Compare fresh main and branch exports at event and property levels. The only
+allowed tracking-plan differences are the exact approved soft-deletes of
+ingested/live/unexpected objects and exact approved hard-removals of
+never-ingested/planned objects.
+Before completion, report:
+
+- the exact approved event and property transitions;
+- `0 additions`;
+- `0 restorations`;
+- `0 metadata-only changes`.
+
+If anything else changed, stop and report the unexpected difference. Do not
+make an additive, restorative, or metadata correction inside this skill; any
+reversion of unintended branch-local changes requires separate explicit
+authorization. Do not rely on export `Action` fields or UI counters.
+Deleted parent events may hide child rows in an export; accept that only after
+verifying no global object was added, restored, or changed.
+
+## Global verification
+
+After plan-wide property deletion, fully paginate the connected event-property
+taxonomy reader on the branch with deleted objects included. Prefer the
+catalog's consolidated taxonomy reader when exposed, using only its advertised
+event-property and deleted-object selectors.
+
+Verify each soft-deleted global at the response's documented global scope with
+deleted status. Verify each hard-removed never-ingested global is absent.
+Confirm the accumulated row count matches the API total and no cursor failed;
+retry transient failures rather than accepting a short read.
+
+Finally export main and branch again and compare stable taxonomy fields while
+excluding telemetry fields that can drift between export timestamps.


### PR DESCRIPTION
## Summary

Customers need a safe way to reduce tracking-plan noise and ingestion volume without deleting events or event properties based on telemetry alone. This adds a focused, evidence-backed deletion audit that combines taxonomy state, telemetry, source-code reachability, ownership, dependency checks, and tracking-plan branch comparisons.

## Audit modes

The skill preserves nine distinct modes:

1. General stale events and properties
2. Cross-app overlap
3. Planned but never ingested objects
4. Global orphan properties
5. Dead generated-client definitions
6. Duplicate events and properties
7. Retired features, routes, flags, and experiments
8. High-volume, low-query instrumentation
9. Code still emitting deleted or blocked events

Mode 7 also uses connected monitoring, APM/logging, feature-flag, experimentation, and deployment capabilities read-only, leaving unavailable evidence unresolved rather than inferring retirement.

## Safety model

Source code is mandatory. Before the skill can recommend or execute a deletion, the customer must identify and confirm every known repository or directory capable of emitting into the project. Generated definitions are treated as potential usage, not proof of a production call site, and the workflow explicitly covers dynamic instrumentation, external producers, dependencies, and dead-code reachability.

Every destructive tracking-plan mutation requires an exact two-step preview and explicit confirmation. The skill permits only approved soft-delete or hard-removal transitions and requires verification of `0 additions`, `0 restorations`, and `0 metadata-only changes`. It explains that historical data remains queryable while future ingestion stops, distinguishes one-event property attachments from global definitions, and requires a separate global orphan-property sweep and confirmation after event deletion.

Taxonomy reads must be fully paginated, reconciled to the API total, and retried on transient failures. Partial reads cannot produce deletion recommendations. Reports exclude credentials, property values, PII, and customer-sensitive payloads.

## Relationship to `taxonomy`

The existing `taxonomy` skill remains the broad source of governance, naming, metadata, and tracking-plan design guidance. `tracking-plan-audit` is deliberately narrower: it specializes in evidence-backed deletion audits and destructive-change safeguards.

The new skill discovers the connected public Amplitude MCP catalog at runtime instead of hard-coding tool names, making it resilient to future tool consolidation and renames.

## Validation

- Repository JSON parsing and Claude/Cursor manifest synchronization
- `git diff --check`
- Skill frontmatter name/description validation
- Relative Markdown link validation across the skill and references
- Nine-mode presence check
- Added-diff scan for local/internal paths, project or ticket IDs, internal-only names, and stale tool names
- Adversarial control/skill pressure checks for source coverage, mutation confirmation, global-property scope, pagination, generated clients, and deletion-only behavior

## Versioning

No plugin or marketplace manifest was edited. The repository's automatic version-bump workflow detects newly added plugin files and will apply the appropriate Amplitude plugin version bump after merge.
