### PR TITLE
fix(amplitude): make MCP tool discovery resilient across skills

### DIFF
--- a/plugins/amplitude/skills/analyze-account-health/SKILL.md
+++ b/plugins/amplitude/skills/analyze-account-health/SKILL.md
@@ -22,11 +22,11 @@ Use `Amplitude:search_amp_entities` to find existing dashboards, charts, or note
 Every step below breaks down "by account", and there are three different ways a
 project represents one. Check in this order and reuse the answer throughout:
 
-1. `get_group_types` — if the project has a group type (commonly `org id` or
-   `company`), that is the account. Account attributes are **group
-   properties**: `get_properties({propertyType: 'group', groupType: '<type>'})`,
-   referenced with `scope: 'group'` plus `group_type`. To count accounts rather
-   than users, set `count_unique_by` to the group type.
+1. Use the connected catalog's group-type discovery capability. If the project
+   has a group type (commonly `org id` or `company`), that is the account. Read
+   its attributes from the active taxonomy reader's group-property surface,
+   then reference them with `scope: 'group'` plus `group_type`. To count
+   accounts rather than users, set `count_unique_by` to the group type.
 2. If there is no group type, the account is usually a **user property**
    (`company`, `org_name`) — `scope: 'user'`.
 3. Failing both, an **event property** carrying the org (`org id`, `org url`).

--- a/plugins/amplitude/skills/analyze-experiment-consolidated/SKILL.md
+++ b/plugins/amplitude/skills/analyze-experiment-consolidated/SKILL.md
@@ -83,9 +83,9 @@ If incomplete, explain what's missing and stop.
 when you need ad hoc per-variant numbers outside `analyze` (entry-point
 funnels, custom slices, cross-checks against another warehouse):
 
-- Discover the assignment event first: use `search_amp_data_taxonomy` for the
-  experiment's flag key and `search_amp_entities` for existing charts that
-  filter on it — do not guess the event name.
+- Discover the assignment event first with the connected catalog's taxonomy
+  search capability for the experiment's flag key and `search_amp_entities`
+  for existing charts that filter on it—do not guess the event name.
 - Read how an existing experiment chart structures its variant segments
   (`get_amplitude_charts` with `include: "typed"` on one) and copy that
   pattern exactly — including the bucketing property (`subject_id_type`

--- a/plugins/amplitude/skills/build-charts-with-typed-params/SKILL.md
+++ b/plugins/amplitude/skills/build-charts-with-typed-params/SKILL.md
@@ -29,15 +29,14 @@ The compiler validates **structure**, not your taxonomy. An event or property
 name that doesn't exist won't error — it returns a well-formed chart with
 **empty data**, which reads like a real answer of "zero".
 
-Resolve names first with `search_amp_data_taxonomy`, and `get_properties`
-(`propertyType: 'event'`, `'user'`, or `'group'`). Use the exact name **and
-scope** that comes back. There is no `get_event_properties` tool — server
-descriptions and error messages sometimes mention it; use `get_properties`
-instead.
+Resolve names first with the taxonomy search/read capabilities advertised by
+the connected catalog. Read event, user, or group properties as appropriate
+and use the exact name **and scope** returned. Do not invent a property-reader
+name from server prose or copy parameters from an older schema.
 
 ## Two workflows
 
-**Create:** `search_amp_data_taxonomy` for the taxonomy → build the typed `chart` → call
+**Create:** discover names with the current taxonomy capability → build the typed `chart` → call
 `query_amplitude_data` → `render_amplitude_chart` with the returned
 `chartEditId` to show it.
 
@@ -118,11 +117,8 @@ tier, ARR, industry, on the `org id` (or similarly named) group type. They are
 how almost every B2B question gets asked, and they are the most common thing to
 get stuck on.
 
-Discover them explicitly — they are **not** in the event or user catalogues:
-
-```jsonc
-get_properties({ projectId, propertyType: "group", groupType: "org id" })
-```
+Discover them explicitly with the connected taxonomy reader's group-property
+selector—they are **not** in the event or user catalogues.
 
 Then use `scope: "group"` with the `group_type` the lookup returned, in a
 `where` filter or a `group_by`:
@@ -135,7 +131,7 @@ Then use `scope: "group"` with the `group_type` the lookup returned, in a
 Three rules that avoid nearly all of the failures seen in production:
 
 1. **`group_type` is the group's display name** (`"org id"`, `"company"`) —
-   exactly as `get_group_types` / `get_properties` spells it, lowercase and
+   exactly as the group-type and taxonomy readers spell it, lowercase and
    spaced. Not the property name, not `"Group"`, not a `grp:`-prefixed key.
 2. **Never prefix the property name.** Write `"plan"`, not `"grp:plan"` or
    `"gp:org id:plan"` — those are storage-layer spellings that the chart API
@@ -155,8 +151,8 @@ this tool.
 
 Do this instead, in order:
 
-1. Re-read the exact name from `get_properties({propertyType: 'group'})`. If it
-   differs from what you sent, correct it and retry **once**.
+1. Re-read the exact name with the active taxonomy reader's group-property
+   selector. If it differs from what you sent, correct it and retry **once**.
 2. If it matches, stop retrying. Check for a user-scoped equivalent (accounts
    are often mirrored onto users, e.g. a user property `plan`) and use
    `scope: "user"`.
@@ -275,9 +271,9 @@ rather than trying a third spelling.
 
 ## When results come back empty
 
-1. Re-read every event and property name from `search_amp_data_taxonomy` / `get_properties`, and
-   check the `scope` matches what the taxonomy returned — including
-   `propertyType: 'group'` for account-level properties.
+1. Re-read every event and property name with the current taxonomy
+   search/reader and check the `scope` matches what it returned, including the
+   group-property surface for account-level properties.
 2. Widen `date_range` — the window may predate instrumentation.
 3. Drop `segments`, then `where`, to find which filter empties the result.
 4. For property aggregations, confirm the property is in the event's `group_by`.

--- a/plugins/amplitude/skills/compare-user-journeys/SKILL.md
+++ b/plugins/amplitude/skills/compare-user-journeys/SKILL.md
@@ -19,8 +19,8 @@ Investigate what distinguishes two user groups by pulling session replays and me
 **Supporting tools:**
 - **`Amplitude:search_amp_entities`** — Search for existing charts, funnels, dashboards, and cohorts relevant to the comparison. Always check for existing analysis before building from scratch.
 - **`Amplitude:use_amplitude_cohorts`** with `action: "list"` — Discover existing cohorts that define the groups (e.g., "power users", "churned", "converted").
-- **`Amplitude:manage_amp_events`** with `action: "get"` and `kind: "event"` — Discover valid event names. Never guess event names.
-- **`Amplitude:get_properties`** — Discover properties available for segmentation.
+- **Available taxonomy reader** — Inspect the connected catalog and use its
+  event and property read capabilities to discover valid names and scopes.
 - **`Amplitude:get_amplitude_charts`** with `include: "data"` — Pull quantitative metrics segmented by the two groups for statistical grounding.
 - **`Amplitude:use_amplitude_ai_feedback`** with `facet: "insights"` / `facet: "mentions"` — Check if feedback themes differ between groups.
 
@@ -51,8 +51,8 @@ If the user's request is ambiguous (e.g., "compare power users"), ask: "What def
 
 1. Call `Amplitude:get_amplitude_context`. If multiple projects, ask which to compare within.
 2. Call `Amplitude:use_amplitude_cohorts` with `action: "list"` to check if existing cohorts match the requested groups. Existing cohorts encode institutional knowledge — prefer them over ad-hoc definitions.
-3. Call `Amplitude:manage_amp_events` with `action: "get"` and `kind: "event"` to discover events relevant to the comparison (the goal event for conversion comparisons, engagement events for activity comparisons, etc.).
-4. Call `Amplitude:get_properties` for the key events to discover available segmentation properties.
+3. Use the available taxonomy event reader to discover events relevant to the comparison (the goal event for conversion comparisons, engagement events for activity comparisons, etc.).
+4. Use the same catalog's property read capability for the key events to discover available segmentation properties and scopes.
 
 ### Step 3: Quantitative Comparison (Metrics)
 
@@ -194,7 +194,7 @@ For each differentiating behavior:
 - **One group has few sessions.** If one group has <3 watchable sessions, note the limited sample and reduce confidence. Present findings as "preliminary" and suggest waiting for more data or broadening the time window.
 - **User asks to compare 3+ groups.** Decline and suggest pairwise comparison: "Comparing more than 2 groups at once dilutes the analysis. Which two would you like me to start with?" Offer to run a second comparison after.
 - **Cohort doesn't exist.** If the user references a segment that doesn't have a cohort, build the group filter from events and user properties. Suggest creating a cohort for reuse: "There's no 'power users' cohort defined. I'll filter by [criteria]. Want me to suggest a cohort definition to save?"
-- **Conversion event isn't clear.** If comparing converters vs. non-converters but the conversion event isn't obvious, call `manage_amp_events` with `action: "get"` and `kind: "event"` and propose 2-3 candidate events. Let the user confirm.
+- **Conversion event isn't clear.** If comparing converters vs. non-converters but the conversion event isn't obvious, use the available taxonomy event reader and propose 2-3 candidate events. Let the user confirm.
 - **nodeId limitations.** Interaction timelines show coordinates and node IDs, not element names. When comparing actions between groups, describe by page context and interaction sequence rather than specific UI elements. Focus on which pages and flows users engage with, not which buttons they click.
 
 ## Examples

--- a/plugins/amplitude/skills/create-chart/SKILL.md
+++ b/plugins/amplitude/skills/create-chart/SKILL.md
@@ -73,7 +73,7 @@ Amplitude:search with entity_types=['EVENT', 'CUSTOM_EVENT']
 
 **Get properties:**
 ```
-Amplitude:get_properties for exact property names/values
+Use the connected catalog's taxonomy property reader for exact names and scopes
 ```
 
 **Find cohorts:**
@@ -194,8 +194,8 @@ Amplitude:get_cohorts to get full definitions
 > `group_type` here is the **counting entity** ("User", or a group like
 > "org id") — not the scope of the property. To filter on an account-level
 > property, set `subprop_type` to `"group"` and `group_type` to the group type
-> that owns it, using the exact name from
-> `get_properties({propertyType: 'group', groupType: '<type>'})`. Never prefix
+> that owns it, using the exact name from the active taxonomy reader's
+> group-property surface. Never prefix
 > the property name with `grp:`. If the response is
 > `Invalid group property … for group type …`, that pair is not queryable in
 > this project — do not retry variants; use a user- or event-level equivalent.
@@ -257,7 +257,7 @@ Amplitude:get_charts to see definition structure
 
 5. **Get properties if needed:**
 ```
-Amplitude:get_properties
+Use the connected catalog's taxonomy property reader
 ```
 
 6. **Build definition** using discovered names
@@ -303,7 +303,7 @@ Amplitude:save_chart_edits with editId from query_dataset
 **Verification:**
 - Always verify event exists before using
 - Check similar charts to understand event usage
-- Confirm properties with get_properties
+- Confirm property names and scopes with the active taxonomy reader
 
 **Comparisons:**
 - Use segments for comparing user groups on same chart
@@ -314,6 +314,5 @@ Amplitude:save_chart_edits with editId from query_dataset
 - What the chart shows
 - Key insights from initial data
 - Methodology used
-
 
 

--- a/plugins/amplitude/skills/create-dashboard/SKILL.md
+++ b/plugins/amplitude/skills/create-dashboard/SKILL.md
@@ -13,8 +13,9 @@ Create new team or initiative dashboards, organize scattered charts, build execu
 
 Before building, understand what you're tracking:
 - Search for existing dashboards/charts related to the topic
-- Search for relevant events with `Amplitude:search_amp_data_taxonomy`
-- Use `get_properties` to understand available properties for segmentation
+- Inspect the connected catalog and use its taxonomy search/read capabilities
+  to find relevant events and segmentation properties; never guess names or
+  scopes
 - Ask user for clarification on primary goals, key segments, or time horizons
 
 ### Step 1: Define Dashboard Purpose
@@ -105,6 +106,5 @@ Include rich text blocks for:
 - Check event names are exact matches (case-sensitive)
 - Verify date range covers when events were tracked
 - Confirm user segments aren't too restrictive
-
 
 

--- a/plugins/amplitude/skills/debug-replay/SKILL.md
+++ b/plugins/amplitude/skills/debug-replay/SKILL.md
@@ -20,8 +20,9 @@ This skill operates on three Amplitude Session Replay tools. Use them in this or
 
 Supporting tools used in this skill:
 - **`Amplitude:use_amplitude_cohorts`** with `action: "find"` — Look up users by email, user ID, or other identifiers.
-- **`Amplitude:manage_amp_events`** with `action: "get"` and `kind: "event"` — Discover valid event names before filtering. Never guess event names.
-- **`Amplitude:get_properties`** — Discover properties available on an event for filtering.
+- **Available taxonomy reader** — Inspect the connected catalog and use its
+  event and event-property read capabilities to discover valid filter names.
+  Never guess names or copy parameters from an older schema.
 - **`Amplitude:use_amp_flags`** with `action: "list_deployments"` — Check if error aligns with a recent deploy.
 
 ---
@@ -42,7 +43,7 @@ If the report is vague (e.g., "something is broken in checkout"), ask one clarif
 ### Step 2: Get Context and Find the Error Event
 
 1. Call `Amplitude:get_amplitude_context`. If multiple projects, ask which to investigate.
-2. Call `Amplitude:manage_amp_events` with `action: "get"` and `kind: "event"` to confirm the error event name exists in the project. Common patterns:
+2. Use the catalog's taxonomy reader to confirm the exact error event name exists in the project. Common patterns:
    - `[Amplitude] Error Logged` — auto-captured JS errors
    - `[Amplitude] Network Request` with status code filters — API failures
    - Custom error events specific to the product
@@ -153,7 +154,7 @@ Structure the output as an engineering-ready bug report.
 
 ## Edge Cases
 
-- **No error events found.** The project may not have auto-capture enabled, or the error may be tracked under a custom event name. Call `Amplitude:manage_amp_events` with `action: "get"` and `kind: "event"` and search for error-related events. Report what you find and suggest what to instrument if nothing exists.
+- **No error events found.** The project may not have auto-capture enabled, or the error may be tracked under a custom event name. Use the available taxonomy event reader to search for error-related events. Report what you find and suggest what to instrument if nothing exists.
 - **User not found.** If `use_amplitude_cohorts` with `action: "find"` returns nothing, try searching with alternative identifiers (email domain, partial match). If still nothing, proceed without user filtering and search by error event alone.
 - **Sessions found but no replay events.** Some sessions may not have rrweb data (replay disabled, ad blocker, etc.). Skip those sessions and note it. Try the next session.
 - **Only 1 session available.** Present the timeline as "unvalidated reproduction steps" with Low confidence. Suggest the user try to reproduce manually to confirm.

--- a/plugins/amplitude/skills/diagnose-errors/SKILL.md
+++ b/plugins/amplitude/skills/diagnose-errors/SKILL.md
@@ -86,7 +86,10 @@ This is where the skill adds value beyond looking at each event in isolation.
 For the top 2-3 error patterns from Step 3:
 
 1. **User scope.** Use `Amplitude:query_amplitude_data` to count unique users affected. Compare to total active users for an impact percentage.
-2. **Segment breakdown.** Group by available user properties (platform, browser, country, plan tier, org) to determine if errors concentrate in a specific segment. Call `Amplitude:get_properties` if you need to discover available properties.
+2. **Segment breakdown.** Group by available user properties (platform,
+   browser, country, plan tier, org) to determine if errors concentrate in a
+   specific segment. If discovery is needed, inspect the connected catalog and
+   use its current taxonomy property reader.
 3. **Session Replays.** For the most impactful error pattern, call `Amplitude:get_amp_session_replay_info` with `action: "search"` filtered to sessions containing the error event. Provide 2-3 replay links so the user can see exactly what happened.
 
 ### Step 5: Root Cause Hypothesis

--- a/plugins/amplitude/skills/discover-analytics-patterns/SKILL.md
+++ b/plugins/amplitude/skills/discover-analytics-patterns/SKILL.md
@@ -48,14 +48,13 @@ Use two approaches based on what's available.
 
 ### If the Amplitude MCP is connected
 
-Call `manage_amp_events` with `action: "get"` and `kind: "event"` to fetch a
-sample of event names from the project. If its input schema accepts `_client`,
-every `manage_amp_events` call made by this skill MUST include the top-level argument
-`"_client": { "type": "skill", "skill_name": "discover-analytics-patterns" }`
-in the tool arguments; otherwise, omit `_client`. Use those results to choose a
-few representative non-system product events, then call `get_properties`
-for those events to inspect real property names. This is your primary naming
-reference.
+Inspect the connected catalog and use its current taxonomy reader to fetch a
+sample of event names from the project. Follow only the reader's advertised
+schema. When it supports caller attribution, identify this skill with the
+`name` from its YAML frontmatter. Use those results to choose a few
+representative non-system product events, then use its
+event-property read capability to inspect real property names. This is your
+primary naming reference.
 
 Do not infer naming conventions from bracket-prefixed Amplitude system names
 such as `[Amplitude], [Guides-Surveys], [Assistant], [Experiment]` for either events or properties. Exclude those from
@@ -140,8 +139,8 @@ Use this precedence order:
    event or property naming convention, it wins outright — record it and skip
    inference for whatever it specifies. Only fall through when the file is absent
    or silent on naming.
-2. **Amplitude MCP second.** If the observed `eventType` values and
-   property names returned by `get_properties` for a few representative
+2. **Amplitude MCP second.** If the observed event names and property names
+   returned by the active taxonomy reader for a few representative
    non-system events show a clear dominant convention, use that. Do not use
    bracket-prefixed Amplitude system names as naming evidence.
 3. **Codebase third.** If the MCP evidence is unavailable, sparse, or

--- a/plugins/amplitude/skills/discover-event-surfaces/SKILL.md
+++ b/plugins/amplitude/skills/discover-event-surfaces/SKILL.md
@@ -102,14 +102,12 @@ target. You need a `projectId` for the next call.
 
 ### Pull existing events
 
-Call `manage_amp_events` with `action: "get"`, `kind: "event"`, and the resolved
-`projectId`. If its input schema accepts `_client`, every `manage_amp_events`
-call made by this skill MUST include the top-level
-argument
-`"_client": { "type": "skill", "skill_name": "discover-event-surfaces" }`
-in the tool arguments. Otherwise, omit `_client`. No cursor is needed — just the
-first page is enough for pattern detection. This returns event objects with
-fields like `eventType`, `category`, `description`, etc.
+Inspect the connected catalog and use its current taxonomy event reader with
+the resolved `projectId`. Follow only its advertised schema. When it supports
+caller attribution, identify this skill with the `name` from its YAML
+frontmatter. No cursor is needed—the first page is enough for pattern
+detection. Request the event name, category, and description fields when its
+schema supports field selection, then use the returned field names.
 
 ### Build naming references and an existing event index
 

--- a/plugins/amplitude/skills/discover-opportunities/SKILL.md
+++ b/plugins/amplitude/skills/discover-opportunities/SKILL.md
@@ -48,7 +48,11 @@ For each funnel chart discovered, examine:
 - The step with the largest absolute drop-off
 - Whether drop-off is getting worse or better over time
 
-If no funnel charts exist but the user mentioned a flow, use `query_amplitude_data` to build an ad-hoc funnel. Call `get_properties` for the relevant events first to discover which properties are available for segmentation (platform, plan, country, etc.) — don't guess property names.
+If no funnel charts exist but the user mentioned a flow, use
+`query_amplitude_data` to build an ad-hoc funnel. First inspect the connected
+catalog and use its taxonomy property reader for the relevant events to
+discover which properties and scopes are available for segmentation (platform,
+plan, country, etc.)—don't guess property names.
 
 #### 2c. Experiment Insights
 

--- a/plugins/amplitude/skills/investigate-ai-session/SKILL.md
+++ b/plugins/amplitude/skills/investigate-ai-session/SKILL.md
@@ -108,7 +108,9 @@ Structure the output as a root cause analysis.
 
 7. **Recommended fixes** (2-4 numbered items): Concrete actions. Examples:
    - "Add a retry with exponential backoff for the query_amplitude_data tool — 8 of 15 failures are transient timeouts"
-   - "The agent is calling manage_amp_events before get_amplitude_context, causing a missing project ID error — fix the tool ordering in the agent prompt"
+   - "The agent is calling a taxonomy capability before project-context
+     discovery, causing a missing project ID error—fix the capability ordering
+     in the agent prompt"
    - "Users asking about retention are getting routed to the Chart Agent instead of the Funnel Agent — update the routing logic"
 
 8. **Follow-on prompt**: Offer next steps — "Want me to check if this tool timeout affects other agents, search for similar user complaints, or monitor this pattern over the next few days?"

--- a/plugins/amplitude/skills/live-data-forensics/SKILL.md
+++ b/plugins/amplitude/skills/live-data-forensics/SKILL.md
@@ -15,12 +15,11 @@ follow one arc — follow it too.
    Do not guess project IDs.
 2. **Reuse before rebuild.** `search_amp_entities` for existing analyses of the same
    area — saved charts already encode correct event names and segments.
-3. **Verify taxonomy before querying.** `manage_amp_events` `action: 'get'`
-   to confirm candidate event names exist (returns category, isInSchema,
-   isQueryable), `get_properties`
-   (`propertyType: 'event' | 'user' | 'group'`) for the exact property names
-   **and scope** (`event` vs `user` vs `derived`). Never guess names — a wrong
-   name returns a well-formed chart with empty data, which reads as "zero".
+3. **Verify taxonomy before querying.** Inspect the connected catalog and use
+   its current taxonomy reader to confirm candidate event names, status, and
+   queryability, then read event, user, or group properties for exact names
+   **and scope**. Never guess names—a wrong name returns a well-formed chart
+   with empty data, which reads as "zero".
 4. **Check the event is live.** `check_for_recent_event_ingestion` confirms
    first-seen/last-seen before you query — a silent event means the chart
    will be empty no matter how correct the definition is.

--- a/plugins/amplitude/skills/replay-ux-audit/SKILL.md
+++ b/plugins/amplitude/skills/replay-ux-audit/SKILL.md
@@ -17,8 +17,9 @@ Watch 5-10 session replays for a specific feature, page, or flow, then synthesiz
 - **`Amplitude:get_amp_session_replay_info`** with `action: "events"` — Decode a replay into an interaction timeline: navigations, clicks, inputs, scrolls. This is what you "watch."
 
 **Supporting tools:**
-- **`Amplitude:manage_amp_events`** with `action: "get"` and `kind: "event"` — Discover valid event names. Never guess event names.
-- **`Amplitude:get_properties`** — Discover properties for filtering (page path, feature area, etc.).
+- **Available taxonomy reader** — Inspect the connected catalog and use its
+  event and property read capabilities to discover valid filter names and
+  scopes. Never guess them.
 - **`Amplitude:get_amplitude_charts`** with `include: "data"` — Pull quantitative context (funnel conversion rates, feature adoption) to anchor the qualitative replay findings.
 - **`Amplitude:use_amplitude_ai_feedback`** with `facet: "insights"` / `facet: "mentions"` — Cross-reference replay friction with customer feedback themes.
 
@@ -42,7 +43,7 @@ Also determine:
 ### Step 2: Get Context and Discover Events
 
 1. Call `Amplitude:get_amplitude_context`. If multiple projects, ask which to audit.
-2. Call `Amplitude:manage_amp_events` with `action: "get"` and `kind: "event"` to find events related to the target area. Look for:
+2. Use the available taxonomy event reader to find events related to the target area. Look for:
    - Page view or navigation events for the target area
    - Key interaction events (clicks, form submissions) within the flow
    - Error or failure events that may indicate friction

--- a/plugins/amplitude/skills/taxonomy/SKILL.md
+++ b/plugins/amplitude/skills/taxonomy/SKILL.md
@@ -400,109 +400,59 @@ Default lookback: **180 days**.
 
 ---
 
-# Available Tools
+# Amplitude MCP capability selection
 
-These are the actual Amplitude MCP server tools available for taxonomy work. Tool names must match exactly.
+Inspect the connected public Amplitude MCP catalog at runtime. Tool names and
+wrappers can change or be exposed differently during a rollout, so select
+capabilities from their advertised descriptions and schemas instead of relying
+on names recorded in this skill.
 
-## Context
+## Context and discovery
 
-### `get_amplitude_context`
-Get information about the current user, organization, and accessible projects. Call this first to discover project IDs.
+- Use the project-context capability to discover accessible project IDs and
+  read the selected project's settings. Ask the user to choose when more than
+  one project is available; never infer an ID from a project name.
+- Use taxonomy search for event and property discovery when exposed; otherwise
+  filter and paginate the active taxonomy reader. Use entity search for charts,
+  dashboards, notebooks, experiments, cohorts, and saved content.
+- Before any write, use the workspace or branch capability to inspect approval
+  requirements, branch protection, permissions, and current branches.
 
-### `get_amplitude_context` with `projectId`
-Get project-specific settings: time zone, currency, session definition, AI context. Use to understand project configuration before making changes.
+## Taxonomy reads
 
-### `search_amp_entities` and `search_amp_data_taxonomy`
-Use `search_amp_entities` for charts, dashboards, notebooks, experiments,
-cohorts, and other Amplitude content. Use `search_amp_data_taxonomy` for events
-and properties.
+- Prefer the consolidated taxonomy reader when the catalog exposes one. Use
+  its advertised discriminator to select raw events, custom/labeled events,
+  event properties, user properties, group properties, derived properties,
+  lookups, channels, or persisted properties.
+- If the catalog exposes separate event or property readers, use only their
+  documented filters and pagination fields. Do not invent an alias or copy
+  parameters from another reader.
+- Resolve event and property names from returned taxonomy rows. Names are
+  case-sensitive; do not substitute display names.
+- Paginate exhaustive reads through every cursor. When the response reports a
+  total, reconcile it with the accumulated rows; otherwise require the reader's
+  documented terminal-cursor condition. A failed or partial page is not
+  completion.
+- Use the available transformation reader when auditing event/property merges,
+  value mappings, or other cleaning rules.
 
-### `manage_amp_data_taxonomy`
-Use `action: "get"` for workspace settings, including approval workflow status.
-Check before writing to the default branch — when `approvalWF` is "Required",
-the user must create a non-default branch first.
+## Metadata updates
 
-## Event Discovery
-
-### `manage_amp_events`
-Use `action: "get"` and `kind: "event"` to retrieve events from a project with
-filtering by event types, limit, and cursor pagination. Returns full event
-objects including category and active status.
-
-If the connected MCP server's `manage_amp_events` input schema accepts `_client`,
-every `manage_amp_events` call made by this skill MUST include this top-level caller
-attribution exactly. Otherwise, omit `_client`.
-
-```json
-"_client": { "type": "skill", "skill_name": "taxonomy" }
-```
-
-- Use `search_amp_data_taxonomy` first to find the event you're looking for.
-- If search doesn't return it, call `manage_amp_events` with `action: "get"` and
-  `kind: "event"` without `eventTypes` to paginate through all events.
-- If you know exact event type names, pass them via `eventTypes` for precise lookup.
-
-Use `manage_amp_events` with `action: "get"` and `kind: "custom"`, `"labeled"`,
-or `"all"` to retrieve custom events, labeled (autotrack) events, or both.
-
-- `eventKind: "_all"` — both custom and labeled events (default).
-- `eventKind: "custom"` — non-autotrack custom events only.
-- `eventKind: "labeled"` — labeled/autotrack events only.
-- Returns `isAutotrack` flag, definition, and `flattenedDefinition` (source event lists).
-
-### `get_transformations`
-Retrieve data transformations (merge events, merge properties, map property values) from a project. Use to audit data cleaning rules.
-
-## Property Discovery
-
-### `get_properties`
-Retrieve properties from a project's taxonomy. Use `propertyType` to select which kind:
-
-| `propertyType` | What it returns | Key params |
-|---|---|---|
-| `event` | Properties for a specific event type | `eventType` (required) |
-| `user` | User-level properties | `sources`, `name` |
-| `derived` | Computed/formula properties | `derivedPropertyType`, `names` |
-| `group` | Group properties (e.g., company_name, plan_tier) | `groupTypes` |
-| `lookup` | CSV lookup table properties | `configurationFilter`, `lookupTableName` |
-| `channel` | Traffic source channel properties | `names` |
-| `persisted` | Event-to-user persisted properties | `names` |
-
-All property types except `event` support limit/cursor pagination.
-
-## Metadata Updates
-
-Use `manage_amp_events` with `action: "update"` and `kind: "event"` to update
-event metadata: descriptions, display names, categories, official status, and
-event names. It operates on the tracking plan.
-
-- Event type keys must match the event `name` exactly (case-sensitive) — not the
-  `displayName`. Resolve via `manage_amp_events` with `action: "get"` and
-  `kind: "event"` first if needed.
-- Supports `branchId` or `branchName` to target non-default branches.
-- Do not overwrite existing descriptions — append additional context instead.
-- Never update bracket-prefixed or vendor-prefixed events (`[Amplitude]`, `[Experiment]`, etc.) unless explicitly requested.
-- Requires "Update Tracking Plan" permission.
-
-### `update_properties`
-Update property metadata (description, official status, category, and/or name). Use `propertyType` to select which kind:
-
-| `propertyType` | What it updates | Key params |
-|---|---|---|
-| `event` | Event property metadata (global or event-scoped) | `metadataScope`, `eventType` (when scope is `"event"`) |
-| `user` | User property metadata | `descriptions`, `isOfficial`, `categories`, `newNames` |
-
-- Use `get_properties` first to verify property names and status before updating.
-- Requires "Update Tracking Plan" permission.
-
-Use `manage_amp_events` with `action: "update"` and `kind: "custom"` or
-`"labeled"` to update descriptions, categories, names, official status, and/or
-definitions on custom or labeled events.
-
-- Only use when the user explicitly asks to update a "custom event" or "labeled
-  event." For regular events, use `kind: "event"`.
-- Definitions are **replaced in full**, not merged — pass the complete new source-event list.
-- Renaming will break chart references — always warn the user.
+- Select the event or property mutation capability only after verifying that
+  its current schema supports the requested object type, metadata fields,
+  branch selector, and scope.
+- Read the exact current object first. Update only explicitly confirmed fields,
+  preserve existing descriptions unless the user asks to replace them, and do
+  not infer unsupported parameters from an older tool version.
+- Event-property metadata can be global or scoped to one event. Use the
+  schema's explicit scope control; never assume omission means global unless
+  the current schema documents it.
+- Custom/labeled event definitions are full replacements, not merges. Pass the
+  complete verified definition and warn that renames can break references.
+- Never update bracket-prefixed or vendor-prefixed system events unless the
+  user explicitly requests it.
+- Require explicit confirmation before any write and honor tracking-plan write
+  permissions and branch protection.
 
 ---
 


### PR DESCRIPTION
## Summary

This is a plugin-wide MCP compatibility update across **15 customer-facing Amplitude skills**, not a change limited to the `taxonomy` skill.

Public Amplitude MCP capabilities can be consolidated, renamed, or exposed differently during staged rollouts. Several skills embedded specific event/property reader names in otherwise unrelated workflows, which could make chart creation, replay analysis, instrumentation discovery, account analysis, and other customer tasks fail when the same capability moved behind a newer wrapper.

Each affected workflow now inspects the connected MCP catalog at runtime, selects taxonomy discovery by advertised capability and schema, and preserves exact event/property names and scopes without copying parameters from an older tool version.

## Customer workflows updated

| Area | Skills |
| --- | --- |
| Chart and dashboard creation | `build-charts-with-typed-params`, `create-chart`, `create-dashboard` |
| Product and account analysis | `analyze-account-health`, `analyze-experiment-consolidated`, `discover-opportunities`, `diagnose-errors` |
| Session replay and journey analysis | `debug-replay`, `replay-ux-audit`, `compare-user-journeys` |
| Instrumentation discovery | `discover-analytics-patterns`, `discover-event-surfaces` |
| Live-data and AI-session investigation | `live-data-forensics`, `investigate-ai-session` |
| General tracking-plan governance | `taxonomy` |

## What changed

- Replaces stale event/property taxonomy-reader references throughout those workflows with runtime capability discovery.
- Reworks `taxonomy`'s fixed tool catalog into capability-based guidance for project context, search, exhaustive reads, transformations, workspace/branch checks, and metadata mutations.
- Preserves caller attribution by using the active skill's YAML name when the connected schema supports attribution.
- Retains exact tool names for core schema-specific operations where the name is part of the executable workflow; this PR abstracts the shared taxonomy-discovery layer rather than indiscriminately removing every tool reference.
- Adds safe fallbacks when taxonomy search is unavailable: use the active reader's documented filters and pagination instead of inventing an alias.

## Safety and behavior preserved

- Project IDs are discovered or selected, never inferred.
- Event and property names remain case-sensitive and must come from taxonomy results.
- Property scope remains explicit, including group properties and global versus event-scoped metadata.
- Exhaustive reads follow every cursor; reported totals are reconciled when available, otherwise the documented terminal-cursor condition is required.
- Writes still require current-object reads, schema validation, branch/permission checks, and explicit confirmation.

## Relationship to #58

This follows the capability-driven approach introduced for the new `tracking-plan-audit` skill in #58, then applies that compatibility principle to existing public skills whose taxonomy discovery was coupled to older reader names.

## Validation

- Static RED/GREEN assertion: stale taxonomy reader references were present before this change and are absent afterward.
- `git diff --check`
- JSON parsing and Claude/Cursor manifest synchronization
- Frontmatter and relative-link checks across all 15 modified skills
- Added-diff scan for local/internal paths, project or ticket IDs, and internal-only names
- Behavioral correctness review of the capability-driven routing changes

## Versioning

No manifests or versions were edited manually. Because this modifies public Amplitude plugin files, the repository's automatic version-bump workflow will apply the patch version bump after merge.
